### PR TITLE
Make subagent inherit tools from parent

### DIFF
--- a/internal/extbridge/extbridge.go
+++ b/internal/extbridge/extbridge.go
@@ -66,6 +66,7 @@ func SpawnSubagent(ctx context.Context, k *kit.Kit, cfg extensions.SubagentConfi
 		SystemPrompt: cfg.SystemPrompt,
 		Timeout:      cfg.Timeout,
 		NoSession:    cfg.NoSession,
+		Tools:        k.GetToolsForSubagent(),
 	}
 	if cfg.OnEvent != nil {
 		sdkCfg.OnEvent = func(e kit.Event) {

--- a/pkg/kit/kit.go
+++ b/pkg/kit/kit.go
@@ -138,6 +138,19 @@ func (m *Kit) GetToolNames() []string {
 	return names
 }
 
+// GetToolsForSubagent like GetTools but eliminates subagent tool
+// to avoid infinite recursion.
+func (m *Kit) GetToolsForSubagent() []Tool {
+	var tools []Tool
+	for _, t := range m.agent.GetTools() {
+		if t.Info().Name == "subagent" {
+			continue
+		}
+		tools = append(tools, t)
+	}
+	return tools
+}
+
 // GetLoadingMessage returns the agent's startup info message (e.g. GPU
 // fallback info), or empty string if none.
 func (m *Kit) GetLoadingMessage() string {
@@ -1814,8 +1827,14 @@ type SubagentConfig struct {
 	// Empty string uses a minimal default prompt.
 	SystemPrompt string
 
-	// Tools overrides the tool set. If nil, SubagentTools() is used (all
-	// core tools except subagent, preventing infinite recursion).
+	// Tools overrides the tool set available to the subagent.
+	// If nil and the subagent is created via the SDK (Kit.Subagent()), the
+	// static SubagentTools() set (all core tools except "subagent") is used.
+	// When spawned internally by the agent loop, the parent's active tools
+	// minus "subagent" are used instead (see GetToolsForSubagent()).
+	// Pass m.GetToolsForSubagent() explicitly to opt into inheritance from
+	// SDK call sites.
+	// (The subagent tool is dropped to prevent infinite recursion.)
 	Tools []Tool
 
 	// NoSession, when true, uses an in-memory ephemeral session. When false
@@ -2076,6 +2095,7 @@ func (m *Kit) generate(ctx context.Context, messages []fantasy.Message) (*agent.
 			SystemPrompt: systemPrompt,
 			Timeout:      timeout,
 			OnEvent:      onEvent,
+			Tools:        m.GetToolsForSubagent(),
 		})
 		m.cleanupSubagentListeners(toolCallID)
 		if result == nil {


### PR DESCRIPTION
There exist a number of ways to configure what tools are made available to agents:

1. DisableCoreTools - a boolean which allows to disable all core tools.
2. CoreTools - an explicit list (`[]fantasy.AgentTool`) of allowed core tools.
3. ExtraTools - a list of tools provided by extensions.

Subagent however, receive the static list of subagent tools (`core.SubagentTools()`) - unless tools are explicitly provided through the API call to `kit.Subagent()`.  This ignores all settings concerning tools for the main agent. This affects subagents created in the TUI as the tools list provided in the subagent configuration will always be empty.
IHMO, subagent should inherit tools from the main agent unless an explicit list of tools has been provided.

This patch provides this: It retrieves the list of agent tools, removes the subagent tool and adds it to the subagent configuration with the subagent tool itself removed.

The removal of the subaagent tool makes this change slightly ugly as it adds knowledge about details from `internal/core` (name of subagent tool) known to the `kit` package.
Please let me know if I should address this differently!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented recursive spawning by excluding the subagent tool from child subagent toolsets.
* **Improvements**
  * Child subagents now inherit the parent agent’s active toolset (with subagent excluded), ensuring consistent tool availability across agent hierarchies.
* **Documentation**
  * Clarified subagent toolset behavior for SDK-created versus internally spawned subagents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->