### PR TITLE
CLI & Config changes to support disabling core tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ max-tokens: 4096
 temperature: 0.7
 stream: true
 thinking-level: off       # off, none, minimal, low, medium, high
+no-core-tools: false      # set to true to disable all built-in core tools
 ```
 
 All of the above keys can also be set programmatically via the SDK
@@ -195,9 +196,10 @@ mcpServers:
 --compact                Enable compact output mode
 --auto-compact           Auto-compact conversation near context limit
 
-# Extensions
+# Extensions and tools
 --extension, -e          Load additional extension file(s) (repeatable)
 --no-extensions          Disable all extensions
+--no-core-tools          Disable all built-in core tools (bash, read, write, edit, grep, find, ls, subagent)
 --prompt-template        Load a specific prompt template by name
 --no-prompt-templates    Disable prompt template loading
 
@@ -579,7 +581,9 @@ host, err := kit.New(ctx, &kit.Options{
     // Tool options
     Tools:            []kit.Tool{...},     // Replace default tool set entirely
     ExtraTools:       []kit.Tool{...},     // Add tools alongside defaults
-    DisableCoreTools: true,                // Use no core tools (0 tools, for chat-only)
+    DisableCoreTools: true,                // Disable all built-in core tools; also controllable via
+                                           // --no-core-tools flag, KIT_NO_CORE_TOOLS env var,
+                                           // or no-core-tools: true in .kit.yml
 
     // Configuration
     SkipConfig:   true,                   // Skip .kit.yml files (viper defaults + env vars still apply)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -70,8 +70,9 @@ var (
 	mainGPU int32
 
 	// Extensions control
-	noExtensionsFlag bool
-	extensionPaths   []string
+	noExtensionsFlag  bool
+	noCoreToolsFlag   bool
+	extensionPaths    []string
 
 	// TLS configuration
 	tlsSkipVerify bool
@@ -279,6 +280,8 @@ func init() {
 	rootCmd.PersistentFlags().
 		BoolVar(&noExtensionsFlag, "no-extensions", false, "disable all extensions")
 	rootCmd.PersistentFlags().
+		BoolVar(&noCoreToolsFlag, "no-core-tools", false, "disable all built-in core tools (bash, read, write, edit, grep, find, ls, subagent)")
+	rootCmd.PersistentFlags().
 		StringSliceVarP(&extensionPaths, "extension", "e", nil, "load additional extension file(s)")
 
 	flags := rootCmd.PersistentFlags()
@@ -327,6 +330,7 @@ func init() {
 	_ = viper.BindPFlag("main-gpu", rootCmd.PersistentFlags().Lookup("main-gpu"))
 	_ = viper.BindPFlag("tls-skip-verify", rootCmd.PersistentFlags().Lookup("tls-skip-verify"))
 	_ = viper.BindPFlag("no-extensions", rootCmd.PersistentFlags().Lookup("no-extensions"))
+	_ = viper.BindPFlag("no-core-tools", rootCmd.PersistentFlags().Lookup("no-core-tools"))
 	_ = viper.BindPFlag("extension", rootCmd.PersistentFlags().Lookup("extension"))
 	_ = viper.BindPFlag("prompt-template", rootCmd.PersistentFlags().Lookup("prompt-template"))
 	_ = viper.BindPFlag("no-prompt-templates", rootCmd.PersistentFlags().Lookup("no-prompt-templates"))
@@ -772,13 +776,14 @@ func runNormalMode(ctx context.Context) error {
 	var appInstancePtr *app.App
 
 	kitOpts := &kit.Options{
-		Quiet:          quietFlag,
-		Debug:          debugMode,
-		NoSession:      noSessionFlag,
-		Continue:       continueFlag,
-		SessionPath:    sessionPath,
-		AutoCompact:    autoCompactFlag,
-		MCPAuthHandler: authHandler,
+		Quiet:            quietFlag,
+		Debug:            debugMode,
+		NoSession:        noSessionFlag,
+		Continue:         continueFlag,
+		SessionPath:      sessionPath,
+		AutoCompact:      autoCompactFlag,
+		MCPAuthHandler:   authHandler,
+		DisableCoreTools: viper.GetBool("no-core-tools"),
 		// This callback is called when each MCP server finishes loading.
 		// We use a closure that captures appInstancePtr which is set after
 		// app.New() is called below.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -70,9 +70,9 @@ var (
 	mainGPU int32
 
 	// Extensions control
-	noExtensionsFlag  bool
-	noCoreToolsFlag   bool
-	extensionPaths    []string
+	noExtensionsFlag bool
+	noCoreToolsFlag  bool
+	extensionPaths   []string
 
 	// TLS configuration
 	tlsSkipVerify bool

--- a/pkg/kit/kit.go
+++ b/pkg/kit/kit.go
@@ -1194,6 +1194,7 @@ func New(ctx context.Context, opts *Options) (*Kit, error) {
 		mcpConfig             *config.Config
 		debug                 bool
 		noExtensions          bool
+		disableCoreTools      bool
 		maxSteps              int
 		streaming             bool
 		hasCustomSystemPrompt bool
@@ -1389,6 +1390,7 @@ func New(ctx context.Context, opts *Options) (*Kit, error) {
 		modelString = viper.GetString("model")
 		debug = viper.GetBool("debug")
 		noExtensions = opts.NoExtensions || viper.GetBool("no-extensions")
+		disableCoreTools = opts.DisableCoreTools || viper.GetBool("no-core-tools")
 		maxSteps = viper.GetInt("max-steps")
 		streaming = viper.GetBool("stream")
 
@@ -1446,7 +1448,7 @@ func New(ctx context.Context, opts *Options) (*Kit, error) {
 		MCPConfig:         mcpConfig,
 		Quiet:             opts.Quiet,
 		CoreTools:         opts.Tools,
-		DisableCoreTools:  opts.DisableCoreTools,
+		DisableCoreTools:  disableCoreTools,
 		ExtraTools:        opts.ExtraTools,
 		ToolWrapper:       hookToolWrapper(beforeToolCall, afterToolResult),
 		ProviderConfig:    providerConfig,


### PR DESCRIPTION
Allow users to disable all built-in core tools (bash, read, write,
edit, grep, find, ls, subagent) without recompiling, using a CLI flag,
environment variable, or .kit.yml config key.

Changes
-------
cmd/root.go
  - Declare noCoreToolsFlag bool alongside noExtensionsFlag.
  - Register --no-core-tools persistent flag with a descriptive help string
    listing the affected tools.
  - Bind the flag to viper key "no-core-tools" so the config file and
    KIT_NO_CORE_TOOLS env var also work (viper's standard precedence:
    CLI flag > env var > config file > default).
  - Set kitOpts.DisableCoreTools = viper.GetBool("no-core-tools") when
    assembling the Options struct in runNormalMode.

pkg/kit/kit.go
  - Add disableCoreTools local variable inside the viperInitMu-protected
    snapshot block, mirroring the noExtensions pattern exactly.
  - Resolve it as opts.DisableCoreTools || viper.GetBool("no-core-tools")
    so the SDK option and the viper key are both respected (OR semantics:
    either source can enable the flag).
  - Pass the resolved disableCoreTools into kitsetup.AgentSetupOptions
    instead of the raw opts.DisableCoreTools, completing the chain.

Usage
-----
  # CLI flag
  `kit --no-core-tools`

  # Environment variable
  `KIT_NO_CORE_TOOLS=true kit`

  # .kit.yml config file
 `no-core-tools: true`

  # SDK (unchanged, was already supported)
  kit.New(ctx, &kit.Options{DisableCoreTools: true})

The downstream path (kitsetup → agent.AgentConfig.DisableCoreTools →
agent.NewAgent nil-tool branch) was already in place and required no
changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--no-core-tools` CLI flag (also configurable via KIT_NO_CORE_TOOLS env var or `.kit.yml`) to control built-in core tools.

* **Documentation**
  * Updated README and SDK docs to document the `--no-core-tools` flag, env var, and configuration key; updated example YAML and CLI flag docs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mark3labs/kit/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->