### PR TITLE
fix(ui): show pasted image previews in input and transcript

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1795,13 +1795,13 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// messages stay in chronological order.
 				m.pendingUserPrints = append(m.pendingUserPrints, displayText)
 				m.flushStreamAndPendingUserMessages()
-				// Append inline thumbnail previews after the user message.
-				cmds = append(cmds, m.transcriptPreviewCmd(msg.Images))
+				// Insert inline thumbnail previews after the user message.
+				cmds = append(cmds, m.transcriptPreviewCmd(msg.Images, m.lastMessageID()))
 			}
 		} else {
 			m.printUserMessage(displayText)
-			// Append inline thumbnail previews after the user message.
-			cmds = append(cmds, m.transcriptPreviewCmd(msg.Images))
+			// Insert inline thumbnail previews after the user message.
+			cmds = append(cmds, m.transcriptPreviewCmd(msg.Images, m.lastMessageID()))
 		}
 		if m.state != stateWorking {
 			m.state = stateWorking
@@ -1811,7 +1811,7 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case imagePreviewReadyMsg:
 		if msg.block != "" {
 			item := NewStyledMessageItem(generateMessageID(), "user", "", msg.block)
-			m.messages = append(m.messages, item)
+			m.insertMessageAfter(msg.anchorID, item)
 			m.refreshContent()
 			m.layoutDirty = true
 		}
@@ -3074,19 +3074,24 @@ func truncateMessageForBlock(msg string, maxLines, width int) string {
 // --------------------------------------------------------------------------
 
 // imagePreviewReadyMsg carries an asynchronously rendered transcript image
-// preview block back to the Update loop, where it is appended to the
-// ScrollList as a verbatim item directly after the user's message.
+// preview block back to the Update loop, where it is inserted into the
+// ScrollList directly after the originating user message (identified by
+// anchorID). Inserting by anchor — rather than appending — keeps the preview
+// next to its message even when the agent's streamed reply has already been
+// appended while the thumbnail was being decoded off the event loop.
 type imagePreviewReadyMsg struct {
-	block string
+	block    string
+	anchorID string
 }
 
 // transcriptPreviewCmd returns a tea.Cmd that renders half-block thumbnail
 // previews for the given clipboard images off the Bubble Tea event loop
 // (decode + resample must not block Update). The rendered block is delivered
-// via imagePreviewReadyMsg. Returns nil when there is nothing to render or no
-// room for a preview; an empty result (terminal lacks color support) yields a
-// nil message that Bubble Tea ignores.
-func (m *AppModel) transcriptPreviewCmd(images []uicore.ImageAttachment) tea.Cmd {
+// via imagePreviewReadyMsg, tagged with anchorID so the consumer can place it
+// directly after the originating user message. Returns nil when there is
+// nothing to render or no room for a preview; an empty result (terminal lacks
+// color support) yields a nil message that Bubble Tea ignores.
+func (m *AppModel) transcriptPreviewCmd(images []uicore.ImageAttachment, anchorID string) tea.Cmd {
 	if len(images) == 0 {
 		return nil
 	}
@@ -3112,8 +3117,39 @@ func (m *AppModel) transcriptPreviewCmd(images []uicore.ImageAttachment) tea.Cmd
 		if len(blocks) == 0 {
 			return nil
 		}
-		return imagePreviewReadyMsg{block: strings.Join(blocks, "\n")}
+		return imagePreviewReadyMsg{block: strings.Join(blocks, "\n"), anchorID: anchorID}
 	}
+}
+
+// lastMessageID returns the ID of the most recently added ScrollList message,
+// or "" when there are none. Used to anchor an async transcript preview to the
+// user message that was just printed.
+func (m *AppModel) lastMessageID() string {
+	if len(m.messages) == 0 {
+		return ""
+	}
+	return m.messages[len(m.messages)-1].ID()
+}
+
+// insertMessageAfter inserts item immediately after the message whose ID
+// matches anchorID. If anchorID is empty or not found, item is appended.
+func (m *AppModel) insertMessageAfter(anchorID string, item MessageItem) {
+	idx := -1
+	if anchorID != "" {
+		for i, msgItem := range m.messages {
+			if msgItem.ID() == anchorID {
+				idx = i
+				break
+			}
+		}
+	}
+	if idx < 0 {
+		m.messages = append(m.messages, item)
+		return
+	}
+	m.messages = append(m.messages, nil)
+	copy(m.messages[idx+2:], m.messages[idx+1:])
+	m.messages[idx+1] = item
 }
 
 // printUserMessage renders a user message into the ScrollList.

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mark3labs/kit/internal/ui/commands"
 	uicore "github.com/mark3labs/kit/internal/ui/core"
 	"github.com/mark3labs/kit/internal/ui/fileutil"
+	"github.com/mark3labs/kit/internal/ui/imagepreview"
 	"github.com/mark3labs/kit/internal/ui/prefs"
 	"github.com/mark3labs/kit/internal/ui/style"
 	kit "github.com/mark3labs/kit/pkg/kit"
@@ -1794,12 +1795,25 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// messages stay in chronological order.
 				m.pendingUserPrints = append(m.pendingUserPrints, displayText)
 				m.flushStreamAndPendingUserMessages()
+				// Append inline thumbnail previews after the user message.
+				cmds = append(cmds, m.transcriptPreviewCmd(msg.Images))
 			}
 		} else {
 			m.printUserMessage(displayText)
+			// Append inline thumbnail previews after the user message.
+			cmds = append(cmds, m.transcriptPreviewCmd(msg.Images))
 		}
 		if m.state != stateWorking {
 			m.state = stateWorking
+		}
+
+	// ── Async transcript image preview ───────────────────────────────────────
+	case imagePreviewReadyMsg:
+		if msg.block != "" {
+			item := NewStyledMessageItem(generateMessageID(), "user", "", msg.block)
+			m.messages = append(m.messages, item)
+			m.refreshContent()
+			m.layoutDirty = true
 		}
 
 	// ── Shell command (! / !!) ───────────────────────────────────────────────
