### PR TITLE
fix(extensions): implement non-blocking subagent spawn with usable handle

### DIFF
--- a/examples/extensions/subagent-test.go
+++ b/examples/extensions/subagent-test.go
@@ -112,12 +112,17 @@ func Init(api ext.API) {
 			ctx.PrintInfo(fmt.Sprintf("Spawning background subagent for: %s", task))
 
 			start := time.Now()
+			var chunkMu sync.Mutex
+			chunks := 0
 			handle, _, err := ctx.SpawnSubagent(ext.SubagentConfig{
 				Prompt:  task,
 				Timeout: 2 * time.Minute,
 				OnOutput: func(chunk string) {
-					// Live output - could update a widget here
-					fmt.Print(chunk)
+					// Live assistant text - could update a widget here.
+					// (Do not print to stdout: it would corrupt the TUI.)
+					chunkMu.Lock()
+					chunks++
+					chunkMu.Unlock()
 				},
 				OnComplete: func(result ext.SubagentResult) {
 					elapsed := time.Since(start)
@@ -137,7 +142,11 @@ func Init(api ext.API) {
 						return
 					}
 
-					msg := fmt.Sprintf("Background subagent completed in %ds", int(elapsed.Seconds()))
+					chunkMu.Lock()
+					n := chunks
+					chunkMu.Unlock()
+
+					msg := fmt.Sprintf("Background subagent completed in %ds (%d text chunks)", int(elapsed.Seconds()), n)
 					if result.Usage != nil {
 						msg += fmt.Sprintf(" (tokens: %d in / %d out)", result.Usage.InputTokens, result.Usage.OutputTokens)
 					}
@@ -149,6 +158,9 @@ func Init(api ext.API) {
 
 			if err != nil {
 				return fmt.Sprintf("Spawn error: %v", err), nil
+			}
+			if handle == nil {
+				return "Spawn error: no handle returned", nil
 			}
 
 			return fmt.Sprintf("Background subagent spawned (ID: %s). Results will be delivered when complete.", handle.ID), nil

--- a/internal/extbridge/extbridge.go
+++ b/internal/extbridge/extbridge.go
@@ -79,8 +79,8 @@ func SpawnSubagent(ctx context.Context, k *kit.Kit, cfg extensions.SubagentConfi
 func dispatchSubagent(ctx context.Context, run func(context.Context) (*extensions.SubagentResult, error), cfg extensions.SubagentConfig) (*extensions.SubagentHandle, *extensions.SubagentResult, error) {
 	if cfg.Blocking {
 		result, err := run(ctx)
-		if cfg.OnComplete != nil && result != nil {
-			cfg.OnComplete(*result)
+		if cfg.OnComplete != nil {
+			cfg.OnComplete(completionResult(result, err))
 		}
 		return nil, result, err
 	}
@@ -89,16 +89,24 @@ func dispatchSubagent(ctx context.Context, run func(context.Context) (*extension
 	handle := extensions.NewSubagentHandle(newSubagentID(), cancel)
 	go func() {
 		defer cancel()
-		result, _ := run(runCtx)
-		if result == nil {
-			result = &extensions.SubagentResult{ExitCode: 1}
-		}
-		handle.Complete(*result)
+		final := completionResult(run(runCtx))
+		handle.Complete(final)
 		if cfg.OnComplete != nil {
-			cfg.OnComplete(*result)
+			cfg.OnComplete(final)
 		}
 	}()
 	return handle, nil, nil
+}
+
+// completionResult normalizes a run outcome for delivery to
+// SubagentHandle.Complete and cfg.OnComplete: a nil result (defensive —
+// runSubagent always returns non-nil) becomes a failure result carrying
+// err, so the error is never silently dropped.
+func completionResult(result *extensions.SubagentResult, err error) extensions.SubagentResult {
+	if result == nil {
+		return extensions.SubagentResult{Error: err, ExitCode: 1}
+	}
+	return *result
 }
 
 // runSubagent executes one subagent run synchronously via the Kit SDK and

--- a/internal/extbridge/extbridge.go
+++ b/internal/extbridge/extbridge.go
@@ -5,6 +5,8 @@ package extbridge
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 
 	"github.com/mark3labs/kit/internal/extensions"
 	kit "github.com/mark3labs/kit/pkg/kit"
@@ -51,15 +53,59 @@ func SDKEventToSubagentEvent(e kit.Event) extensions.SubagentEvent {
 }
 
 // SpawnSubagent runs a subagent in-process via the Kit SDK and translates
-// the result/events back into the extension-facing types. The returned
-// handle is always nil — the SDK path runs synchronously and does not
-// expose a separate process handle. Callers that need non-blocking
-// behaviour should run this in their own goroutine.
+// the result/events back into the extension-facing types.
+//
+// When cfg.Blocking is true, the call waits for completion and returns
+// (nil, result, err); cfg.OnComplete (if set) is invoked before returning.
+// When cfg.Blocking is false (default), the subagent runs in a background
+// goroutine and the call returns immediately with (handle, nil, nil). The
+// handle supports Wait/Done/Kill; cfg.OnComplete and cfg.OnEvent are
+// invoked asynchronously from the subagent's goroutine.
 //
 // This function consolidates the previously-duplicated wiring in
 // cmd/root.go (interactive + runtime contexts) and
 // internal/acpserver/session.go.
 func SpawnSubagent(ctx context.Context, k *kit.Kit, cfg extensions.SubagentConfig) (*extensions.SubagentHandle, *extensions.SubagentResult, error) {
+	run := func(runCtx context.Context) (*extensions.SubagentResult, error) {
+		return runSubagent(runCtx, k, cfg)
+	}
+	return dispatchSubagent(ctx, run, cfg)
+}
+
+// dispatchSubagent implements the blocking/background contract of
+// SpawnSubagent on top of an injectable run function. Split out from
+// SpawnSubagent so the dispatch logic is testable without a real Kit
+// instance.
+func dispatchSubagent(ctx context.Context, run func(context.Context) (*extensions.SubagentResult, error), cfg extensions.SubagentConfig) (*extensions.SubagentHandle, *extensions.SubagentResult, error) {
+	if cfg.Blocking {
+		result, err := run(ctx)
+		if cfg.OnComplete != nil && result != nil {
+			cfg.OnComplete(*result)
+		}
+		return nil, result, err
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	handle := extensions.NewSubagentHandle(newSubagentID(), cancel)
+	go func() {
+		defer cancel()
+		result, _ := run(runCtx)
+		if result == nil {
+			result = &extensions.SubagentResult{ExitCode: 1}
+		}
+		handle.Complete(*result)
+		if cfg.OnComplete != nil {
+			cfg.OnComplete(*result)
+		}
+	}()
+	return handle, nil, nil
+}
+
+// runSubagent executes one subagent run synchronously via the Kit SDK and
+// converts the outcome to the extension-facing result type. The returned
+// result is always non-nil; on failure result.Error and result.ExitCode
+// are set in addition to the returned error.
+func runSubagent(ctx context.Context, k *kit.Kit, cfg extensions.SubagentConfig) (*extensions.SubagentResult, error) {
 	sdkCfg := kit.SubagentConfig{
 		Prompt:       cfg.Prompt,
 		Model:        cfg.Model,
@@ -68,18 +114,24 @@ func SpawnSubagent(ctx context.Context, k *kit.Kit, cfg extensions.SubagentConfi
 		NoSession:    cfg.NoSession,
 		Tools:        k.GetToolsForSubagent(),
 	}
-	if cfg.OnEvent != nil {
+	if cfg.OnEvent != nil || cfg.OnOutput != nil {
 		sdkCfg.OnEvent = func(e kit.Event) {
 			se := SDKEventToSubagentEvent(e)
-			if se.Type != "" {
+			if se.Type == "" {
+				return
+			}
+			if cfg.OnEvent != nil {
 				cfg.OnEvent(se)
+			}
+			if cfg.OnOutput != nil && se.Type == "text" && se.Content != "" {
+				cfg.OnOutput(se.Content)
 			}
 		}
 	}
 
 	result, err := k.Subagent(ctx, sdkCfg)
 	if result == nil {
-		return nil, &extensions.SubagentResult{Error: err}, err
+		return &extensions.SubagentResult{Error: err, ExitCode: 1}, err
 	}
 
 	extResult := &extensions.SubagentResult{
@@ -88,11 +140,24 @@ func SpawnSubagent(ctx context.Context, k *kit.Kit, cfg extensions.SubagentConfi
 		SessionID: result.SessionID,
 		Elapsed:   result.Elapsed,
 	}
+	if err != nil {
+		extResult.ExitCode = 1
+	}
 	if result.Usage != nil {
 		extResult.Usage = &extensions.SubagentUsage{
 			InputTokens:  result.Usage.InputTokens,
 			OutputTokens: result.Usage.OutputTokens,
 		}
 	}
-	return nil, extResult, err
+	return extResult, err
+}
+
+// newSubagentID returns a short random identifier for a background
+// subagent handle.
+func newSubagentID() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "subagent-unknown"
+	}
+	return "subagent-" + hex.EncodeToString(b[:])
 }

--- a/internal/extbridge/extbridge_test.go
+++ b/internal/extbridge/extbridge_test.go
@@ -142,8 +142,9 @@ func TestDispatchSubagent_KillCancelsRunContext(t *testing.T) {
 }
 
 func TestDispatchSubagent_NilResultFallback(t *testing.T) {
+	wantErr := errors.New("boom")
 	run := func(context.Context) (*extensions.SubagentResult, error) {
-		return nil, errors.New("boom")
+		return nil, wantErr
 	}
 
 	handle, _, err := dispatchSubagent(context.Background(), run, extensions.SubagentConfig{})
@@ -154,6 +155,38 @@ func TestDispatchSubagent_NilResultFallback(t *testing.T) {
 	got := handle.Wait()
 	if got.ExitCode != 1 {
 		t.Errorf("nil-result fallback exit code = %d, want 1", got.ExitCode)
+	}
+	if !errors.Is(got.Error, wantErr) {
+		t.Errorf("nil-result fallback error = %v, want %v (run error must not be dropped)", got.Error, wantErr)
+	}
+}
+
+func TestDispatchSubagent_BlockingNilResultStillFiresOnComplete(t *testing.T) {
+	wantErr := errors.New("boom")
+	run := func(context.Context) (*extensions.SubagentResult, error) {
+		return nil, wantErr
+	}
+
+	var completed *extensions.SubagentResult
+	cfg := extensions.SubagentConfig{
+		Blocking: true,
+		OnComplete: func(r extensions.SubagentResult) {
+			completed = &r
+		},
+	}
+
+	_, result, err := dispatchSubagent(context.Background(), run, cfg)
+	if !errors.Is(err, wantErr) {
+		t.Errorf("dispatch error = %v, want %v", err, wantErr)
+	}
+	if result != nil {
+		t.Errorf("result = %+v, want nil passthrough", result)
+	}
+	if completed == nil {
+		t.Fatal("OnComplete must fire even when the run returns a nil result")
+	}
+	if !errors.Is(completed.Error, wantErr) || completed.ExitCode != 1 {
+		t.Errorf("OnComplete got %+v, want Error=%v ExitCode=1", completed, wantErr)
 	}
 }
 

--- a/internal/extbridge/extbridge_test.go
+++ b/internal/extbridge/extbridge_test.go
@@ -1,0 +1,168 @@
+package extbridge
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/kit/internal/extensions"
+)
+
+// Regression tests for issue #86: SpawnSubagent with Blocking=false must
+// return a usable non-nil handle and run in the background, and
+// OnComplete must fire in both modes.
+
+func TestDispatchSubagent_BlockingReturnsResultAndNilHandle(t *testing.T) {
+	want := &extensions.SubagentResult{Response: "done"}
+	completed := false
+
+	run := func(context.Context) (*extensions.SubagentResult, error) {
+		return want, nil
+	}
+	cfg := extensions.SubagentConfig{
+		Blocking: true,
+		OnComplete: func(r extensions.SubagentResult) {
+			completed = true
+			if r.Response != "done" {
+				t.Errorf("OnComplete got response %q, want %q", r.Response, "done")
+			}
+		},
+	}
+
+	handle, result, err := dispatchSubagent(context.Background(), run, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if handle != nil {
+		t.Error("blocking spawn should return nil handle")
+	}
+	if result == nil || result.Response != "done" {
+		t.Errorf("blocking spawn result = %+v, want Response %q", result, "done")
+	}
+	if !completed {
+		t.Error("OnComplete should fire before blocking spawn returns")
+	}
+}
+
+func TestDispatchSubagent_NonBlockingReturnsHandleImmediately(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	completed := make(chan extensions.SubagentResult, 1)
+
+	run := func(context.Context) (*extensions.SubagentResult, error) {
+		close(started)
+		<-release
+		return &extensions.SubagentResult{Response: "background done"}, nil
+	}
+	cfg := extensions.SubagentConfig{
+		Blocking: false,
+		OnComplete: func(r extensions.SubagentResult) {
+			completed <- r
+		},
+	}
+
+	handle, result, err := dispatchSubagent(context.Background(), run, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if handle == nil {
+		t.Fatal("non-blocking spawn must return a non-nil handle (issue #86)")
+	}
+	if handle.ID == "" {
+		t.Error("handle.ID should be populated")
+	}
+	if result != nil {
+		t.Errorf("non-blocking spawn should return nil result, got %+v", result)
+	}
+
+	// The run must have started in the background but not completed.
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background run never started")
+	}
+	select {
+	case <-handle.Done():
+		t.Fatal("handle reported done while run still in flight")
+	default:
+	}
+
+	close(release)
+
+	// Wait delivers the result.
+	got := handle.Wait()
+	if got.Response != "background done" {
+		t.Errorf("Wait() response = %q, want %q", got.Response, "background done")
+	}
+
+	// OnComplete fires asynchronously with the same result.
+	select {
+	case r := <-completed:
+		if r.Response != "background done" {
+			t.Errorf("OnComplete response = %q, want %q", r.Response, "background done")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnComplete never fired for background spawn")
+	}
+}
+
+func TestDispatchSubagent_KillCancelsRunContext(t *testing.T) {
+	run := func(ctx context.Context) (*extensions.SubagentResult, error) {
+		<-ctx.Done()
+		return &extensions.SubagentResult{Error: ctx.Err(), ExitCode: 1}, ctx.Err()
+	}
+
+	handle, _, err := dispatchSubagent(context.Background(), run, extensions.SubagentConfig{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if handle == nil {
+		t.Fatal("expected non-nil handle")
+	}
+
+	if err := handle.Kill(); err != nil {
+		t.Fatalf("Kill() error: %v", err)
+	}
+
+	select {
+	case <-handle.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("Kill() did not terminate the background run")
+	}
+
+	got := handle.Wait()
+	if !errors.Is(got.Error, context.Canceled) {
+		t.Errorf("Wait() error = %v, want context.Canceled", got.Error)
+	}
+	if got.ExitCode != 1 {
+		t.Errorf("Wait() exit code = %d, want 1", got.ExitCode)
+	}
+}
+
+func TestDispatchSubagent_NilResultFallback(t *testing.T) {
+	run := func(context.Context) (*extensions.SubagentResult, error) {
+		return nil, errors.New("boom")
+	}
+
+	handle, _, err := dispatchSubagent(context.Background(), run, extensions.SubagentConfig{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := handle.Wait()
+	if got.ExitCode != 1 {
+		t.Errorf("nil-result fallback exit code = %d, want 1", got.ExitCode)
+	}
+}
+
+func TestNewSubagentID(t *testing.T) {
+	a, b := newSubagentID(), newSubagentID()
+	if !strings.HasPrefix(a, "subagent-") {
+		t.Errorf("ID %q missing subagent- prefix", a)
+	}
+	if a == b {
+		t.Errorf("IDs should be unique, both were %q", a)
+	}
+}

--- a/internal/extensions/api.go
+++ b/internal/extensions/api.go
@@ -703,13 +703,19 @@ type Context struct {
 	//   })
 	ReloadExtensions func() error
 
-	// SpawnSubagent spawns a child Kit instance to perform a task autonomously.
-	// The subagent runs as a separate subprocess with full tool access but
-	// isolated session and extensions (--no-session --no-extensions).
+	// SpawnSubagent spawns an in-process child Kit instance to perform a
+	// task autonomously. The subagent gets its own session, event bus, and
+	// agent loop but shares the parent's provider configuration (API keys,
+	// model settings). It inherits the parent's active tools minus the
+	// subagent tool (no recursion) and does not load extensions. The
+	// child's session is persisted by default so it can be inspected or
+	// replayed; set config.NoSession for ephemeral runs.
 	//
 	// When config.Blocking is true, blocks until completion and returns the
-	// result directly (handle is nil). When false, returns immediately with
-	// a handle for monitoring/cancellation.
+	// result directly (handle is nil). When false (default), the subagent
+	// runs in a background goroutine and SpawnSubagent returns immediately
+	// with a non-nil handle (result is nil); OnComplete and OnEvent fire
+	// asynchronously.
 	//
 	// Example — blocking call:
 	//
@@ -729,13 +735,13 @@ type Context struct {
 	//   handle, _, _ := ctx.SpawnSubagent(ext.SubagentConfig{
 	//       Prompt: "Write unit tests for UserService",
 	//       OnOutput: func(chunk string) {
-	//           // Live output streaming
+	//           // Live assistant text streaming
 	//       },
 	//       OnComplete: func(result ext.SubagentResult) {
 	//           ctx.SendMessage("Subagent finished:\n" + result.Response)
 	//       },
 	//   })
-	//   // handle.Kill() to cancel, handle.Wait() to block
+	//   // handle.Kill() to cancel, handle.Wait() to block, handle.Done() to select
 	SpawnSubagent func(SubagentConfig) (*SubagentHandle, *SubagentResult, error)
 
 	// -------------------------------------------------------------------------

--- a/internal/extensions/subagent.go
+++ b/internal/extensions/subagent.go
@@ -3,7 +3,6 @@ package extensions
 
 import (
 	"fmt"
-	"os"
 	"sync"
 	"time"
 )
@@ -27,8 +26,10 @@ type SubagentConfig struct {
 	// Timeout limits execution time. Zero means 5 minute default.
 	Timeout time.Duration
 
-	// OnOutput streams stderr output chunks as the subagent runs.
-	// Called from a goroutine; must be safe for concurrent use.
+	// OnOutput streams the subagent's assistant text chunks as it runs.
+	// It is a convenience alternative to OnEvent for callers that only
+	// care about text output. May be called from a goroutine; must be
+	// safe for concurrent use.
 	OnOutput func(chunk string)
 
 	// OnEvent receives real-time events from the subagent's execution:
@@ -37,12 +38,16 @@ type SubagentConfig struct {
 	OnEvent func(SubagentEvent)
 
 	// OnComplete is called when the subagent finishes (success or error).
-	// Called from a goroutine; must be safe for concurrent use.
+	// For background spawns (Blocking false) it is called from the
+	// subagent's goroutine; must be safe for concurrent use. For blocking
+	// spawns it is called before SpawnSubagent returns.
 	OnComplete func(result SubagentResult)
 
 	// Blocking, when true, makes SpawnSubagent wait for completion and
-	// return the result directly. When false (default), spawns in background
-	// and returns immediately with a handle.
+	// return the result directly (handle is nil). When false (default),
+	// the subagent runs in a background goroutine and SpawnSubagent
+	// returns immediately with a non-nil handle for monitoring and
+	// cancellation (result is nil; use OnComplete or handle.Wait()).
 	Blocking bool
 
 	// NoSession, when true, runs the subagent without persisting a session
@@ -92,7 +97,9 @@ type SubagentResult struct {
 	// Error is set if the subagent failed (nil on success).
 	Error error
 
-	// ExitCode is the subprocess exit code (0 = success).
+	// ExitCode is 0 on success and 1 on failure. The subagent runs
+	// in-process (not as a subprocess); this field mirrors Error for
+	// callers that prefer a numeric status.
 	ExitCode int
 
 	// Elapsed is the total execution time.
@@ -113,24 +120,51 @@ type SubagentUsage struct {
 	OutputTokens int64
 }
 
-// SubagentHandle provides control over a running subagent.
+// SubagentHandle provides control over a background (non-blocking)
+// subagent. The subagent runs in-process in a goroutine; the handle
+// exposes cancellation and completion signalling.
 type SubagentHandle struct {
 	// ID is a unique identifier for this subagent instance.
 	ID string
 
-	proc   *os.Process
-	done   chan struct{}
-	result *SubagentResult
-	mu     sync.Mutex
+	cancel   func()
+	done     chan struct{}
+	result   *SubagentResult
+	complete sync.Once
+	mu       sync.Mutex
 }
 
-// Kill terminates the subagent process.
+// NewSubagentHandle creates a handle for a background subagent run.
+// cancel, when non-nil, is invoked by Kill to abort the run. The host
+// (extension bridge) must call Complete exactly once when the run
+// finishes. Extensions receive handles from SpawnSubagent and should
+// not construct their own.
+func NewSubagentHandle(id string, cancel func()) *SubagentHandle {
+	return &SubagentHandle{
+		ID:     id,
+		cancel: cancel,
+		done:   make(chan struct{}),
+	}
+}
+
+// Complete records the final result and signals Done/Wait. Called by
+// the host when the background run finishes; subsequent calls are
+// no-ops. Extensions should not call this.
+func (h *SubagentHandle) Complete(result SubagentResult) {
+	h.complete.Do(func() {
+		h.mu.Lock()
+		h.result = &result
+		h.mu.Unlock()
+		close(h.done)
+	})
+}
+
+// Kill cancels the running subagent. The run terminates with a context
+// cancellation error, delivered via OnComplete/Wait as usual. Calling
+// Kill after completion is a no-op.
 func (h *SubagentHandle) Kill() error {
-	h.mu.Lock()
-	proc := h.proc
-	h.mu.Unlock()
-	if proc != nil {
-		return proc.Kill()
+	if h.cancel != nil {
+		h.cancel()
 	}
 	return nil
 }
@@ -143,7 +177,7 @@ func (h *SubagentHandle) Wait() SubagentResult {
 	if h.result != nil {
 		return *h.result
 	}
-	return SubagentResult{Error: fmt.Errorf("subagent completed without result")}
+	return SubagentResult{Error: fmt.Errorf("subagent completed without result"), ExitCode: 1}
 }
 
 // Done returns a channel that closes when the subagent completes.

--- a/internal/extensions/subagent_test.go
+++ b/internal/extensions/subagent_test.go
@@ -1,0 +1,59 @@
+package extensions
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSubagentHandle_CompleteWaitDone(t *testing.T) {
+	h := NewSubagentHandle("subagent-test", nil)
+
+	select {
+	case <-h.Done():
+		t.Fatal("Done() closed before Complete()")
+	default:
+	}
+
+	h.Complete(SubagentResult{Response: "ok"})
+
+	select {
+	case <-h.Done():
+	case <-time.After(time.Second):
+		t.Fatal("Done() not closed after Complete()")
+	}
+
+	if got := h.Wait(); got.Response != "ok" {
+		t.Errorf("Wait() response = %q, want %q", got.Response, "ok")
+	}
+}
+
+func TestSubagentHandle_CompleteIsIdempotent(t *testing.T) {
+	h := NewSubagentHandle("subagent-test", nil)
+	h.Complete(SubagentResult{Response: "first"})
+	// A second Complete must not panic (double close) and must not
+	// overwrite the recorded result.
+	h.Complete(SubagentResult{Response: "second"})
+
+	if got := h.Wait(); got.Response != "first" {
+		t.Errorf("Wait() response = %q, want %q", got.Response, "first")
+	}
+}
+
+func TestSubagentHandle_KillInvokesCancel(t *testing.T) {
+	cancelled := false
+	h := NewSubagentHandle("subagent-test", func() { cancelled = true })
+
+	if err := h.Kill(); err != nil {
+		t.Fatalf("Kill() error: %v", err)
+	}
+	if !cancelled {
+		t.Error("Kill() did not invoke cancel func")
+	}
+}
+
+func TestSubagentHandle_KillWithoutCancelIsNoop(t *testing.T) {
+	h := NewSubagentHandle("subagent-test", nil)
+	if err := h.Kill(); err != nil {
+		t.Errorf("Kill() with nil cancel should be a no-op, got error: %v", err)
+	}
+}

--- a/pkg/extensions/test/README.md
+++ b/pkg/extensions/test/README.md
@@ -321,7 +321,7 @@ The test harness has these limitations:
 
 1. **No TUI rendering** - Widgets are recorded but not rendered visually
 2. **Prompts return configured values** - You must pre-configure prompt results in tests
-3. **Subagents don't spawn real processes** - SpawnSubagent returns nil/empty results
+3. **Subagents don't run** - SpawnSubagent returns nil handle/result (no child Kit instance is started)
 4. **LLM completions are mocked** - Complete returns empty responses
 5. **Some context methods are no-ops** - Exit, SetActiveTools, etc. don't have side effects
 

--- a/skills/kit-extensions/SKILL.md
+++ b/skills/kit-extensions/SKILL.md
@@ -929,7 +929,7 @@ api.RegisterCommand(ext.CommandDef{
 
 ### Pattern: Spawning Kit as a Sub-Agent
 
-Use `ctx.SpawnSubagent` to spawn an isolated child Kit instance. The subagent runs as a subprocess with `--json --no-extensions` flags, ensuring isolation.
+Use `ctx.SpawnSubagent` to spawn an in-process child Kit instance. The subagent gets its own session, event bus, and agent loop, inherits the parent's active tools minus the `subagent` tool (no recursion), and does not load extensions. Its session is persisted by default (set `NoSession: true` for ephemeral runs).
 
 **Blocking mode** — waits for completion:
 
@@ -960,7 +960,7 @@ ctx.PrintInfo("Result:\n" + result.Response)
 handle, _, err := ctx.SpawnSubagent(ext.SubagentConfig{
     Prompt: "Write unit tests for UserService",
     OnOutput: func(chunk string) {
-        // Live stderr streaming (progress, tool calls, etc.)
+        // Live assistant text chunks
     },
     OnEvent: func(event ext.SubagentEvent) {
         // Real-time events: "text", "reasoning", "tool_call",
@@ -985,10 +985,10 @@ handle, _, err := ctx.SpawnSubagent(ext.SubagentConfig{
 | `Model` | string | Override model ("provider/model"), empty = parent's |
 | `SystemPrompt` | string | Custom system prompt, empty = default |
 | `Timeout` | time.Duration | Execution limit, 0 = 5 minutes |
-| `Blocking` | bool | Wait for completion vs return handle |
+| `Blocking` | bool | true = wait and return result; false (default) = background goroutine + handle |
 | `NoSession` | bool | Don't persist subagent session file |
 | `ParentSessionID` | string | Link to parent session (optional) |
-| `OnOutput` | func(string) | Stderr streaming callback |
+| `OnOutput` | func(string) | Live assistant text chunk callback |
 | `OnEvent` | func(SubagentEvent) | Real-time event callback |
 | `OnComplete` | func(SubagentResult) | Completion callback |
 
@@ -998,7 +998,7 @@ handle, _, err := ctx.SpawnSubagent(ext.SubagentConfig{
 |-------|------|-------------|
 | `Response` | string | Final text response |
 | `Error` | error | Non-nil on failure |
-| `ExitCode` | int | Process exit code (0 = success) |
+| `ExitCode` | int | 0 on success, 1 on failure (runs in-process, mirrors Error) |
 | `Elapsed` | time.Duration | Total execution time |
 | `Usage` | *SubagentUsage | Token usage (InputTokens, OutputTokens) |
 | `SessionID` | string | Subagent's session ID (if persisted) |

--- a/www/pages/advanced/subagents.md
+++ b/www/pages/advanced/subagents.md
@@ -52,12 +52,32 @@ Subagents run as separate in-process Kit instances with full tool access (except
 Extensions can spawn subagents programmatically:
 
 ```go
-result := ctx.SpawnSubagent(ext.SubagentConfig{
-    Task:         "Review this code for security issues",
+_, result, err := ctx.SpawnSubagent(ext.SubagentConfig{
+    Prompt:       "Review this code for security issues",
     Model:        "anthropic/claude-sonnet-latest",
     SystemPrompt: "You are a security auditor.",
+    Blocking:     true,
 })
 ```
+
+With `Blocking: false` (the default), the subagent runs in a background goroutine and `SpawnSubagent` returns immediately with a non-nil handle (result is nil); use `OnComplete`/`OnEvent` callbacks or the handle to observe the run:
+
+```go
+handle, _, err := ctx.SpawnSubagent(ext.SubagentConfig{
+    Prompt: "Write unit tests for UserService",
+    OnOutput: func(chunk string) {
+        // Live assistant text chunks (e.g. update a widget)
+    },
+    OnComplete: func(result ext.SubagentResult) {
+        ctx.SendMessage("Subagent finished:\n" + result.Response)
+    },
+})
+// handle.Kill()   — cancel the running subagent
+// handle.Wait()   — block until completion, returns SubagentResult
+// <-handle.Done() — channel that closes on completion
+```
+
+Background subagents run in-process (no subprocess): they get their own session, event bus, and agent loop, inherit the parent's active tools minus the `subagent` tool, and do not load extensions. Sessions are persisted by default; set `NoSession: true` for ephemeral runs.
 
 ### Monitoring subagents from extensions
 

--- a/www/pages/extensions/capabilities.md
+++ b/www/pages/extensions/capabilities.md
@@ -275,12 +275,15 @@ api.RegisterOption(ext.OptionDef{
 Spawn in-process child Kit instances:
 
 ```go
-result := ctx.SpawnSubagent(ext.SubagentConfig{
-    Task:         "Analyze the test files and summarize coverage",
+_, result, err := ctx.SpawnSubagent(ext.SubagentConfig{
+    Prompt:       "Analyze the test files and summarize coverage",
     Model:        "anthropic/claude-haiku-latest",
     SystemPrompt: "You are a test analysis expert.",
+    Blocking:     true,
 })
 ```
+
+With `Blocking: false` (the default), the subagent runs in a background goroutine and `SpawnSubagent` returns immediately with a non-nil handle (`handle.Wait()`, `handle.Done()`, `handle.Kill()`); use `OnComplete`/`OnEvent` callbacks for results. See [Subagents](/advanced/subagents) for a full background-mode example.
 
 ### Monitoring subagents spawned by the main agent
 

--- a/www/pages/extensions/testing.md
+++ b/www/pages/extensions/testing.md
@@ -448,7 +448,7 @@ The test harness has these intentional limitations:
 
 - **No TUI rendering** — Widgets are recorded but not rendered visually
 - **Prompts return configured values** — Pre-configure prompt results in tests
-- **Subagents don't spawn real processes** — `SpawnSubagent()` returns nil/empty results
+- **Subagents don't run** — `SpawnSubagent()` returns nil handle/result (no child Kit instance is started)
 - **LLM completions are mocked** — `Complete()` returns empty responses
 - **Some context methods are no-ops** — `Exit()`, `SetActiveTools()`, etc. don't have side effects
 


### PR DESCRIPTION
## Description

The extension-facing subagent API was a trap for extension authors: `SpawnSubagent` always ran synchronously and returned a `nil` handle regardless of `Blocking: false`, `SubagentHandle` carried dead subprocess fields (`proc *os.Process`) from a design that was never wired up, the docs in `api.go` claimed subprocess isolation (`--no-session --no-extensions`) that doesn't exist, and the shipped example `subagent-test.go` dereferenced the nil handle.

This PR implements **Option A** from the issue — true non-blocking spawning. With `Blocking: false` (the default), `SpawnSubagent` now runs the subagent in a background goroutine and returns immediately with a populated `SubagentHandle`; `OnComplete`/`OnEvent` fire asynchronously. Blocking mode is unchanged, and now also invokes `OnComplete` before returning. The previously-dead `OnOutput` callback is wired to assistant text chunks, and `ExitCode` is set (0/1) on results.

**Before / after:**

```go
// Before: blocked until completion, handle == nil → example panicked on handle.ID
// After: returns immediately with a usable handle
handle, _, err := ctx.SpawnSubagent(ext.SubagentConfig{
    Prompt:     "Write unit tests for UserService",
    OnComplete: func(r ext.SubagentResult) { /* async */ },
})
// handle.Kill() — cancel · handle.Wait() — block for result · <-handle.Done() — select
```

Docs, types, bridge behavior, the shipped example, and the docs site now all agree on the actual execution model: an in-process child Kit with its own session/event bus/agent loop, inheriting the parent's tools minus `subagent`, no extensions loaded, session persisted by default.

Fixes #86

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] Code follows project style guidelines (`go fmt`, `go vet`, `golangci-lint` — 0 issues)
- [x] Self-reviewed the diff
- [x] Tests added (regression tests for the dispatch contract and handle semantics)
- [x] All tests pass (`go test -race ./...`)
- [x] Documentation updated (godoc, SKILL.md, www docs site — `tome build` passes)

## Additional Information

**Modified:**

- `internal/extbridge/extbridge.go` — `Blocking` dispatch (`dispatchSubagent`, testable without a real Kit), background goroutine + handle construction, `OnOutput` wiring, `ExitCode`
- `internal/extensions/subagent.go` — removed dead `proc *os.Process`; `Kill` cancels the run context; added `NewSubagentHandle`/`Complete` (idempotent via `sync.Once`); corrected field docs
- `internal/extensions/api.go` — `SpawnSubagent` godoc now describes the real in-process contract
- `examples/extensions/subagent-test.go` — `/subbg` nil-guards the handle and no longer prints raw chunks to stdout (corrupted the TUI)
- `skills/kit-extensions/SKILL.md`, `www/pages/{advanced/subagents,extensions/{capabilities,testing}}.md`, `pkg/extensions/test/README.md` — aligned with actual behavior

**Added:**

- `internal/extbridge/extbridge_test.go` — non-blocking returns non-nil handle immediately (the #86 failure), Wait/Done delivery, Kill cancellation, async OnComplete, nil-result fallback
- `internal/extensions/subagent_test.go` — handle Complete/Wait/Done, idempotent Complete (no double-close panic), Kill semantics

**Backward compatibility:** blocking callers (`Blocking: true`) see identical behavior plus `OnComplete` now firing as documented. Callers that relied on the undocumented always-synchronous behavior of `Blocking: false` should set `Blocking: true` or use `handle.Wait()`. The mock harness (`pkg/extensions/test`) is unchanged and its docs now state it returns a nil handle.

**Interactive verification (tmux):** `/subbg` returns immediately with a populated handle ID and delivers results asynchronously via `OnComplete`; `/subtest` (blocking) returns the result directly with token usage.

Related: #84 and #87 build on this same subagent machinery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subagents now run in-process with clear blocking vs background behavior, returning a handle for background runs and firing live completion callbacks.
  * Background subagents have independent runtime behavior (separate loop/event bus) while inheriting the parent’s active tools.
* **Bug Fixes**
  * Streamed output is now tracked as text chunks, and completion messaging reflects chunk counts.
  * Improved handling for missing handles and normalized failure outcomes (including `ExitCode: 1` on canceled/empty completions).
* **Documentation**
  * Updated Subagent API docs, examples, and test-harness limitations to match the new calling pattern and runtime behavior.
* **Tests**
  * Added regression/unit coverage for blocking/background dispatch, cancellation, completion semantics, and ID generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->