### PR TITLE
fix: normalize .wav MIME type to audio/wav

### DIFF
--- a/internal/ui/fileutil/processor.go
+++ b/internal/ui/fileutil/processor.go
@@ -243,6 +243,15 @@ func wrapFileContent(absPath string, content []byte) string {
 func detectMediaType(path string, content []byte) string {
 	// Extension-based detection is more reliable for well-known types.
 	ext := strings.ToLower(filepath.Ext(path))
+
+	// Some system MIME databases return legacy or inconsistent types
+	// (e.g. audio/x-wav instead of audio/wav). Force canonical types
+	// for extensions we explicitly support.
+	switch ext {
+	case ".wav":
+		return "audio/wav"
+	}
+
 	if mt := mime.TypeByExtension(ext); mt != "" {
 		// mime.TypeByExtension returns types like "image/png; charset=utf-8"
 		// — strip parameters.


### PR DESCRIPTION
System MIME databases vary: some return `audio/x-wav` for `.wav`, which causes `TestDetectMediaType` to fail on certain CI images. This change forces the canonical `audio/wav` type for `.wav` files so the test is deterministic across environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of WAV files so they are consistently treated as audio/WAV across the app.
  * This helps prevent incorrect file-type detection in workflows that rely on media identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->