@@ -2447,6 +2461,19 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.printSystemMessage(msg.Text)
 		}
 
+	// ── Clipboard image attached / thumbnail rendered ────────────────────────
+	// Both messages change the input region's rendered height (the pill and
+	// the async half-block preview), so forward them to the input and mark the
+	// layout dirty — otherwise distributeHeight keeps a stale, too-short input
+	// height and the preview is clipped off the bottom of the screen.
+	case clipboardImageMsg, thumbnailReadyMsg:
+		if m.input != nil {
+			updated, cmd := m.input.Update(msg)
+			m.input, _ = updated.(inputComponentIface)
+			cmds = append(cmds, cmd)
+		}
+		m.layoutDirty = true
+
 	default:
 		// Pass unrecognised messages to all children.
 		if m.input != nil {
@@ -3045,6 +3072,49 @@ func truncateMessageForBlock(msg string, maxLines, width int) string {
 // --------------------------------------------------------------------------
 // Print helpers — add content to ScrollList
 // --------------------------------------------------------------------------
+
+// imagePreviewReadyMsg carries an asynchronously rendered transcript image
+// preview block back to the Update loop, where it is appended to the
+// ScrollList as a verbatim item directly after the user's message.
+type imagePreviewReadyMsg struct {
+	block string
+}
+
+// transcriptPreviewCmd returns a tea.Cmd that renders half-block thumbnail
+// previews for the given clipboard images off the Bubble Tea event loop
+// (decode + resample must not block Update). The rendered block is delivered
+// via imagePreviewReadyMsg. Returns nil when there is nothing to render or no
+// room for a preview; an empty result (terminal lacks color support) yields a
+// nil message that Bubble Tea ignores.
+func (m *AppModel) transcriptPreviewCmd(images []uicore.ImageAttachment) tea.Cmd {
+	if len(images) == 0 {
+		return nil
+	}
+	cols := thumbMaxCols
+	if m.width > 6 && m.width-6 < cols {
+		cols = m.width - 6
+	}
+	if cols < 1 {
+		return nil
+	}
+	bg := style.GetTheme().Background
+	imgs := images
+	return func() tea.Msg {
+		pad := lipgloss.NewStyle().PaddingLeft(2)
+		var blocks []string
+		for _, img := range imgs {
+			thumb, err := imagepreview.Render(img.Data, img.MediaType, cols, thumbMaxRows, bg)
+			if err != nil || thumb == "" {
+				continue
+			}
+			blocks = append(blocks, pad.Render(thumb))
+		}
+		if len(blocks) == 0 {
+			return nil
+		}
+		return imagePreviewReadyMsg{block: strings.Join(blocks, "\n")}
+	}
+}
 
 // printUserMessage renders a user message into the ScrollList.
 func (m *AppModel) printUserMessage(text string) {

--- a/internal/ui/pending_thumbnail_layout_test.go
+++ b/internal/ui/pending_thumbnail_layout_test.go
@@ -1,0 +1,77 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	uicore "github.com/mark3labs/kit/internal/ui/core"
+)
+
+// drainCmds runs a tea.Cmd chain back through m.Update like the BubbleTea
+// event loop, expanding batches, until no further messages are produced.
+func drainCmds(t *testing.T, m *AppModel, cmd tea.Cmd) *AppModel {
+	t.Helper()
+	queue := []tea.Cmd{cmd}
+	for i := 0; i < 50 && len(queue) > 0; i++ {
+		c := queue[0]
+		queue = queue[1:]
+		if c == nil {
+			continue
+		}
+		msg := c()
+		if msg == nil {
+			continue
+		}
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			queue = append(queue, batch...)
+			continue
+		}
+		updated, nc := m.Update(msg)
+		m = updated.(*AppModel)
+		_ = m.View()
+		if nc != nil {
+			queue = append(queue, nc)
+		}
+	}
+	return m
+}
+
+func measuredInputHeight(m *AppModel) int {
+	rendered := m.renderInput()
+	if rendered == "" {
+		return 0
+	}
+	return strings.Count(rendered, "\n") + 1
+}
+
+// TestPendingThumbnailTriggersLayoutRecompute is a regression test for the bug
+// where a pasted image's async half-block preview rendered but was clipped off
+// the bottom of the screen: the thumbnail arrives via thumbnailReadyMsg after
+// distributeHeight already measured the input region without it. The parent
+// must mark the layout dirty so the (now taller) input is re-measured.
+func TestPendingThumbnailTriggersLayoutRecompute(t *testing.T) {
+	real := NewInputComponent(80, nil)
+	m, _, _ := newTestAppModel(nil)
+	m.input = real
+	m = sendMsg(m, tea.WindowSizeMsg{Width: 80, Height: 24})
+
+	heightBefore := measuredInputHeight(m)
+
+	updated, cmd := m.Update(clipboardImageMsg{image: &uicore.ImageAttachment{
+		Data:      makeTestPNG(t, 16, 16),
+		MediaType: "image/png",
+	}})
+	m = updated.(*AppModel)
+	_ = m.View()
+	m = drainCmds(t, m, cmd)
+
+	heightAfter := measuredInputHeight(m)
+	if heightAfter <= heightBefore {
+		t.Errorf("input region should grow to fit the thumbnail (before=%d after=%d)", heightBefore, heightAfter)
+	}
+
+	if !strings.Contains(m.View().Content, "▀") {
+		t.Error("parent View should contain the half-block thumbnail (was clipped or not rendered)")
+	}
+}

--- a/internal/ui/pending_thumbnail_layout_test.go
+++ b/internal/ui/pending_thumbnail_layout_test.go
@@ -51,6 +51,14 @@ func measuredInputHeight(m *AppModel) int {
 // distributeHeight already measured the input region without it. The parent
 // must mark the layout dirty so the (now taller) input is re-measured.
 func TestPendingThumbnailTriggersLayoutRecompute(t *testing.T) {
+	// Force a truecolor profile so imagepreview.Render deterministically
+	// produces a thumbnail regardless of the CI terminal's color support.
+	// Without this, a low-color test environment yields an empty preview and
+	// the glyph / height assertions below would flake.
+	t.Setenv("TERM", "xterm-256color")
+	t.Setenv("COLORTERM", "truecolor")
+	t.Setenv("NO_COLOR", "")
+
 	real := NewInputComponent(80, nil)
 	m, _, _ := newTestAppModel(nil)
 	m.input = real

--- a/internal/ui/transcript_preview_test.go
+++ b/internal/ui/transcript_preview_test.go
@@ -29,7 +29,7 @@ func makeTestPNG(t *testing.T, w, h int) []byte {
 
 func TestTranscriptPreviewCmdNoImages(t *testing.T) {
 	m, _, _ := newTestAppModel(nil)
-	if cmd := m.transcriptPreviewCmd(nil); cmd != nil {
+	if cmd := m.transcriptPreviewCmd(nil, ""); cmd != nil {
 		t.Error("expected nil cmd when there are no images")
 	}
 }
@@ -39,7 +39,7 @@ func TestTranscriptPreviewCmdRendersBlock(t *testing.T) {
 	images := []uicore.ImageAttachment{
 		{Data: makeTestPNG(t, 16, 16), MediaType: "image/png"},
 	}
-	cmd := m.transcriptPreviewCmd(images)
+	cmd := m.transcriptPreviewCmd(images, "anchor-1")
 	if cmd == nil {
 		t.Fatal("expected a non-nil cmd for a valid image")
 	}
@@ -58,6 +58,9 @@ func TestTranscriptPreviewCmdRendersBlock(t *testing.T) {
 	if !strings.Contains(ready.block, "▀") {
 		t.Errorf("preview block should contain half-block glyphs, got %q", ready.block)
 	}
+	if ready.anchorID != "anchor-1" {
+		t.Errorf("preview should carry the originating anchorID, got %q", ready.anchorID)
+	}
 }
 
 func TestImagePreviewReadyMsgAppendsItem(t *testing.T) {
@@ -73,6 +76,53 @@ func TestImagePreviewReadyMsgAppendsItem(t *testing.T) {
 	}
 	if !strings.Contains(last.Render(0), "▀") {
 		t.Error("appended preview item should render the half-block block verbatim")
+	}
+}
+
+// TestImagePreviewReadyMsgInsertsAfterAnchor verifies the preview is placed
+// directly after its originating user message even when a later message (e.g.
+// a streamed assistant reply) was already appended while the thumbnail was
+// being decoded asynchronously.
+func TestImagePreviewReadyMsgInsertsAfterAnchor(t *testing.T) {
+	m, _, _ := newTestAppModel(nil)
+	userItem := NewStyledMessageItem("user-anchor", "user", "hi", "hi")
+	assistantItem := NewStyledMessageItem("assistant-1", "assistant", "reply", "reply")
+	m.messages = append(m.messages, userItem, assistantItem)
+
+	m = sendMsg(m, imagePreviewReadyMsg{
+		block:    "\x1b[38;2;1;2;3;48;2;4;5;6m▀\x1b[0m",
+		anchorID: "user-anchor",
+	})
+
+	// Expect order: user, preview, assistant.
+	if len(m.messages) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(m.messages))
+	}
+	if m.messages[0].ID() != "user-anchor" {
+		t.Errorf("messages[0] should be the user message, got %q", m.messages[0].ID())
+	}
+	if m.messages[2].ID() != "assistant-1" {
+		t.Errorf("messages[2] should be the assistant message, got %q", m.messages[2].ID())
+	}
+	if !strings.Contains(m.messages[1].Render(0), "▀") {
+		t.Errorf("messages[1] should be the inserted preview, got %q", m.messages[1].Render(0))
+	}
+}
+
+// TestImagePreviewReadyMsgUnknownAnchorAppends verifies that when the anchor
+// is missing (e.g. the message was cleared), the preview falls back to append.
+func TestImagePreviewReadyMsgUnknownAnchorAppends(t *testing.T) {
+	m, _, _ := newTestAppModel(nil)
+	m.messages = append(m.messages, NewStyledMessageItem("only", "user", "hi", "hi"))
+	m = sendMsg(m, imagePreviewReadyMsg{
+		block:    "\x1b[38;2;1;2;3;48;2;4;5;6m▀\x1b[0m",
+		anchorID: "does-not-exist",
+	})
+	if len(m.messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(m.messages))
+	}
+	if !strings.Contains(m.messages[1].Render(0), "▀") {
+		t.Error("preview should be appended as the last item when anchor is unknown")
 	}
 }
 

--- a/internal/ui/transcript_preview_test.go
+++ b/internal/ui/transcript_preview_test.go
@@ -1,0 +1,86 @@
+package ui
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+	"strings"
+	"testing"
+
+	uicore "github.com/mark3labs/kit/internal/ui/core"
+)
+
+// makeTestPNG builds a small solid-color PNG for transcript preview tests.
+func makeTestPNG(t *testing.T, w, h int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := range h {
+		for x := range w {
+			img.Set(x, y, color.RGBA{R: 200, G: 40, B: 90, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encode png: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestTranscriptPreviewCmdNoImages(t *testing.T) {
+	m, _, _ := newTestAppModel(nil)
+	if cmd := m.transcriptPreviewCmd(nil); cmd != nil {
+		t.Error("expected nil cmd when there are no images")
+	}
+}
+
+func TestTranscriptPreviewCmdRendersBlock(t *testing.T) {
+	m, _, _ := newTestAppModel(nil)
+	images := []uicore.ImageAttachment{
+		{Data: makeTestPNG(t, 16, 16), MediaType: "image/png"},
+	}
+	cmd := m.transcriptPreviewCmd(images)
+	if cmd == nil {
+		t.Fatal("expected a non-nil cmd for a valid image")
+	}
+	msg := cmd()
+	// The result depends on the test process color profile. When the
+	// terminal supports color the cmd yields a preview block; otherwise it
+	// yields nil (caller keeps the text badge). Both are valid — assert the
+	// shape only when a block is produced.
+	if msg == nil {
+		t.Skip("color profile below ANSI256 in test env; preview correctly skipped")
+	}
+	ready, ok := msg.(imagePreviewReadyMsg)
+	if !ok {
+		t.Fatalf("expected imagePreviewReadyMsg, got %T", msg)
+	}
+	if !strings.Contains(ready.block, "▀") {
+		t.Errorf("preview block should contain half-block glyphs, got %q", ready.block)
+	}
+}
+
+func TestImagePreviewReadyMsgAppendsItem(t *testing.T) {
+	m, _, _ := newTestAppModel(nil)
+	before := len(m.messages)
+	m = sendMsg(m, imagePreviewReadyMsg{block: "\x1b[38;2;1;2;3;48;2;4;5;6m▀\x1b[0m"})
+	if len(m.messages) != before+1 {
+		t.Fatalf("expected one appended message item, got %d (was %d)", len(m.messages), before)
+	}
+	last, ok := m.messages[len(m.messages)-1].(*TextMessageItem)
+	if !ok {
+		t.Fatalf("expected last item to be *TextMessageItem, got %T", m.messages[len(m.messages)-1])
+	}
+	if !strings.Contains(last.Render(0), "▀") {
+		t.Error("appended preview item should render the half-block block verbatim")
+	}
+}
+
+func TestImagePreviewReadyMsgEmptyBlockIgnored(t *testing.T) {
+	m, _, _ := newTestAppModel(nil)
+	before := len(m.messages)
+	m = sendMsg(m, imagePreviewReadyMsg{block: ""})
+	if len(m.messages) != before {
+		t.Errorf("empty preview block should not append an item; got %d (was %d)", len(m.messages), before)
+	}
+}


### PR DESCRIPTION
## Description

Follow-up to #47. The half-block image thumbnail preview added in that PR
**rendered correctly but never appeared on screen**, and submitted images
showed only a text badge in the conversation transcript.

Two distinct bugs:

**1. Pending preview clipped off the bottom of the input box.** Thumbnails
render asynchronously (a `tea.Cmd` so decode + resample never blocks the
event loop). The result arrives via `thumbnailReadyMsg`, handled inside the
child `InputComponent`. But `AppModel.View()` only re-measures the layout
when `layoutDirty` is set, and nothing set it — so `distributeHeight` had
already measured the input region while the thumbnail was still empty
(~6 lines). When the ~12-row thumbnail arrived, the region kept its stale
short height and the preview (rendered below the `[N image(s) attached]`
pill) fell off the bottom of the screen.

**2. No preview in the transcript.** After submitting, the conversation
history showed only `[1 image(s) pasted]` with no thumbnail — transcript
previews were never implemented in #47.

## How It Works

- **Layout fix:** a parent `Update` case for `clipboardImageMsg` /
  `thumbnailReadyMsg` forwards them to the input **and sets
  `layoutDirty = true`**, so the now-taller input region is re-measured and
  the stream shrinks to make room.
- **Transcript previews:** `transcriptPreviewCmd` renders thumbnails off the
  event loop and delivers them via `imagePreviewReadyMsg`; the handler
  appends them as a **verbatim** `TextMessageItem` directly after the user
  message. A separate item is required because user text flows through a
  word-wrapped, bordered render block that would mangle embedded raw ANSI
  half-blocks.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Verification

Beyond unit tests, I drove the actual Bubble Tea v2 render pipeline through a
live tmux pane and a live zellij session (captured with escape sequences):
the half-block + truecolor output survives both multiplexers byte-for-byte,
degrading to 256-color under tmux. The regression test confirms the input
region grows from 6 to 15 lines once the async thumbnail lands and that the
`▀` glyphs appear in the full parent `View()`.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-reviewed the changes
- [x] Added regression tests (input layout recompute + transcript preview)
- [x] `go test ./internal/ui/... -race` passes
- [x] `go vet ./...` clean; `golangci-lint run` reports no issues on changed code

## Additional Information

**Files**

- `internal/ui/model.go` — layout-dirty fix + async transcript preview
- `internal/ui/pending_thumbnail_layout_test.go` — regression test for the
  input clipping bug
- `internal/ui/transcript_preview_test.go` — transcript preview cmd + handler tests

**Backwards compatibility**

- Fully compatible. When the terminal cannot display a preview (no
  truecolor/256-color), behaviour is unchanged: the text pill / badge is
  shown alone.

**Scope note**

- Transcript previews are wired into the synchronous submit paths (agent
  idle / no controller). The *queued* submit path (sending while the agent is
  busy) renders its message later via a string-only queue and is left as a
  focused follow-up to avoid an ordering refactor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clipboard-pasted images now show inline thumbnail previews in the conversation. Previews render asynchronously and are inserted after the relevant message (or appended), with automatic input/preview height adjustment.
* **Tests**
  * Added regression and functional tests for thumbnail rendering, layout recomputation when previews arrive late, anchor insertion behavior, and deterministic preview generation across terminal color profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->