### PR TITLE
feat(ui): display subagent name in progress bar

### DIFF
--- a/internal/ui/stream.go
+++ b/internal/ui/stream.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -427,7 +428,11 @@ func (s *StreamComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if _, exists := s.activeTools[toolID]; !exists {
 				s.activeToolOrder = append(s.activeToolOrder, toolID)
 			}
-			s.activeTools[toolID] = formatToolExecutionMessage(msg.ToolName)
+			agentName := ""
+			if msg.ToolName == "subagent" {
+				agentName = extractAgentNameFromArgs(msg.ToolArgs)
+			}
+			s.activeTools[toolID] = formatToolExecutionMessage(msg.ToolName, agentName)
 			s.spinnerFrame = 0
 			if !s.spinning {
 				s.phase = streamPhaseActive
@@ -585,8 +590,25 @@ func removeToolID(ids []string, id string) []string {
 	return ids
 }
 
+// extractAgentNameFromArgs parses the agent field from subagent ToolArgs JSON.
+// Returns empty string if the agent field is not found or JSON parsing fails.
+func extractAgentNameFromArgs(toolArgs string) string {
+	var args map[string]any
+	if err := json.Unmarshal([]byte(toolArgs), &args); err != nil {
+		return ""
+	}
+	if agent, ok := args["agent"].(string); ok && agent != "" {
+		return agent
+	}
+	return ""
+}
+
 // formatToolExecutionMessage creates a descriptive spinner message for tool execution.
-func formatToolExecutionMessage(toolName string) string {
+// For subagents, includes the agent type in parentheses (e.g., "subagent (explore)").
+func formatToolExecutionMessage(toolName, agentName string) string {
+	if toolName == "subagent" && agentName != "" {
+		return fmt.Sprintf("subagent (%s)", agentName)
+	}
 	return toolName
 }
 

--- a/internal/ui/stream.go
+++ b/internal/ui/stream.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -590,15 +591,62 @@ func removeToolID(ids []string, id string) []string {
 	return ids
 }
 
+// sanitizeAgentName validates and sanitizes the agent name for safe display in the spinner.
+// Returns the sanitized agent name or empty string if invalid.
+// Enforces:
+//   - Maximum length of 50 characters
+//   - No embedded newlines or control characters
+//   - No ANSI escape sequences
+//   - Only alphanumeric, hyphens, underscores, and dots
+func sanitizeAgentName(agent string) string {
+	if agent == "" {
+		return ""
+	}
+
+	const maxLen = 50
+
+	// Enforce length limit
+	if len(agent) > maxLen {
+		return ""
+	}
+
+	// Reject any embedded newlines or carriage returns
+	if strings.ContainsAny(agent, "\n\r") {
+		return ""
+	}
+
+	// Reject ANSI escape sequences (ESC followed by any character)
+	if strings.Contains(agent, "\x1b") {
+		return ""
+	}
+
+	// Reject control characters (0x00-0x1F, 0x7F)
+	for _, r := range agent {
+		if r < 0x20 || r == 0x7F {
+			return ""
+		}
+	}
+
+	// Allow only alphanumeric, hyphens, underscores, and dots
+	// This permits names like "explore", "general", "custom-agent", "agent_v2", etc.
+	validPattern := regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
+	if !validPattern.MatchString(agent) {
+		return ""
+	}
+
+	return agent
+}
+
 // extractAgentNameFromArgs parses the agent field from subagent ToolArgs JSON.
-// Returns empty string if the agent field is not found or JSON parsing fails.
+// Returns empty string if the agent field is not found, JSON parsing fails, or the agent name is invalid.
+// The returned agent name is sanitized for safe spinner rendering.
 func extractAgentNameFromArgs(toolArgs string) string {
 	var args map[string]any
 	if err := json.Unmarshal([]byte(toolArgs), &args); err != nil {
 		return ""
 	}
-	if agent, ok := args["agent"].(string); ok && agent != "" {
-		return agent
+	if agent, ok := args["agent"].(string); ok {
+		return sanitizeAgentName(agent)
 	}
 	return ""
 }

--- a/internal/ui/stream.go
+++ b/internal/ui/stream.go
@@ -591,13 +591,14 @@ func removeToolID(ids []string, id string) []string {
 	return ids
 }
 
-// sanitizeAgentName validates and sanitizes the agent name for safe display in the spinner.
+// agentNamePattern validates agent names: only alphanumeric, hyphens, underscores, and dots.
+// Compiled once at package init time for reuse across function calls.
+var agentNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
+
+// sanitizeAgentName validates the agent name for safe display in the spinner.
 // Returns the sanitized agent name or empty string if invalid.
-// Enforces:
-//   - Maximum length of 50 characters
-//   - No embedded newlines or control characters
-//   - No ANSI escape sequences
-//   - Only alphanumeric, hyphens, underscores, and dots
+// Enforces: maximum 50 characters and only alphanumeric, hyphens, underscores, and dots.
+// The regex pattern inherently rejects all control characters, newlines, and ANSI escapes.
 func sanitizeAgentName(agent string) string {
 	if agent == "" {
 		return ""
@@ -605,32 +606,14 @@ func sanitizeAgentName(agent string) string {
 
 	const maxLen = 50
 
-	// Enforce length limit
+	// Enforce length limit (efficient early return)
 	if len(agent) > maxLen {
 		return ""
 	}
 
-	// Reject any embedded newlines or carriage returns
-	if strings.ContainsAny(agent, "\n\r") {
-		return ""
-	}
-
-	// Reject ANSI escape sequences (ESC followed by any character)
-	if strings.Contains(agent, "\x1b") {
-		return ""
-	}
-
-	// Reject control characters (0x00-0x1F, 0x7F)
-	for _, r := range agent {
-		if r < 0x20 || r == 0x7F {
-			return ""
-		}
-	}
-
-	// Allow only alphanumeric, hyphens, underscores, and dots
-	// This permits names like "explore", "general", "custom-agent", "agent_v2", etc.
-	validPattern := regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
-	if !validPattern.MatchString(agent) {
+	// Validate character set: only alphanumeric, hyphens, underscores, and dots.
+	// The regex inherently rejects control characters, newlines, and ANSI escapes.
+	if !agentNamePattern.MatchString(agent) {
 		return ""
 	}
 


### PR DESCRIPTION
Add explicit subagent agent name to the real-time spinner display in the StreamComponent. When a subagent tool starts executing, the spinner now shows the agent type (derived from the 'agent' parameter in ToolArgs JSON) in the format 'subagent (explore)', 'subagent (general)', etc.

## Changes:

- Add encoding/json import for parsing ToolArgs
- Add extractAgentNameFromArgs() helper to safely parse the agent field from JSON-encoded ToolArgs, returning empty string on parse failure
- Update formatToolExecutionMessage() to accept optional agentName parameter and format subagents as 'subagent (agentName)' when agent is specified
- Modify ToolExecutionEvent handler in StreamComponent.Update() to extract agent name from ToolArgs when tool is 'subagent' and pass it through

This improves user visibility into which subagent type is running without requiring additional event fields or architectural changes. Falls back gracefully to 'subagent' if agent field is missing or JSON parsing fails.

No functional changes to non-subagent tools or existing behavior. All existing tests pass.

## Visual Impact

Before:
▪ ▪ ▪ ▪ ▪ ▪ ▪ ▪  subagent
After (with agent type):
▪ ▪ ▪ ▪ ▪ ▪ ▪ ▪  subagent (explore)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Spinner messages now include the `subagent` subtype when it’s provided, parsed, and safe to display.
  * If the subtype is missing or can’t be interpreted safely, spinner labels automatically fall back to the general tool name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->