### PR TITLE
Set subagent tool name in a single place

### DIFF
--- a/internal/core/subagent.go
+++ b/internal/core/subagent.go
@@ -10,6 +10,7 @@ import (
 
 const defaultSubagentTimeout = 5 * time.Minute
 const maxSubagentTimeout = 30 * time.Minute
+const SubagentToolName = "subagent"
 
 // ---------------------------------------------------------------------------
 // Context-based subagent spawner
@@ -63,7 +64,7 @@ type subagentArgs struct {
 func NewSubagentTool(opts ...ToolOption) fantasy.AgentTool {
 	return &coreTool{
 		info: fantasy.ToolInfo{
-			Name: "subagent",
+			Name: SubagentToolName,
 			Description: `Spawn a subagent to perform a task autonomously.
 
 The subagent runs as a separate in-process Kit instance with full tool access

--- a/pkg/kit/kit.go
+++ b/pkg/kit/kit.go
@@ -143,7 +143,7 @@ func (m *Kit) GetToolNames() []string {
 func (m *Kit) GetToolsForSubagent() []Tool {
 	var tools []Tool
 	for _, t := range m.agent.GetTools() {
-		if t.Info().Name == "subagent" {
+		if t.Info().Name == core.SubagentToolName {
 			continue
 		}
 		tools = append(tools, t)


### PR DESCRIPTION
This helps to keep the names in sync between packages and improves commit ef072f6e594a927862e27eb7265020344cbd1ba9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to code organization and consistency for enhanced maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->