### PR TITLE
feat(sdk): add Options.DebugLogger and WithDebugLogger option

### DIFF
--- a/internal/kitsetup/setup.go
+++ b/internal/kitsetup/setup.go
@@ -53,6 +53,11 @@ type AgentSetupOptions struct {
 	// Debug enables debug logging. When zero-value, viper is consulted.
 	// Only meaningful when ProviderConfig is also set.
 	Debug bool
+	// DebugLogger, if non-nil, is used directly as the engine/MCP debug
+	// logger — overriding the built-in SimpleDebugLogger / BufferedDebugLogger
+	// selected by Debug + UseBufferedLogger. Callers supply this when they
+	// want to route debug output into their own logging system.
+	DebugLogger tools.DebugLogger
 	// NoExtensions skips extension loading. When false, viper is consulted.
 	// Only meaningful when ProviderConfig is also set.
 	NoExtensions bool
@@ -192,7 +197,12 @@ func SetupAgent(ctx context.Context, opts AgentSetupOptions) (*AgentSetupResult,
 	// Create the appropriate debug logger.
 	var debugLogger tools.DebugLogger
 	var bufferedLogger *tools.BufferedDebugLogger
-	if debugEnabled {
+	switch {
+	case opts.DebugLogger != nil:
+		// Caller-supplied logger wins unconditionally. Its IsDebugEnabled()
+		// is the source of truth for whether downstream code emits messages.
+		debugLogger = opts.DebugLogger
+	case debugEnabled:
 		if opts.UseBufferedLogger {
 			bufferedLogger = tools.NewBufferedDebugLogger(true)
 			debugLogger = bufferedLogger

--- a/pkg/kit/README.md
+++ b/pkg/kit/README.md
@@ -74,7 +74,8 @@ host, err := kit.NewAgent(ctx,
 
 Helpers: `WithModel`, `WithSystemPrompt`, `WithStreaming`, `WithMaxTokens`,
 `WithThinkingLevel`, `WithTools`, `WithExtraTools`, `WithProviderAPIKey`,
-`WithProviderURL`, `WithConfigFile`, `WithDebug`, and `Ephemeral`. `Option` is
+`WithProviderURL`, `WithConfigFile`, `WithDebug`, `WithDebugLogger`, and
+`Ephemeral`. `Option` is
 a plain `func(*Options)`, so you can define your own. For fields without a
 `With*` helper (`MCPConfig`, `InProcessMCPServers`, `SessionManager`, MCP task
 tuning) construct an `Options` value and call `kit.New`.

--- a/pkg/kit/kit.go
+++ b/pkg/kit/kit.go
@@ -1047,8 +1047,24 @@ type Options struct {
 	AutoCompact       bool               // Auto-compact when near context limit
 	CompactionOptions *CompactionOptions // Config for auto-compaction (nil = defaults)
 
-	// Debug enables debug logging for the SDK.
+	// Debug enables debug logging for the SDK. When DebugLogger is nil this
+	// flag selects between the default no-op SimpleDebugLogger (Debug=false)
+	// and the built-in console/buffered logger (Debug=true). When DebugLogger
+	// is non-nil this flag is ignored — the supplied logger's
+	// IsDebugEnabled() controls whether downstream code emits messages.
 	Debug bool
+
+	// DebugLogger, if non-nil, routes low-level debug output from the engine
+	// and the MCP tool plumbing to a caller-supplied implementation. This is
+	// the SDK escape hatch for embedders that want to forward debug output
+	// into their own logging system (zap, slog, log/charm, an in-app TUI
+	// panel, etc.) instead of the built-in console logger.
+	//
+	// When nil (default) the Debug bool controls whether the built-in logger
+	// is installed. When non-nil this logger is used unconditionally and the
+	// Debug bool is ignored; the supplied logger's IsDebugEnabled() reports
+	// whether downstream code should bother formatting messages.
+	DebugLogger DebugLogger
 
 	// MCPAuthHandler handles OAuth authorization for remote MCP servers.
 	// When set, remote transports (streamable HTTP, SSE) are configured
@@ -1514,6 +1530,7 @@ func New(ctx context.Context, opts *Options) (*Kit, error) {
 		ToolWrapper:       hookToolWrapper(beforeToolCall, afterToolResult),
 		ProviderConfig:    providerConfig,
 		Debug:             debug,
+		DebugLogger:       opts.DebugLogger,
 		NoExtensions:      noExtensions,
 		MaxSteps:          maxSteps,
 		StreamingEnabled:  streaming,

--- a/pkg/kit/options.go
+++ b/pkg/kit/options.go
@@ -83,6 +83,17 @@ func WithConfigFile(path string) Option { return func(o *Options) { o.ConfigFile
 // WithDebug enables SDK debug logging.
 func WithDebug() Option { return func(o *Options) { o.Debug = true } }
 
+// WithDebugLogger installs a caller-supplied [DebugLogger] for low-level
+// engine and MCP tool plumbing output. When set this overrides the built-in
+// logger selected by [WithDebug] — messages flow into the supplied logger
+// unconditionally, and the logger's IsDebugEnabled reports whether downstream
+// code should bother formatting them. Use this to forward Kit's debug output
+// into your application's logging system (slog, zap, charm/log, an in-app
+// panel, etc.).
+func WithDebugLogger(l DebugLogger) Option {
+	return func(o *Options) { o.DebugLogger = l }
+}
+
 // Ephemeral configures an in-memory session with no persistence (equivalent to
 // Options.NoSession = true).
 func Ephemeral() Option { return func(o *Options) { o.NoSession = true } }

--- a/pkg/kit/viper_isolation_test.go
+++ b/pkg/kit/viper_isolation_test.go
@@ -63,6 +63,52 @@ func TestOptionFunctionsPlumbing(t *testing.T) {
 	}
 }
 
+// recordingDebugLogger is a kit.DebugLogger used to verify WithDebugLogger
+// plumbs the supplied logger into Options. It records each LogDebug call.
+type recordingDebugLogger struct {
+	enabled  bool
+	messages []string
+}
+
+func (l *recordingDebugLogger) LogDebug(m string)    { l.messages = append(l.messages, m) }
+func (l *recordingDebugLogger) IsDebugEnabled() bool { return l.enabled }
+
+// TestWithDebugLoggerPlumbing verifies that kit.WithDebugLogger assigns the
+// supplied logger to Options.DebugLogger. End-to-end propagation into the
+// engine is covered indirectly by the existing kitsetup tests; this test
+// pins the SDK-surface contract.
+func TestWithDebugLoggerPlumbing(t *testing.T) {
+	l := &recordingDebugLogger{enabled: true}
+	o := &kit.Options{}
+	kit.WithDebugLogger(l)(o)
+	if o.DebugLogger == nil {
+		t.Fatal("WithDebugLogger: expected Options.DebugLogger to be set")
+	}
+	if o.DebugLogger != l {
+		t.Error("WithDebugLogger: expected the supplied logger to be installed verbatim")
+	}
+	// Sanity: the installed logger satisfies the SDK interface contract.
+	if !o.DebugLogger.IsDebugEnabled() {
+		t.Error("installed logger IsDebugEnabled() returned false")
+	}
+	o.DebugLogger.LogDebug("hello")
+	if len(l.messages) != 1 || l.messages[0] != "hello" {
+		t.Errorf("LogDebug not forwarded; got %v", l.messages)
+	}
+}
+
+// TestWithDebugLoggerNilClears verifies that passing a nil logger to
+// WithDebugLogger clears any previously-installed logger. This lets later
+// options override earlier ones the same way WithModel / WithStreaming do.
+func TestWithDebugLoggerNilClears(t *testing.T) {
+	o := &kit.Options{}
+	kit.WithDebugLogger(&recordingDebugLogger{enabled: true})(o)
+	kit.WithDebugLogger(nil)(o)
+	if o.DebugLogger != nil {
+		t.Errorf("WithDebugLogger(nil): expected DebugLogger to be cleared; got %#v", o.DebugLogger)
+	}
+}
+
 // TestOptionOrderingOverrides verifies later options override earlier ones.
 func TestOptionOrderingOverrides(t *testing.T) {
 	o := &kit.Options{}


### PR DESCRIPTION
## Summary

The SDK exposes a `DebugLogger` interface (`pkg/kit/types.go`) but no public path to install one. The only consumer of the field is the unexported `kit.AgentConfig.toInternal()` method, which itself is not reachable from outside the package. Embedders that want to forward Kit's low-level engine + MCP debug output into their own logging system (slog, zap, charm/log, an in-app TUI panel, etc.) currently have no option but the on/off `Debug bool`, which always installs the built-in `SimpleDebugLogger` / `BufferedDebugLogger`.

This PR closes that gap on the supported `Options` / functional-option construction path.

## Changes

- **`pkg/kit/kit.go`**: add `Options.DebugLogger DebugLogger`. When non-nil it is used directly and the `Debug` bool is ignored; the supplied logger's `IsDebugEnabled()` controls whether downstream code emits messages.
- **`pkg/kit/options.go`**: add `WithDebugLogger(l DebugLogger) Option`.
- **`internal/kitsetup/setup.go`**: add `AgentSetupOptions.DebugLogger` and switch `SetupAgent`'s logger selection so the caller-supplied logger wins unconditionally; otherwise the existing `Debug` + `UseBufferedLogger` branch picks the built-in implementation. No behaviour change when `DebugLogger` is nil.
- **`pkg/kit/kit.go`**: wire `opts.DebugLogger` into `setupOpts` so the `New()` path threads it through.
- **`pkg/kit/viper_isolation_test.go`**: add `TestWithDebugLoggerPlumbing` and `TestWithDebugLoggerNilClears` covering the option-to-field contract and later-options-override semantics consistent with the other `With*` helpers.
- **`pkg/kit/README.md`**: list `WithDebugLogger` in the helper inventory.

## Usage

```go
type myLogger struct{ /* slog/zap/charm-log wrapper */ }

func (l *myLogger) LogDebug(msg string)    { /* forward */ }
func (l *myLogger) IsDebugEnabled() bool   { return true }

k, err := kit.NewAgent(ctx,
    kit.WithModel("anthropic/claude-sonnet-4-5-20250929"),
    kit.WithDebugLogger(&myLogger{}),
)
```

## Notes

- `kit.DebugLogger` and `tools.DebugLogger` are structurally identical (`LogDebug(string)` / `IsDebugEnabled() bool`), so the SDK value flows into the internal field without a conversion.
- This is purely additive on the SDK surface and does not touch `kit.AgentConfig` — that field already carried a `DebugLogger`, but the `AgentConfig` path is unreachable from outside the package today.
- A discussion thread suggested removing the unreachable `kit.AgentConfig` entirely; this PR is intentionally scoped to the "keep `DebugLogger`, add the missing wiring" option only. Removal of `AgentConfig` (if desired) belongs in a separate change.

## Verification

- `go build ./pkg/... ./internal/... ./cmd/...` — clean
- `go vet ./...` — clean (modulo the pre-existing `examples/extensions` Yaegi source not being a `main` package)
- `go test -race ./pkg/kit/... ./internal/kitsetup/... ./internal/agent/... ./internal/tools/...` — passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `WithDebugLogger` option to supply custom debug logger implementations, allowing users to route and control debug output
  * Custom-supplied loggers override built-in debug logging when configured, providing full control over debug output handling
  * Debug state reporting now determined by the configured logger instance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->