### PR TITLE
test(kit): Add test for `GetToolsForSubagent()`

### DIFF
--- a/pkg/kit/kit_test.go
+++ b/pkg/kit/kit_test.go
@@ -662,3 +662,54 @@ exclude-core-tools:
 		}
 	})
 }
+
+func TestGetToolsForSubagent(t *testing.T) {
+	if os.Getenv("ANTHROPIC_API_KEY") == "" {
+		t.Skip("Skipping test: ANTHROPIC_API_KEY not set")
+	}
+	defer resetViper()
+
+	ctx := context.Background()
+	type HelloInput struct {
+		Query string `json:"query,omitempty" description:"Hello request"`
+	}
+	helloTool := kit.NewTool("hello", "Say \"Hello!\"",
+		func(ctx context.Context, input HelloInput) (kit.ToolOutput, error) {
+			return kit.TextResult("Hello!"), nil
+		},
+	)
+
+	host, err := kit.New(ctx, &kit.Options{
+		Model:        "anthropic/claude-sonnet-4-5-20250929",
+		Quiet:        true,
+		NoSession:    true,
+		NoExtensions: true,
+		CoreToolList: []string{"subagent", "bash"},
+		ExtraTools:   []kit.Tool{helloTool},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create Kit: %v", err)
+	}
+	defer func() { _ = host.Close() }()
+	toolsForSubagent := host.GetToolsForSubagent()
+	if len(toolsForSubagent) != 2 {
+		t.Fatalf("`GetToolsForSubagent()` should return 2 tools but has: %d", len(toolsForSubagent))
+	}
+	hasTool := func(name string) bool {
+		for _, tool := range toolsForSubagent {
+			if tool.Info().Name == name {
+				return true
+			}
+		}
+		return false
+	}
+	if hasTool("subagent") {
+		t.Errorf("`GetToolsForSubagent()` unexpectedly includes the `subagent` tool")
+	}
+	if !hasTool("hello") {
+		t.Errorf("`GetToolsForSubagent()` is missing the `hello` tool")
+	}
+	if !hasTool("bash") {
+		t.Errorf("`GetToolsForSubagent()` is missing the `bash` tool")
+	}
+}


### PR DESCRIPTION
`GetToolsForSubagent()` was added in commit:
       Make subagent inherit tools from parent (#51)
       ef072f6e594a927862e27eb7265020344cbd1ba9
to collect all tools from the main agent but exclude the 'subagent' tool. The resulting tool list may be passed to the `Tools` argument of `SubagentConfig`.
    
 The test works as follows:

1. The main 'kit' instance is configured with a `CoreToolList`  only containing 'subagent' and 'bash'.  
2. A 'hello' tool is provided as `ExtraTools` in `kit.Options`.  In this case, the main 'kit' instance will only have the  'subagent', 'bash' and 'hello' tool. `GetToolsForSubagent()` should filter out the 'subagent' tool. `GetToolsForSubagent()` is called and the result is checked against the expected list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage to ensure subagent tool availability behaves correctly when core tools are disabled.
  * Verified that subagent does not include the core subagent tool, while still exposing both custom extra tools and remaining allowed core tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->