### PR TITLE
fix(session): strip illegal characters from windows session dir (#18)

### DIFF
--- a/internal/session/session_dir_test.go
+++ b/internal/session/session_dir_test.go
@@ -1,0 +1,70 @@
+package session
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestEncodeCwdForDir verifies the working-directory → session-directory
+// name encoding strips characters that are illegal on Windows (notably the
+// drive-letter colon, see issue #18) while preserving the previous output
+// for the typical Unix paths.
+func TestEncodeCwdForDir(t *testing.T) {
+	tests := []struct {
+		name string
+		cwd  string
+		want string
+	}{
+		{
+			name: "unix absolute path",
+			cwd:  "/home/user/proj",
+			want: "home--user--proj",
+		},
+		{
+			name: "unix relative path",
+			cwd:  "proj/sub",
+			want: "proj--sub",
+		},
+		{
+			name: "windows drive root",
+			cwd:  `C:\test`,
+			want: "C--test",
+		},
+		{
+			name: "windows nested path",
+			cwd:  `C:\Users\User\code`,
+			want: "C--Users--User--code",
+		},
+		{
+			name: "windows secondary drive",
+			cwd:  `S:\work\repo`,
+			want: "S--work--repo",
+		},
+		{
+			name: "windows mixed separators",
+			cwd:  `C:\Users/User\code`,
+			want: "C--Users--User--code",
+		},
+		{
+			name: "windows other illegal chars stripped",
+			cwd:  `C:\a<b>c|d?e*f"g`,
+			want: "C--abcdefg",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := encodeCwdForDir(tc.cwd)
+			if got != tc.want {
+				t.Errorf("encodeCwdForDir(%q) = %q, want %q", tc.cwd, got, tc.want)
+			}
+			// Encoded directory must never contain characters that are
+			// illegal in Windows directory names.
+			for _, bad := range []string{":", "<", ">", "\"", "|", "?", "*", "\\", "/"} {
+				if strings.Contains(got, bad) {
+					t.Errorf("encodeCwdForDir(%q) = %q contains illegal char %q", tc.cwd, got, bad)
+				}
+			}
+		})
+	}
+}

--- a/internal/session/tree_manager.go
+++ b/internal/session/tree_manager.go
@@ -1356,9 +1356,35 @@ func DefaultSessionDir(cwd string) string {
 	if err != nil {
 		home = "."
 	}
-	// Convert path separators to double dashes.
-	safeCwd := strings.ReplaceAll(cwd, string(filepath.Separator), "--")
+	return filepath.Join(home, ".kit", "sessions", encodeCwdForDir(cwd))
+}
+
+// encodeCwdForDir converts a working-directory path into a single, filesystem-
+// safe directory name. Path separators are replaced with double dashes and
+// characters that are illegal in Windows directory names — most importantly
+// the colon that follows the drive letter (e.g. `C:\foo` → `C--foo`) — are
+// stripped. The result is identical to the previous Unix-only encoding for
+// paths that do not contain such characters, so existing session directories
+// are preserved.
+func encodeCwdForDir(cwd string) string {
+	// Convert both `/` and `\` to double dashes so encoding is stable across
+	// platforms and remains correct on Windows where `filepath.Separator`
+	// would otherwise miss forward-slash style paths.
+	safeCwd := strings.ReplaceAll(cwd, "\\", "--")
+	safeCwd = strings.ReplaceAll(safeCwd, "/", "--")
 	// Remove leading separator replacement.
 	safeCwd = strings.TrimPrefix(safeCwd, "--")
-	return filepath.Join(home, ".kit", "sessions", safeCwd)
+	// Strip characters that are illegal in directory names on Windows
+	// (`< > : " | ? *`). On Unix these characters are legal but rare in
+	// practice; stripping them keeps the encoding portable.
+	replacer := strings.NewReplacer(
+		":", "",
+		"<", "",
+		">", "",
+		"\"", "",
+		"|", "",
+		"?", "",
+		"*", "",
+	)
+	return replacer.Replace(safeCwd)
 }

--- a/internal/session/tree_manager.go
+++ b/internal/session/tree_manager.go
@@ -1350,7 +1350,10 @@ func (tm *TreeManager) buildTreeNodeDepth(id string, depth int, visited map[stri
 // --- Path conventions ---
 
 // DefaultSessionDir returns the default session storage directory for a cwd.
-// Convention: ~/.kit/sessions/--<cwd-path>--/
+// Convention: ~/.kit/sessions/<encoded-cwd>, where path separators are
+// encoded as "--" with no leading or trailing dashes — e.g.
+// /home/user/proj becomes home--user--proj. See encodeCwdForDir for the
+// full encoding rules (including Windows path handling).
 func DefaultSessionDir(cwd string) string {
 	home, err := os.UserHomeDir()
 	if err != nil {


### PR DESCRIPTION
## Description

On Windows, `kit` failed to start a session because the working-directory
encoder kept the colon after the drive letter, producing directory names
like `C:--test`. Windows rejects colons anywhere except immediately after
the drive letter, so `mkdir` failed with `The directory name is invalid.`
and Kit could not initialize a session.

This change replaces the inline encoding inside `DefaultSessionDir` with a
new `encodeCwdForDir` helper that:

- Replaces both `/` and `\` with `--` (so Windows paths and any caller
  that mixes separators encode consistently).
- Strips characters that are illegal in Windows directory names
  (`: < > " | ? *`).
- Preserves the previous output for typical Unix paths
  (`/home/user/proj` → `home--user--proj`), so existing session
  directories continue to resolve.

`Cwd` is recovered from the JSONL session header, never reverse-decoded
from the directory name, so changing the encoding is safe.

Fixes #18

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes (`go test -race ./...`)
- [x] `go vet ./...` and `golangci-lint run` are clean

## Additional Information

Files:

- `internal/session/tree_manager.go` — refactored `DefaultSessionDir`,
  added `encodeCwdForDir`.
- `internal/session/session_dir_test.go` — new regression test
  (`TestEncodeCwdForDir`) covering Unix paths, Windows drive roots,
  secondary drives, mixed separators, and other illegal characters.

Backward compatibility: encoding for existing Unix paths is unchanged,
so previously created session directories remain discoverable. Only
paths that previously contained illegal Windows characters (which would
have failed outright on Windows anyway) are affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session directory path encoding for better cross-platform compatibility, ensuring proper handling of special characters in working-directory paths across different operating systems.
* **Tests**
  * Added comprehensive test coverage for working-directory path encoding validation across Unix and Windows platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->