### PR TITLE
refactor(ui): minimal UI pass — activity row, unified gutter, theme-aware syntax

### DIFF
--- a/internal/extensions/api.go
+++ b/internal/extensions/api.go
@@ -1692,7 +1692,10 @@ type UIVisibility struct {
 	HideStartupMessage bool // Hide the "Model loaded..." startup block
 	HideStatusBar      bool // Hide the "provider · model  Tokens: ..." line
 	HideSeparator      bool // Hide the "────────" divider between stream and input
-	HideInputHint      bool // Hide the "enter submit · ctrl+j..." hint below input
+	// HideInputHint is retained for compatibility and has no effect. The
+	// submit hint is no longer a separate line below the composer; it lives
+	// in the placeholder and disappears as soon as the user types.
+	HideInputHint bool
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/ui/activity.go
+++ b/internal/ui/activity.go
@@ -248,6 +248,11 @@ const activityHintGap = 3
 // degrading from a full hint to a compact one as width allows. The caller
 // decides whether there is room to show it at all.
 func (m *AppModel) activityHint() string {
+	// A pending confirmation displaces the ordinary hint: it is the only thing
+	// the next keystroke can do, so offering alternatives would be misleading.
+	if m.ctrlCPressedOnce {
+		return "ctrl+c again to quit"
+	}
 	if m.canceling {
 		return "esc again to cancel"
 	}

--- a/internal/ui/activity.go
+++ b/internal/ui/activity.go
@@ -1,0 +1,296 @@
+package ui
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/mark3labs/kit/internal/ui/style"
+)
+
+// The activity row is the single live-status line rendered directly above the
+// composer. It answers three questions at a glance: what is the agent doing
+// right now, how long has it been doing it, and how do I stop it.
+//
+// Two rules keep it readable:
+//
+//  1. The activity row is the only place present-tense work appears. The
+//     transcript records finished work in the past tense, so scrollback never
+//     looks as though it is still running.
+//  2. Ambient facts (model, token count, cost, working directory) belong in
+//     the status bar, not here. They must never compete with live activity for
+//     horizontal space.
+
+// activityMaxTarget caps the length of the target fragment in an activity
+// phrase (the command, path or pattern) so a long argument cannot push the
+// elapsed time and interrupt hint off the row.
+const activityMaxTarget = 56
+
+// activityVerb returns a present-tense phrase describing an in-flight tool
+// call, e.g. "Running go test ./..." or "Reading internal/ui/model.go".
+// toolArgs is the raw JSON argument payload; malformed JSON degrades to the
+// bare tool name rather than erroring.
+func activityVerb(toolName, toolArgs string) string {
+	args := parseToolArgs(toolArgs)
+
+	// verb is the present-tense action; target is the thing being acted on.
+	// Keeping them separate lets a missing target degrade to a bare verb
+	// instead of leaving a dangling "Reading " with nothing after it.
+	var verb, target string
+
+	switch strings.ToLower(toolName) {
+	case "bash":
+		verb, target = "Running", shortenTarget(oneLine(argString(args, "command")))
+	case "read":
+		verb, target = "Reading", shortenActivityPath(argString(args, "path"))
+	case "write":
+		verb, target = "Writing", shortenActivityPath(argString(args, "path"))
+	case "edit":
+		verb, target = "Editing", shortenActivityPath(argString(args, "path"))
+	case "grep":
+		verb, target = "Searching", shortenTarget(oneLine(argString(args, "pattern")))
+	case "find":
+		verb, target = "Matching", shortenTarget(oneLine(argString(args, "pattern")))
+	case "ls":
+		verb, target = "Listing", shortenActivityPath(argString(args, "path"))
+	case "fetch":
+		verb, target = "Fetching", shortenTarget(oneLine(argString(args, "url")))
+	case "subagent":
+		if agent := argString(args, "agent"); agent != "" {
+			return "Delegating to " + agent
+		}
+		verb, target = "Delegating", shortenTarget(oneLine(argString(args, "task")))
+	case "todo":
+		return "Updating todos"
+	default:
+		// Unknown tool: title-case the name and attach the first string
+		// argument if one is available, so third-party tools still read as
+		// activity rather than as a bare identifier.
+		verb, target = toolDisplayName(toolName), shortenTarget(oneLine(firstStringArg(args)))
+	}
+
+	if target == "" {
+		// No usable argument (absent, empty or malformed JSON). Fall back to
+		// the tool's display name so the row still says something true.
+		return toolDisplayName(toolName)
+	}
+	return verb + " " + target
+}
+
+// parseToolArgs decodes a raw JSON tool-argument payload. A nil map is
+// returned for empty or malformed input; callers treat that as "no arguments"
+// rather than as an error, because the activity row must never fail to render.
+func parseToolArgs(toolArgs string) map[string]any {
+	if strings.TrimSpace(toolArgs) == "" {
+		return nil
+	}
+	var args map[string]any
+	if err := json.Unmarshal([]byte(toolArgs), &args); err != nil {
+		return nil
+	}
+	return args
+}
+
+// argString returns the named argument as a string, or "" when absent or not
+// a string.
+func argString(args map[string]any, key string) string {
+	if args == nil {
+		return ""
+	}
+	if v, ok := args[key].(string); ok {
+		return strings.TrimSpace(v)
+	}
+	return ""
+}
+
+// firstStringArg returns any string-valued argument, preferring conventional
+// target keys before falling back to an arbitrary one.
+func firstStringArg(args map[string]any) string {
+	for _, key := range []string{"command", "path", "file_path", "pattern", "query", "url", "task"} {
+		if v := argString(args, key); v != "" {
+			return v
+		}
+	}
+	for _, v := range args {
+		if s, ok := v.(string); ok && strings.TrimSpace(s) != "" {
+			return strings.TrimSpace(s)
+		}
+	}
+	return ""
+}
+
+// oneLine collapses a multi-line string into a single line so it cannot break
+// the activity row's layout.
+func oneLine(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\t", " ")
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// shortenTarget truncates a target fragment to activityMaxTarget columns,
+// marking elision with a single-column ellipsis.
+func shortenTarget(s string) string {
+	return truncateLine(s, activityMaxTarget)
+}
+
+// shortenActivityPath keeps a path readable inside the activity row by dropping
+// leading directories once the full path exceeds the target budget. The last
+// two segments are retained because they carry the most identifying detail.
+func shortenActivityPath(p string) string {
+	if p == "" {
+		return ""
+	}
+	if len([]rune(p)) <= activityMaxTarget {
+		return p
+	}
+	dir, file := filepath.Split(p)
+	parent := filepath.Base(strings.TrimSuffix(dir, string(filepath.Separator)))
+	if parent == "." || parent == string(filepath.Separator) || parent == "" {
+		return "…/" + truncateLine(file, activityMaxTarget-2)
+	}
+	return "…/" + truncateLine(parent+string(filepath.Separator)+file, activityMaxTarget-2)
+}
+
+// formatElapsed renders a duration for the activity row. Sub-second values
+// collapse to "<1s" so the row does not flicker through fractional updates.
+func formatElapsed(d time.Duration) string {
+	switch {
+	case d <= 0:
+		return ""
+	case d < time.Second:
+		return "<1s"
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	default:
+		return fmt.Sprintf("%dm%02ds", int(d/time.Minute), int(d/time.Second)%60)
+	}
+}
+
+// renderActivityRow draws the live status line shown above the composer while
+// the agent is working. It returns "" when the agent is idle, so the row costs
+// no vertical space at rest.
+//
+// Layout, widest to narrowest:
+//
+//	● Running go test ./... · 12s                          esc interrupt
+//	● Running go test ./... · 12s                                    esc
+//	● Running go test ./... · 12s
+func (m *AppModel) renderActivityRow() string {
+	if m.state != stateWorking || m.stream == nil {
+		return ""
+	}
+
+	theme := style.GetTheme()
+
+	// The pulsing dot doubles as the liveness indicator: it is always present
+	// while working, so a slow provider reads as active rather than stalled.
+	dot := m.stream.ActivityDot()
+	phrase := m.stream.ActivityPhrase()
+
+	var elapsed string
+	if !m.turnStartedAt.IsZero() {
+		elapsed = formatElapsed(time.Since(m.turnStartedAt))
+	}
+
+	dim := lipgloss.NewStyle().Foreground(theme.VeryMuted)
+	// The phrase is bold with no explicit foreground so it inherits the
+	// terminal's own text color and stays legible under any color scheme.
+	label := lipgloss.NewStyle().Bold(true)
+
+	prefix := " " + dot + " "
+	suffix := ""
+	if elapsed != "" {
+		suffix = dim.Render(" · " + elapsed)
+	}
+
+	hint := m.activityHint()
+	hintWidth := 0
+	if hint != "" {
+		hintWidth = lipgloss.Width(hint) + activityHintGap
+	}
+
+	// Reserve room for the phrase before spending any on the hint, so the
+	// most important text is the last thing to be truncated.
+	phraseBudget := m.width - lipgloss.Width(prefix) - lipgloss.Width(suffix) - hintWidth
+	if phraseBudget < activityMinPhrase && hint != "" {
+		hint = ""
+		phraseBudget = m.width - lipgloss.Width(prefix) - lipgloss.Width(suffix)
+	}
+	if phraseBudget < 1 {
+		phraseBudget = 1
+	}
+
+	left := prefix + label.Render(truncateLine(phrase, phraseBudget)) + suffix
+	if hint == "" {
+		return left
+	}
+
+	gap := max(m.width-lipgloss.Width(left)-lipgloss.Width(hint), activityHintGap)
+	return left + strings.Repeat(" ", gap) + dim.Render(hint)
+}
+
+// activityMinPhrase is the smallest phrase width worth preserving. Below this
+// the interrupt hint is dropped so the activity text stays meaningful.
+const activityMinPhrase = 24
+
+// activityHintGap is the minimum blank gutter between the activity text and
+// the right-aligned key hint.
+const activityHintGap = 3
+
+// activityHint returns the right-aligned key hint for the current state,
+// degrading from a full hint to a compact one as width allows. The caller
+// decides whether there is room to show it at all.
+func (m *AppModel) activityHint() string {
+	if m.canceling {
+		return "esc again to cancel"
+	}
+	full := "↵ queue · esc interrupt"
+	compact := "esc interrupt"
+
+	available := m.width - activityMinPhrase - activityHintGap
+	if lipgloss.Width(full) <= available {
+		return full
+	}
+	if lipgloss.Width(compact) <= available {
+		return compact
+	}
+	return ""
+}
+
+// detectGitBranch returns the current branch name for the repository
+// containing dir, or "" when dir is not inside a git worktree.
+//
+// This reads .git directly rather than shelling out to git: the status bar is
+// built during startup and a subprocess spawn is both slower and a needless
+// dependency on git being installed. Detached HEADs report the short commit
+// hash, matching what a user would see in their prompt.
+func detectGitBranch(dir string) string {
+	if dir == "" {
+		return ""
+	}
+	for {
+		head, err := os.ReadFile(filepath.Join(dir, ".git", "HEAD"))
+		if err == nil {
+			ref := strings.TrimSpace(string(head))
+			if branch, ok := strings.CutPrefix(ref, "ref: refs/heads/"); ok {
+				return branch
+			}
+			// Detached HEAD: HEAD holds a raw commit hash.
+			if len(ref) >= 7 {
+				return ref[:7]
+			}
+			return ""
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}

--- a/internal/ui/activity.go
+++ b/internal/ui/activity.go
@@ -371,3 +371,25 @@ func pluralize(n int, noun string) string {
 	}
 	return fmt.Sprintf("%d %ss", n, noun)
 }
+
+// syncInputHeight marks the layout dirty when the composer's rendered height
+// has changed since it was last measured.
+//
+// The composer grows and shrinks with its content, so a keystroke that adds or
+// removes a wrapped line changes how much room is left for the transcript.
+// Without this the transcript keeps its old height and the joined view either
+// overflows the terminal (clipping the status bar) or leaves a gap. Layout is
+// not recomputed here — that happens once per frame in View() — this only
+// records that it needs to be.
+func (m *AppModel) syncInputHeight() {
+	if m.input == nil || m.layoutDirty {
+		return
+	}
+	rendered := m.renderInput()
+	if rendered == "" {
+		return
+	}
+	if lipgloss.Height(rendered) != m.lastInputHeight {
+		m.layoutDirty = true
+	}
+}

--- a/internal/ui/activity.go
+++ b/internal/ui/activity.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"encoding/json"
 	"fmt"
+	"image/color"
 	"os"
 	"path/filepath"
 	"strings"
@@ -293,4 +294,80 @@ func detectGitBranch(dir string) string {
 		}
 		dir = parent
 	}
+}
+
+// turnOutcome describes how an agent turn ended, which decides the receipt's
+// glyph and label.
+type turnOutcome int
+
+const (
+	turnDone turnOutcome = iota
+	turnCancelled
+	turnFailed
+)
+
+// printTurnReceipt appends a one-line summary of the turn that just ended:
+//
+//	✓ Done · 3 tools · 12s
+//
+// This is the only place a green check appears. Individual tool calls are
+// marked with a dim ·, so the check retains its meaning as "the thing you
+// asked for is finished" rather than "another step happened".
+//
+// The receipt is suppressed for turns that did no measurable work — a bare
+// text answer already ends visibly, and a receipt under every reply would be
+// noise.
+func (m *AppModel) printTurnReceipt(outcome turnOutcome) {
+	elapsed := time.Duration(0)
+	if !m.turnStartedAt.IsZero() {
+		elapsed = time.Since(m.turnStartedAt)
+	}
+
+	// Nothing worth reporting: no tools ran and the turn was quick.
+	if outcome == turnDone && m.turnToolCount == 0 && elapsed < turnReceiptMinDuration {
+		return
+	}
+
+	theme := style.GetTheme()
+
+	var glyph, label string
+	var glyphColor color.Color
+	switch outcome {
+	case turnCancelled:
+		glyph, label, glyphColor = "×", "Interrupted", theme.Warning
+	case turnFailed:
+		glyph, label, glyphColor = "×", "Failed", theme.Error
+	default:
+		glyph, label, glyphColor = "✓", "Done", theme.Success
+	}
+
+	dim := lipgloss.NewStyle().Foreground(theme.VeryMuted)
+	parts := []string{lipgloss.NewStyle().Bold(true).Render(label)}
+	if m.turnToolCount > 0 {
+		parts = append(parts, dim.Render(pluralize(m.turnToolCount, "tool")))
+	}
+	if e := formatElapsed(elapsed); e != "" {
+		parts = append(parts, dim.Render(e))
+	}
+
+	line := lipgloss.NewStyle().Foreground(glyphColor).Render(glyph) + " " +
+		strings.Join(parts, dim.Render(" · "))
+	line = styleMarginBottom1.Render(line)
+
+	m.messages = append(m.messages, NewStyledMessageItem(generateMessageID(), "system", line, line))
+	m.refreshContent()
+}
+
+// turnReceiptMinDuration is the shortest turn worth acknowledging when no
+// tools ran. Below this the answer arrived fast enough that a receipt would
+// say less than the answer itself.
+const turnReceiptMinDuration = 10 * time.Second
+
+// pluralize renders a count with its noun, adding a trailing "s" for any
+// count other than one.
+func pluralize(n int, noun string) string {
+	if n == 1 {
+		return fmt.Sprintf("%d %s", n, noun)
+	}
+	return fmt.Sprintf("%d %ss", n, noun)
 }

--- a/internal/ui/activity.go
+++ b/internal/ui/activity.go
@@ -6,6 +6,7 @@ import (
 	"image/color"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -117,8 +118,18 @@ func firstStringArg(args map[string]any) string {
 			return v
 		}
 	}
-	for _, v := range args {
-		if s, ok := v.(string); ok && strings.TrimSpace(s) != "" {
+	// The activity row re-renders on every spinner tick, so the fallback must
+	// be stable: Go randomizes map iteration order, and picking a different
+	// string each frame would make the row flicker between arguments. Sort the
+	// keys so an unknown tool with several string args always shows the same
+	// one.
+	keys := make([]string, 0, len(args))
+	for k := range args {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	for _, k := range keys {
+		if s, ok := args[k].(string); ok && strings.TrimSpace(s) != "" {
 			return strings.TrimSpace(s)
 		}
 	}

--- a/internal/ui/activity_test.go
+++ b/internal/ui/activity_test.go
@@ -299,24 +299,36 @@ func TestTurnReceipt(t *testing.T) {
 	})
 }
 
-// TestSplashBarScalesWithContent verifies the splash costs exactly as many
+// TestSplashBlockScalesWithContent verifies the splash costs exactly as many
 // rows as it has content, rather than a fixed block-art height.
-func TestSplashBarScalesWithContent(t *testing.T) {
-	theme := style.GetTheme()
-
+func TestSplashBlockScalesWithContent(t *testing.T) {
 	for _, n := range []int{1, 3, 8} {
 		lines := make([]string, n)
 		for i := range lines {
 			lines[i] = "x"
 		}
-		got := style.SplashBar(lines, theme.Primary, theme.Accent)
+		got := style.SplashBlock(lines)
 		if h := lipgloss.Height(got); h != n {
-			t.Errorf("SplashBar with %d lines rendered %d rows", n, h)
+			t.Errorf("SplashBlock with %d lines rendered %d rows", n, h)
 		}
 	}
 
-	if got := style.SplashBar(nil, theme.Primary, theme.Accent); got != "" {
+	if got := style.SplashBlock(nil); got != "" {
 		t.Errorf("expected empty splash for no content, got %q", got)
+	}
+}
+
+// TestSplashBlockHasNoGutter verifies the splash carries no left stripe. It is
+// the application introducing itself, not a message attributed to anyone, so a
+// gutter glyph there would imply an authorship the block does not have.
+func TestSplashBlockHasNoGutter(t *testing.T) {
+	got := stripAnsi(style.SplashBlock([]string{"KIT", "anthropic"}))
+
+	if strings.Contains(got, style.GutterGlyph) {
+		t.Errorf("splash must not carry a gutter glyph, got %q", got)
+	}
+	if strings.Contains(got, "█") {
+		t.Errorf("splash must not carry a left stripe, got %q", got)
 	}
 }
 
@@ -393,12 +405,8 @@ func TestLeftEdgeAlignment(t *testing.T) {
 		}
 	})
 
-	t.Run("splash stripe in column 0", func(t *testing.T) {
-		theme := style.GetTheme()
-		got := style.SplashBar([]string{"KIT"}, theme.Primary, theme.Accent)
-		if !startsAtColumnZero(got) {
-			t.Errorf("splash stripe must sit in column 0, got %q", stripAnsi(got))
-		}
+	t.Run("splash indented to the content column", func(t *testing.T) {
+		got := style.SplashBlock([]string{"KIT"})
 		if col := contentColumn(got); col != style.ContentOffset {
 			t.Errorf("splash text starts at column %d, want %d", col, style.ContentOffset)
 		}

--- a/internal/ui/activity_test.go
+++ b/internal/ui/activity_test.go
@@ -9,6 +9,7 @@ import (
 	"charm.land/lipgloss/v2"
 
 	"github.com/mark3labs/kit/internal/app"
+	"github.com/mark3labs/kit/internal/ui/style"
 )
 
 func TestActivityVerb(t *testing.T) {
@@ -195,5 +196,125 @@ func TestComposerStartsSingleRow(t *testing.T) {
 
 	if got := lipgloss.Height(ic.View().Content); got != 1 {
 		t.Errorf("expected an empty composer to occupy 1 line, got %d", got)
+	}
+}
+
+// TestGutterVocabularyIsConsistent verifies that every attributed block uses
+// the same gutter glyph, rather than mixing border weights.
+func TestGutterVocabularyIsConsistent(t *testing.T) {
+	r := newMessageRenderer(80, false)
+
+	user := r.RenderUserMessage("hello", time.Now())
+	if !strings.Contains(user.Content, style.GutterGlyph) {
+		t.Errorf("expected user message to use the shared gutter glyph %q, got %q",
+			style.GutterGlyph, stripAnsi(user.Content))
+	}
+
+	// The retired glyphs must not reappear anywhere in an attributed block.
+	for _, old := range []string{"┃", "│"} {
+		if strings.Contains(stripAnsi(user.Content), old) {
+			t.Errorf("user message still contains retired gutter glyph %q", old)
+		}
+	}
+}
+
+// TestToolHeaderReservesCheckmark verifies routine tool successes use a quiet
+// marker, leaving ✓ to mean "the turn finished".
+func TestToolHeaderReservesCheckmark(t *testing.T) {
+	r := newMessageRenderer(80, false)
+
+	ok := stripAnsi(r.RenderToolMessage("read", `{"path":"a.go"}`, "contents", false).Content)
+	if strings.Contains(ok, "✓") {
+		t.Errorf("routine tool success should not claim a checkmark, got %q", ok)
+	}
+	if !strings.Contains(ok, "·") {
+		t.Errorf("expected a quiet marker on a routine tool success, got %q", ok)
+	}
+
+	failed := stripAnsi(r.RenderToolMessage("read", `{"path":"a.go"}`, "boom", true).Content)
+	if !strings.Contains(failed, "×") {
+		t.Errorf("expected a failure marker on tool error, got %q", failed)
+	}
+}
+
+// TestTurnReceipt verifies the receipt appears for substantive turns, is
+// suppressed for trivial ones, and reports the outcome.
+func TestTurnReceipt(t *testing.T) {
+	newModel := func() *AppModel {
+		ctrl := &stubAppController{}
+		m, _, _ := newTestAppModel(ctrl)
+		return sendMsg(m, tea.WindowSizeMsg{Width: 100, Height: 30})
+	}
+
+	t.Run("suppressed for trivial turns", func(t *testing.T) {
+		m := newModel()
+		before := len(m.messages)
+		m.turnStartedAt = time.Now()
+		m.turnToolCount = 0
+		m.printTurnReceipt(turnDone)
+
+		if len(m.messages) != before {
+			t.Errorf("expected no receipt for a fast tool-free turn, got %q",
+				stripAnsi(m.messages[len(m.messages)-1].Render(100)))
+		}
+	})
+
+	t.Run("shown after tool use", func(t *testing.T) {
+		m := newModel()
+		m.turnStartedAt = time.Now().Add(-3 * time.Second)
+		m.turnToolCount = 2
+		m.printTurnReceipt(turnDone)
+
+		got := stripAnsi(m.messages[len(m.messages)-1].Render(100))
+		for _, want := range []string{"✓", "Done", "2 tools", "3s"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("expected receipt to contain %q, got %q", want, got)
+			}
+		}
+	})
+
+	t.Run("singular tool", func(t *testing.T) {
+		m := newModel()
+		m.turnStartedAt = time.Now().Add(-time.Second)
+		m.turnToolCount = 1
+		m.printTurnReceipt(turnDone)
+
+		got := stripAnsi(m.messages[len(m.messages)-1].Render(100))
+		if !strings.Contains(got, "1 tool") || strings.Contains(got, "1 tools") {
+			t.Errorf("expected singular %q, got %q", "1 tool", got)
+		}
+	})
+
+	t.Run("interrupted", func(t *testing.T) {
+		m := newModel()
+		m.turnStartedAt = time.Now().Add(-time.Second)
+		m.turnToolCount = 1
+		m.printTurnReceipt(turnCancelled)
+
+		got := stripAnsi(m.messages[len(m.messages)-1].Render(100))
+		if !strings.Contains(got, "Interrupted") {
+			t.Errorf("expected an interrupted receipt, got %q", got)
+		}
+	})
+}
+
+// TestSplashBarScalesWithContent verifies the splash costs exactly as many
+// rows as it has content, rather than a fixed block-art height.
+func TestSplashBarScalesWithContent(t *testing.T) {
+	theme := style.GetTheme()
+
+	for _, n := range []int{1, 3, 8} {
+		lines := make([]string, n)
+		for i := range lines {
+			lines[i] = "x"
+		}
+		got := style.SplashBar(lines, theme.Primary, theme.Accent)
+		if h := lipgloss.Height(got); h != n {
+			t.Errorf("SplashBar with %d lines rendered %d rows", n, h)
+		}
+	}
+
+	if got := style.SplashBar(nil, theme.Primary, theme.Accent); got != "" {
+		t.Errorf("expected empty splash for no content, got %q", got)
 	}
 }

--- a/internal/ui/activity_test.go
+++ b/internal/ui/activity_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -297,6 +298,20 @@ func TestTurnReceipt(t *testing.T) {
 			t.Errorf("expected an interrupted receipt, got %q", got)
 		}
 	})
+
+	t.Run("failed always shows, even with no tools", func(t *testing.T) {
+		// A failed turn is worth acknowledging regardless of how much work it
+		// did, so unlike turnDone it is never suppressed.
+		m := newModel()
+		m.turnStartedAt = time.Now()
+		m.turnToolCount = 0
+		m.printTurnReceipt(turnFailed)
+
+		got := stripAnsi(m.messages[len(m.messages)-1].Render(100))
+		if !strings.Contains(got, "Failed") {
+			t.Errorf("expected a failed receipt even with no tools, got %q", got)
+		}
+	})
 }
 
 // TestSplashBlockScalesWithContent verifies the splash costs exactly as many
@@ -583,5 +598,35 @@ func TestSeparatorGlyphIsConsistent(t *testing.T) {
 		if strings.Contains(s, "•") {
 			t.Errorf("found the retired bullet separator in %q", s)
 		}
+	}
+}
+
+// TestStepErrorEmitsFailedReceipt verifies the StepErrorEvent handler wires
+// through to a failed-turn receipt. The unit test above proves the receipt
+// renders; this proves it is actually reachable from the event that should
+// produce it — the gap a review flagged, where turnFailed was defined but
+// never emitted.
+func TestStepErrorEmitsFailedReceipt(t *testing.T) {
+	ctrl := &stubAppController{}
+	m, _ := newTestAppModelWithRealStream(ctrl)
+	m = sendMsg(m, tea.WindowSizeMsg{Width: 100, Height: 30})
+
+	// Enter a working turn so the terminal event closes it.
+	m, _ = sendMsgExec(m, app.SpinnerEvent{Show: true})
+	m.turnStartedAt = time.Now().Add(-2 * time.Second)
+	m.turnToolCount = 1
+
+	before := len(m.messages)
+	m, _ = sendMsgExec(m, app.StepErrorEvent{Err: errors.New("boom")})
+
+	var found bool
+	for _, msg := range m.messages[before:] {
+		if strings.Contains(stripAnsi(msg.Render(100)), "Failed") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("StepErrorEvent must emit a Failed turn receipt; turnFailed is unreachable otherwise")
 	}
 }

--- a/internal/ui/activity_test.go
+++ b/internal/ui/activity_test.go
@@ -318,3 +318,112 @@ func TestSplashBarScalesWithContent(t *testing.T) {
 		t.Errorf("expected empty splash for no content, got %q", got)
 	}
 }
+
+// TestLeftEdgeAlignment verifies every block honours the shared left-edge
+// contract: a marker in column 0, and text beginning at style.ContentOffset.
+// A ragged left margin reads as a bug even when each block is individually
+// well-formed, so this pins all the block types together.
+func TestLeftEdgeAlignment(t *testing.T) {
+	const width = 80
+	r := newMessageRenderer(width, false)
+
+	// firstVisibleLine returns the first non-blank line of a rendered block.
+	firstVisibleLine := func(rendered string) []rune {
+		for _, line := range strings.Split(stripAnsi(rendered), "\n") {
+			if strings.TrimSpace(line) == "" {
+				continue
+			}
+			return []rune(line)
+		}
+		return nil
+	}
+
+	// contentColumn returns the column at which a block's text begins. For a
+	// block carrying a marker the marker sits in column 0 and text follows the
+	// separating space; for an unmarked block it is simply the indent.
+	contentColumn := func(rendered string) int {
+		runes := firstVisibleLine(rendered)
+		col := 0
+		for col < len(runes) && runes[col] == ' ' {
+			col++
+		}
+		if col == 0 {
+			// A marker occupies column 0. Skip it and the space after it.
+			for col < len(runes) && runes[col] != ' ' {
+				col++
+			}
+			for col < len(runes) && runes[col] == ' ' {
+				col++
+			}
+		}
+		return col
+	}
+
+	// startsAtColumnZero reports whether the block's marker sits in column 0.
+	startsAtColumnZero := func(rendered string) bool {
+		runes := firstVisibleLine(rendered)
+		return len(runes) > 0 && runes[0] != ' '
+	}
+
+	t.Run("user message marker in column 0", func(t *testing.T) {
+		got := r.RenderUserMessage("hello", time.Now()).Content
+		if !startsAtColumnZero(got) {
+			t.Errorf("user gutter must sit in column 0, got %q", stripAnsi(got))
+		}
+		if col := contentColumn(got); col != style.ContentOffset {
+			t.Errorf("user text starts at column %d, want %d", col, style.ContentOffset)
+		}
+	})
+
+	t.Run("tool marker in column 0", func(t *testing.T) {
+		got := r.RenderToolMessage("read", `{"path":"a.go"}`, "x", false).Content
+		if !startsAtColumnZero(got) {
+			t.Errorf("tool marker must sit in column 0, got %q", stripAnsi(got))
+		}
+		if col := contentColumn(got); col != style.ContentOffset {
+			t.Errorf("tool name starts at column %d, want %d", col, style.ContentOffset)
+		}
+	})
+
+	t.Run("assistant prose indented to the content column", func(t *testing.T) {
+		got := r.RenderAssistantMessage("plain prose", time.Now(), "m").Content
+		if col := contentColumn(got); col != style.ContentOffset {
+			t.Errorf("assistant text starts at column %d, want %d", col, style.ContentOffset)
+		}
+	})
+
+	t.Run("splash stripe in column 0", func(t *testing.T) {
+		theme := style.GetTheme()
+		got := style.SplashBar([]string{"KIT"}, theme.Primary, theme.Accent)
+		if !startsAtColumnZero(got) {
+			t.Errorf("splash stripe must sit in column 0, got %q", stripAnsi(got))
+		}
+		if col := contentColumn(got); col != style.ContentOffset {
+			t.Errorf("splash text starts at column %d, want %d", col, style.ContentOffset)
+		}
+	})
+}
+
+// TestAssistantProseFitsWidth verifies assistant text uses the full width
+// available after its indent, leaving a single column of right margin rather
+// than the unexplained four it used to.
+func TestAssistantProseFitsWidth(t *testing.T) {
+	const width = 60
+	r := newMessageRenderer(width, false)
+
+	long := strings.Repeat("word ", 80)
+	rendered := stripAnsi(r.RenderAssistantMessage(long, time.Now(), "m").Content)
+
+	widest := 0
+	for _, line := range strings.Split(rendered, "\n") {
+		if w := len([]rune(strings.TrimRight(line, " "))); w > widest {
+			widest = w
+		}
+	}
+	if widest > width {
+		t.Errorf("assistant prose overflows: widest line %d > width %d", widest, width)
+	}
+	if widest < width-style.ContentOffset-2 {
+		t.Errorf("assistant prose wastes horizontal space: widest line %d, width %d", widest, width)
+	}
+}

--- a/internal/ui/activity_test.go
+++ b/internal/ui/activity_test.go
@@ -119,7 +119,7 @@ func TestRenderActivityRow_IdleIsEmpty(t *testing.T) {
 func TestRenderActivityRow_FitsWidth(t *testing.T) {
 	for _, width := range []int{20, 40, 60, 80, 120, 200} {
 		ctrl := &stubAppController{}
-		m, stream := newTestAppModelWithRealStream(ctrl)
+		m, _ := newTestAppModelWithRealStream(ctrl)
 		m = sendMsg(m, tea.WindowSizeMsg{Width: width, Height: 30})
 
 		m, _ = sendMsgExec(m, app.SpinnerEvent{Show: true})
@@ -129,7 +129,6 @@ func TestRenderActivityRow_FitsWidth(t *testing.T) {
 			ToolArgs:   `{"command":"go test ./... -run TestSomethingWithAVeryLongName"}`,
 			IsStarting: true,
 		})
-		_ = stream
 		m.state = stateWorking
 		m.turnStartedAt = time.Now().Add(-12 * time.Second)
 

--- a/internal/ui/activity_test.go
+++ b/internal/ui/activity_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -329,7 +330,7 @@ func TestLeftEdgeAlignment(t *testing.T) {
 
 	// firstVisibleLine returns the first non-blank line of a rendered block.
 	firstVisibleLine := func(rendered string) []rune {
-		for _, line := range strings.Split(stripAnsi(rendered), "\n") {
+		for line := range strings.SplitSeq(stripAnsi(rendered), "\n") {
 			if strings.TrimSpace(line) == "" {
 				continue
 			}
@@ -415,7 +416,7 @@ func TestAssistantProseFitsWidth(t *testing.T) {
 	rendered := stripAnsi(r.RenderAssistantMessage(long, time.Now(), "m").Content)
 
 	widest := 0
-	for _, line := range strings.Split(rendered, "\n") {
+	for line := range strings.SplitSeq(rendered, "\n") {
 		if w := len([]rune(strings.TrimRight(line, " "))); w > widest {
 			widest = w
 		}
@@ -425,5 +426,87 @@ func TestAssistantProseFitsWidth(t *testing.T) {
 	}
 	if widest < width-style.ContentOffset-2 {
 		t.Errorf("assistant prose wastes horizontal space: widest line %d, width %d", widest, width)
+	}
+}
+
+// TestComposerGrowsAndShrinks verifies the composer tracks its content height,
+// capped at inputMaxRows.
+func TestComposerGrowsAndShrinks(t *testing.T) {
+	ic := NewInputComponent(80, nil)
+	height := func() int { return lipgloss.Height(ic.View().Content) }
+
+	if got := height(); got != 1 {
+		t.Fatalf("empty composer should be 1 line, got %d", got)
+	}
+
+	ic.textarea.SetValue("a\nb\nc")
+	if got := height(); got != 3 {
+		t.Errorf("3-line content should render 3 lines, got %d", got)
+	}
+
+	// Past the cap the textarea scrolls internally rather than growing.
+	ic.textarea.SetValue(strings.Repeat("x\n", inputMaxRows+10))
+	if got := height(); got != inputMaxRows {
+		t.Errorf("composer should cap at %d lines, got %d", inputMaxRows, got)
+	}
+
+	ic.textarea.SetValue("")
+	if got := height(); got != 1 {
+		t.Errorf("cleared composer should return to 1 line, got %d", got)
+	}
+}
+
+// TestComposerAcceptsLongInput guards against the composer's height cap being
+// mistaken for a content limit. MaxHeight alone makes the textarea refuse
+// newlines past that many logical lines, which would silently cap a prompt at
+// inputMaxRows and lose the user's text.
+func TestComposerAcceptsLongInput(t *testing.T) {
+	ic := NewInputComponent(80, nil)
+
+	// Newlines must arrive as real key presses: the content guard lives on the
+	// InsertNewline key binding, so InsertString bypasses it entirely and
+	// would let this test pass against the very bug it exists to catch.
+	newline := tea.KeyPressMsg{Code: 'j', Mod: tea.ModCtrl}
+
+	const lines = inputMaxRows * 4
+	for i := range lines {
+		ic.textarea.InsertString(fmt.Sprintf("line%d", i))
+		updated, _ := ic.Update(newline)
+		ic, _ = updated.(*InputComponent)
+	}
+
+	value := ic.textarea.Value()
+	if got := strings.Count(value, "\n"); got != lines {
+		t.Errorf("composer accepted %d newlines, want %d — input is being truncated", got, lines)
+	}
+	if !strings.Contains(value, fmt.Sprintf("line%d", lines-1)) {
+		t.Errorf("composer dropped later input; value ends %q", value[max(0, len(value)-40):])
+	}
+}
+
+// TestSyncInputHeightMarksLayoutDirty verifies that a composer size change
+// schedules a layout recompute. Without this the transcript keeps a stale
+// height and the joined view overflows the terminal, clipping the status bar.
+func TestSyncInputHeightMarksLayoutDirty(t *testing.T) {
+	ctrl := &stubAppController{}
+	m, _, _ := newTestAppModel(ctrl)
+	m = sendMsg(m, tea.WindowSizeMsg{Width: 80, Height: 30})
+
+	ic := NewInputComponent(80, nil)
+	m.input = ic
+	m.distributeHeight()
+	m.layoutDirty = false
+
+	// No change: layout stays clean.
+	m.syncInputHeight()
+	if m.layoutDirty {
+		t.Error("unchanged composer should not dirty the layout")
+	}
+
+	// Growing the composer must schedule a recompute.
+	ic.textarea.SetValue("a\nb\nc\nd")
+	m.syncInputHeight()
+	if !m.layoutDirty {
+		t.Error("a taller composer must mark the layout dirty, or the transcript overflows")
 	}
 }

--- a/internal/ui/activity_test.go
+++ b/internal/ui/activity_test.go
@@ -1,0 +1,199 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/mark3labs/kit/internal/app"
+)
+
+func TestActivityVerb(t *testing.T) {
+	tests := []struct {
+		name     string
+		tool     string
+		args     string
+		expected string
+	}{
+		{"bash", "bash", `{"command":"go test ./..."}`, "Running go test ./..."},
+		{"read", "read", `{"path":"internal/ui/model.go"}`, "Reading internal/ui/model.go"},
+		{"write", "write", `{"path":"a.go"}`, "Writing a.go"},
+		{"edit", "edit", `{"path":"a.go"}`, "Editing a.go"},
+		{"grep", "grep", `{"pattern":"func main"}`, "Searching func main"},
+		{"find", "find", `{"pattern":"*.go"}`, "Matching *.go"},
+		{"ls", "ls", `{"path":"/tmp"}`, "Listing /tmp"},
+		{"subagent with agent", "subagent", `{"agent":"explore"}`, "Delegating to explore"},
+		{"todo", "todo", `{}`, "Updating todos"},
+		// Multi-line commands must collapse so the row stays one line.
+		{"multiline bash", "bash", `{"command":"echo a\necho b"}`, "Running echo a echo b"},
+		// Malformed and empty arguments degrade to the bare tool name rather
+		// than erroring: the activity row must always render something.
+		{"bad json", "read", `{not json`, "Read"},
+		{"no args", "mytool", ``, "Mytool"},
+		// Unknown tools still get a target when one is available.
+		{"unknown with arg", "deploy", `{"query":"prod"}`, "Deploy prod"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := activityVerb(tt.tool, tt.args); got != tt.expected {
+				t.Errorf("activityVerb(%q, %q) = %q, want %q", tt.tool, tt.args, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestActivityVerbTruncatesLongTargets(t *testing.T) {
+	long := strings.Repeat("x", 200)
+	got := activityVerb("bash", `{"command":"`+long+`"}`)
+
+	if lipgloss.Width(got) > activityMaxTarget+len("Running ") {
+		t.Errorf("expected long command to be truncated, got width %d: %q", lipgloss.Width(got), got)
+	}
+	if !strings.Contains(got, "…") {
+		t.Errorf("expected an ellipsis to mark elision, got %q", got)
+	}
+}
+
+func TestFormatElapsed(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{0, ""},
+		{-time.Second, ""},
+		{500 * time.Millisecond, "<1s"},
+		{time.Second, "1s"},
+		{45 * time.Second, "45s"},
+		{time.Minute, "1m00s"},
+		{90 * time.Second, "1m30s"},
+		{2*time.Minute + 7*time.Second, "2m07s"},
+	}
+
+	for _, tt := range tests {
+		if got := formatElapsed(tt.d); got != tt.want {
+			t.Errorf("formatElapsed(%v) = %q, want %q", tt.d, got, tt.want)
+		}
+	}
+}
+
+func TestShortenActivityPath(t *testing.T) {
+	short := "internal/ui/model.go"
+	if got := shortenActivityPath(short); got != short {
+		t.Errorf("short path should pass through unchanged, got %q", got)
+	}
+
+	long := "/very/deeply/nested/directory/structure/that/keeps/going/and/going/pkg/file.go"
+	got := shortenActivityPath(long)
+	if !strings.HasPrefix(got, "…/") {
+		t.Errorf("expected elided prefix, got %q", got)
+	}
+	if !strings.Contains(got, "file.go") {
+		t.Errorf("expected the filename to survive elision, got %q", got)
+	}
+	if len([]rune(got)) > activityMaxTarget {
+		t.Errorf("expected result within %d columns, got %d: %q", activityMaxTarget, len([]rune(got)), got)
+	}
+}
+
+// TestRenderActivityRow_IdleIsEmpty verifies the row costs nothing at rest.
+func TestRenderActivityRow_IdleIsEmpty(t *testing.T) {
+	ctrl := &stubAppController{}
+	m, _, _ := newTestAppModel(ctrl)
+	m = sendMsg(m, tea.WindowSizeMsg{Width: 100, Height: 30})
+
+	m.state = stateInput
+	if got := m.renderActivityRow(); got != "" {
+		t.Errorf("expected empty activity row while idle, got %q", got)
+	}
+}
+
+// TestRenderActivityRow_FitsWidth verifies the row never exceeds the terminal
+// width, including at narrow sizes where the hint must be dropped.
+func TestRenderActivityRow_FitsWidth(t *testing.T) {
+	for _, width := range []int{20, 40, 60, 80, 120, 200} {
+		ctrl := &stubAppController{}
+		m, stream := newTestAppModelWithRealStream(ctrl)
+		m = sendMsg(m, tea.WindowSizeMsg{Width: width, Height: 30})
+
+		m, _ = sendMsgExec(m, app.SpinnerEvent{Show: true})
+		m, _ = sendMsgExec(m, app.ToolExecutionEvent{
+			ToolCallID: "c1",
+			ToolName:   "bash",
+			ToolArgs:   `{"command":"go test ./... -run TestSomethingWithAVeryLongName"}`,
+			IsStarting: true,
+		})
+		_ = stream
+		m.state = stateWorking
+		m.turnStartedAt = time.Now().Add(-12 * time.Second)
+
+		row := m.renderActivityRow()
+		if row == "" {
+			t.Errorf("width=%d: expected a non-empty activity row while working", width)
+			continue
+		}
+		if got := lipgloss.Width(row); got > width {
+			t.Errorf("width=%d: activity row overflows terminal, got width %d: %q", width, got, row)
+		}
+		if strings.Contains(row, "\n") {
+			t.Errorf("width=%d: activity row must stay a single line, got %q", width, row)
+		}
+	}
+}
+
+// TestRenderActivityRow_DropsHintBeforePhrase verifies the interrupt hint is
+// sacrificed before the activity text when space runs short.
+func TestRenderActivityRow_DropsHintBeforePhrase(t *testing.T) {
+	ctrl := &stubAppController{}
+	m, _ := newTestAppModelWithRealStream(ctrl)
+	m = sendMsg(m, tea.WindowSizeMsg{Width: 30, Height: 30})
+
+	m, _ = sendMsgExec(m, app.SpinnerEvent{Show: true})
+	m, _ = sendMsgExec(m, app.ToolExecutionEvent{
+		ToolCallID: "c1", ToolName: "bash", ToolArgs: `{"command":"make build"}`, IsStarting: true,
+	})
+	m.state = stateWorking
+
+	row := stripAnsi(m.renderActivityRow())
+	if strings.Contains(row, "interrupt") {
+		t.Errorf("expected the hint to be dropped at narrow width, got %q", row)
+	}
+	if !strings.Contains(row, "Running") {
+		t.Errorf("expected the activity phrase to survive, got %q", row)
+	}
+}
+
+// TestComposerFillsWidth verifies the composer bar paints a contiguous
+// background across the full terminal width. A background set only on the
+// outer container tears at every inner ANSI reset, so this guards the
+// per-style fill in applyComposerStyles.
+func TestComposerFillsWidth(t *testing.T) {
+	const width = 60
+	ic := NewInputComponent(width, nil)
+
+	rendered := ic.View().Content
+	firstLine := strings.SplitN(rendered, "\n", 2)[0]
+
+	if got := lipgloss.Width(firstLine); got != width {
+		t.Errorf("expected composer to span %d columns, got %d: %q", width, got, firstLine)
+	}
+
+	// Every reset of the background must be followed by it being set again
+	// before any visible character, otherwise the bar shows gaps.
+	if strings.Count(firstLine, "\x1b[49m") > 1 {
+		t.Errorf("composer background is torn by inner resets: %q", firstLine)
+	}
+}
+
+// TestComposerStartsSingleRow verifies the composer costs one text row when
+// empty, rather than reserving a fixed multi-line block.
+func TestComposerStartsSingleRow(t *testing.T) {
+	ic := NewInputComponent(80, nil)
+
+	if got := lipgloss.Height(ic.View().Content); got != 1 {
+		t.Errorf("expected an empty composer to occupy 1 line, got %d", got)
+	}
+}

--- a/internal/ui/activity_test.go
+++ b/internal/ui/activity_test.go
@@ -518,3 +518,70 @@ func TestSyncInputHeightMarksLayoutDirty(t *testing.T) {
 		t.Error("a taller composer must mark the layout dirty, or the transcript overflows")
 	}
 }
+
+// TestConfirmationPromptNotDuplicated verifies a pending confirmation appears
+// exactly once. The activity row owns it while the agent is working; a second
+// copy on its own line above the transcript said the same thing twice, two
+// lines apart, in a different capitalization.
+func TestConfirmationPromptNotDuplicated(t *testing.T) {
+	newModel := func() *AppModel {
+		ctrl := &stubAppController{}
+		m, _, _ := newTestAppModel(ctrl)
+		return sendMsg(m, tea.WindowSizeMsg{Width: 100, Height: 30})
+	}
+
+	t.Run("esc while working appears only in the activity row", func(t *testing.T) {
+		m := newModel()
+		m.state = stateWorking
+		m.canceling = true
+
+		if !strings.Contains(stripAnsi(m.renderActivityRow()), "esc again") {
+			t.Error("activity row must carry the cancel confirmation while working")
+		}
+		view := stripAnsi(m.View().Content)
+		if got := strings.Count(view, "again to cancel"); got != 1 {
+			t.Errorf("cancel confirmation appears %d times in the view, want exactly 1", got)
+		}
+	})
+
+	t.Run("ctrl+c while working appears only in the activity row", func(t *testing.T) {
+		m := newModel()
+		m.state = stateWorking
+		m.ctrlCPressedOnce = true
+
+		view := stripAnsi(m.View().Content)
+		if got := strings.Count(view, "again to quit"); got != 1 {
+			t.Errorf("quit confirmation appears %d times in the view, want exactly 1", got)
+		}
+	})
+
+	t.Run("ctrl+c while idle still shows", func(t *testing.T) {
+		m := newModel()
+		m.state = stateInput
+		m.ctrlCPressedOnce = true
+
+		// There is no activity row when idle, so the confirmation needs its
+		// own line or the key would give no feedback at all.
+		view := stripAnsi(m.View().Content)
+		if got := strings.Count(view, "again to quit"); got != 1 {
+			t.Errorf("quit confirmation appears %d times when idle, want exactly 1", got)
+		}
+	})
+}
+
+// TestSeparatorGlyphIsConsistent verifies one glyph separates fields
+// everywhere. Two different bullets doing the same job appeared on the same
+// screen: "go.mod • lines 1-3" two lines from "Done · 1 tool · 3s".
+func TestSeparatorGlyphIsConsistent(t *testing.T) {
+	r := newMessageRenderer(80, false)
+
+	samples := []string{
+		stripAnsi(r.RenderToolMessage("read", `{"path":"a.go"}`, "1: x\n2: y", false).Content),
+		stripAnsi(NewInputComponent(80, nil).popup.FooterHint),
+	}
+	for _, s := range samples {
+		if strings.Contains(s, "•") {
+			t.Errorf("found the retired bullet separator in %q", s)
+		}
+	}
+}

--- a/internal/ui/block_renderer.go
+++ b/internal/ui/block_renderer.go
@@ -87,9 +87,11 @@ func renderContentBlock(content string, containerWidth int, options ...rendering
 		fullWidth:     true,
 		paddingTop:    1,
 		paddingBottom: 1,
-		paddingLeft:   2,
-		paddingRight:  0,
-		width:         containerWidth,
+		// The border glyph occupies column 0, so the padding that follows it
+		// is one less than the shared content offset.
+		paddingLeft:  style.ContentOffset - 1,
+		paddingRight: 0,
+		width:        containerWidth,
 	}
 
 	for _, option := range options {

--- a/internal/ui/block_renderer.go
+++ b/internal/ui/block_renderer.go
@@ -123,7 +123,7 @@ func renderContentBlock(content string, containerWidth int, options ...rendering
 	}
 
 	// Single-pass render: padding, border, and foreground in one style.
-	style := lipgloss.NewStyle().
+	blockStyle := lipgloss.NewStyle().
 		PaddingLeft(renderer.paddingLeft).
 		PaddingRight(renderer.paddingRight).
 		PaddingTop(renderer.paddingTop).
@@ -131,29 +131,32 @@ func renderContentBlock(content string, containerWidth int, options ...rendering
 		Foreground(fgColor)
 
 	if hasBorder {
-		style = style.BorderStyle(lipgloss.ThickBorder())
+		// One gutter glyph is used for every attributed block in the UI, so
+		// the left edge reads as a single vocabulary rather than as several
+		// competing border weights.
+		blockStyle = blockStyle.BorderStyle(style.GutterBorder())
 
 		switch borderAlign {
 		case lipgloss.Right:
-			style = style.
+			blockStyle = blockStyle.
 				BorderRight(true).
 				BorderRightForeground(borderColor)
 		default:
-			style = style.
+			blockStyle = blockStyle.
 				BorderLeft(true).
 				BorderLeftForeground(borderColor)
 		}
 	}
 
 	if renderer.background != nil {
-		style = style.Background(*renderer.background)
+		blockStyle = blockStyle.Background(*renderer.background)
 	}
 
 	if renderer.fullWidth {
-		style = style.Width(renderer.width - borderChars)
+		blockStyle = blockStyle.Width(renderer.width - borderChars)
 	}
 
-	content = style.Render(content)
+	content = blockStyle.Render(content)
 
 	// Add margins
 	if renderer.marginTop > 0 {

--- a/internal/ui/children_test.go
+++ b/internal/ui/children_test.go
@@ -389,8 +389,8 @@ func TestStreamComponent_ToolExecution_IsStarting_ShowsSpinner(t *testing.T) {
 	if !c.spinning {
 		t.Fatal("expected spinning=true during tool execution")
 	}
-	tools := c.activeToolDisplays()
-	if len(tools) != 1 || !strings.Contains(tools[0], "exec_tool") {
+	tools := c.activeToolList()
+	if len(tools) != 1 || tools[0].name != "exec_tool" {
 		t.Fatalf("expected activeTools to contain tool name, got %v", tools)
 	}
 	if cmd == nil {
@@ -437,10 +437,10 @@ func TestStreamComponent_ParallelToolExecution(t *testing.T) {
 		t.Fatalf("expected 3 active tools, got %d: %v", len(c.activeTools), c.activeTools)
 	}
 
-	// Check SpinnerView shows all tools
-	view := c.SpinnerView()
-	if !strings.Contains(view, "Running:") {
-		t.Fatalf("expected spinner view to contain 'Running:' for multiple tools, got %q", view)
+	// Concurrent calls collapse to a count so the activity row stays one line.
+	phrase := c.ActivityPhrase()
+	if !strings.Contains(phrase, "3 tools") {
+		t.Fatalf("expected activity phrase to summarise 3 concurrent tools, got %q", phrase)
 	}
 
 	// Finish one tool
@@ -465,20 +465,20 @@ func TestStreamComponent_ParallelSameToolName_UsesToolCallID(t *testing.T) {
 	c = sendStreamMsg(c, app.ToolExecutionEvent{ToolCallID: "call-read-1", ToolName: "read", IsStarting: true})
 	c = sendStreamMsg(c, app.ToolExecutionEvent{ToolCallID: "call-read-2", ToolName: "read", IsStarting: true})
 
-	tools := c.activeToolDisplays()
+	tools := c.activeToolList()
 	if len(tools) != 2 {
 		t.Fatalf("expected 2 active read calls, got %d (%v)", len(tools), tools)
 	}
 
 	c = sendStreamMsg(c, app.ToolExecutionEvent{ToolCallID: "call-read-1", ToolName: "read", IsStarting: false})
-	tools = c.activeToolDisplays()
+	tools = c.activeToolList()
 	if len(tools) != 1 {
 		t.Fatalf("expected 1 active read call after finishing one ID, got %d (%v)", len(tools), tools)
 	}
 
 	c = sendStreamMsg(c, app.ToolExecutionEvent{ToolCallID: "call-read-2", ToolName: "read", IsStarting: false})
-	if len(c.activeToolDisplays()) != 0 {
-		t.Fatalf("expected no active tools after finishing both IDs, got %v", c.activeToolDisplays())
+	if len(c.activeToolList()) != 0 {
+		t.Fatalf("expected no active tools after finishing both IDs, got %v", c.activeToolList())
 	}
 }
 

--- a/internal/ui/exports.go
+++ b/internal/ui/exports.go
@@ -66,4 +66,5 @@ var (
 	KitBanner               = style.KitBanner
 	AdaptiveColor           = style.AdaptiveColor
 	IsDarkBackground        = style.IsDarkBackground
+	SyntaxStyle             = style.SyntaxStyle
 )

--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -130,6 +130,20 @@ type InputComponent struct {
 // maxHistory is the maximum number of prompt entries kept in history.
 const maxHistory = 100
 
+// inputChromeWidth is the number of columns the composer frame consumes: one
+// column of horizontal padding on each side of the filled bar. The textarea is
+// sized to the remainder so text neither wraps early nor overflows.
+const inputChromeWidth = 2
+
+// inputMaxRows caps how tall the composer grows before the textarea begins
+// scrolling its own content.
+const inputMaxRows = 8
+
+// defaultPlaceholder doubles as the submit hint. Folding the hint into the
+// placeholder means the composer needs no separate help line, and the hint
+// disappears exactly when it stops being useful — as soon as the user types.
+const defaultPlaceholder = "Ask kit anything…   ↵ send"
+
 // clipboardImageMsg is the result of an async clipboard image read.
 type clipboardImageMsg struct {
 	image *core.ImageAttachment
@@ -151,12 +165,19 @@ type thumbnailReadyMsg struct {
 // /clear and /clear-queue are no-ops.
 func NewInputComponent(width int, appCtrl AppController) *InputComponent {
 	ta := textarea.New()
-	ta.Placeholder = "Type your message..."
+	ta.Placeholder = defaultPlaceholder
 	ta.ShowLineNumbers = false
 	ta.Prompt = ""
 	ta.CharLimit = 0
-	ta.SetWidth(width - 8) // Account for container padding, border and internal padding
-	ta.SetHeight(4)        // 4 lines for comfortable multi-line input
+	ta.SetWidth(width - inputChromeWidth)
+
+	// The composer starts as a single row and grows with the text, so an empty
+	// prompt costs one line instead of four. Beyond inputMaxRows the textarea
+	// scrolls internally rather than eating the transcript.
+	ta.DynamicHeight = true
+	ta.MinHeight = 1
+	ta.MaxHeight = inputMaxRows
+	ta.SetHeight(1)
 	ta.Focus()
 
 	// Override InsertNewline so only ctrl+j and shift+enter insert newlines.
@@ -166,14 +187,13 @@ func NewInputComponent(width int, appCtrl AppController) *InputComponent {
 		key.WithHelp("ctrl+j", "insert newline"),
 	)
 
-	// Style the textarea using theme colors.
+	// Style the textarea using theme colors. Every span the textarea emits
+	// carries the composer background explicitly: a Background() set only on
+	// the outer container tears at each inner ANSI reset, which renders as
+	// patchy off-color blocks across the bar.
 	theme := style.GetTheme()
 	styles := ta.Styles()
-	styles.Focused.Base = lipgloss.NewStyle()
-	styles.Focused.Placeholder = lipgloss.NewStyle().Foreground(theme.VeryMuted)
-	styles.Focused.Text = lipgloss.NewStyle().Foreground(theme.Text)
-	styles.Focused.Prompt = lipgloss.NewStyle()
-	styles.Focused.CursorLine = lipgloss.NewStyle()
+	applyComposerStyles(&styles, theme)
 	ta.SetStyles(styles)
 
 	ic := &InputComponent{
@@ -231,7 +251,7 @@ func (s *InputComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		s.width = msg.Width
-		s.textarea.SetWidth(msg.Width - 8)
+		s.textarea.SetWidth(msg.Width - inputChromeWidth)
 		return s, nil
 
 	case clipboardImageMsg:
@@ -630,44 +650,37 @@ func renderThumbnailCmd(img core.ImageAttachment, cols, rows int, bg color.Color
 	}
 }
 
-// View implements tea.Model. Renders the textarea, autocomplete popup
-// (if visible), and help text.
+// View implements tea.Model. Renders the composer bar and any pending image
+// attachments. The autocomplete popup is drawn separately as a centered
+// overlay by AppModel.View().
 func (s *InputComponent) View() tea.View {
-	containerStyle := lipgloss.NewStyle()
-
 	theme := style.GetTheme()
 
-	inputBoxStyle := lipgloss.NewStyle().
-		Border(lipgloss.ThickBorder()).
-		BorderLeft(true).
-		BorderRight(false).
-		BorderTop(false).
-		BorderBottom(false).
-		BorderForeground(theme.Primary).
-		MarginTop(1).
-		MarginBottom(1).
-		PaddingLeft(2).    // match message block paddingLeft
-		Width(s.width - 1) // full width minus left border
+	// The composer is a filled bar rather than a bordered box. A background
+	// fill reads as chrome, which is what the composer is; a border reads as
+	// content, which is what messages are. Keeping the two distinct means the
+	// input can never be mistaken for something the agent said.
+	inputBarStyle := lipgloss.NewStyle().
+		Background(theme.InputBg).
+		Padding(0, 1).
+		Width(s.width)
 
 	var view strings.Builder
-	view.WriteString(inputBoxStyle.Render(s.textarea.View()))
-
-	// Popup is now rendered as a centered overlay in AppModel.View()
-	// instead of inline here to prevent bottom overflow
+	view.WriteString(inputBarStyle.Render(s.textarea.View()))
 
 	// Show image attachment previews when images are pending. A cached
 	// half-block thumbnail is rendered when the terminal supports it;
 	// otherwise the text pill alone is shown.
 	if len(s.pendingImages) > 0 {
 		imgStyle := lipgloss.NewStyle().
-			Foreground(theme.Secondary).
-			PaddingLeft(3)
+			Foreground(theme.VeryMuted).
+			PaddingLeft(1)
 
-		label := fmt.Sprintf("[%d image(s) attached] ctrl+u to clear", len(s.pendingImages))
+		label := fmt.Sprintf("%d image(s) attached · ctrl+u to clear", len(s.pendingImages))
 		view.WriteString("\n")
 		view.WriteString(imgStyle.Render(label))
 
-		thumbStyle := lipgloss.NewStyle().PaddingLeft(3)
+		thumbStyle := lipgloss.NewStyle().PaddingLeft(1)
 		for i := range s.pendingImages {
 			if i < len(s.imageThumbs) && s.imageThumbs[i] != "" {
 				view.WriteString("\n")
@@ -676,40 +689,7 @@ func (s *InputComponent) View() tea.View {
 		}
 	}
 
-	if !s.hideHint {
-		helpStyle := lipgloss.NewStyle().
-			Foreground(theme.VeryMuted).
-			MarginTop(1).
-			PaddingLeft(3)
-
-		// Adapt hint text to available width (accounting for left padding of 3).
-		var hint string
-		availableHintWidth := s.width - 3
-		if s.agentBusy {
-			// When the agent is working, show steering shortcut.
-			if availableHintWidth >= 60 {
-				hint = "enter queue • ctrl+x s steer • esc esc cancel"
-			} else if availableHintWidth >= 40 {
-				hint = "↵ queue • ^X s steer • esc×2 cancel"
-			} else {
-				hint = "^X s steer"
-			}
-		} else if availableHintWidth >= 80 {
-			hint = "enter submit • ctrl+j / shift+enter new line • ctrl+x e editor • ctrl+v paste image"
-		} else if availableHintWidth >= 67 {
-			hint = "enter submit • ctrl+j new line • ctrl+x e editor • ctrl+v image"
-		} else if availableHintWidth >= 40 {
-			hint = "↵ submit • ctrl+j newline • ^X e editor"
-		} else if availableHintWidth >= 20 {
-			hint = "↵ submit • ^X e editor"
-		} else {
-			hint = "↵ submit"
-		}
-		view.WriteString("\n")
-		view.WriteString(helpStyle.Render(hint))
-	}
-
-	return tea.NewView(containerStyle.Render(view.String()))
+	return tea.NewView(view.String())
 }
 
 // RenderPopupCentered renders the autocomplete popup for / or @ as a
@@ -967,4 +947,33 @@ func (s *InputComponent) updateEditFilePopup(cmdLen int, pathPrefix string) {
 		s.filtered[i] = FuzzyMatch{Command: &s.fileSynthCmds[i], Score: fs.Score}
 	}
 	s.selected = 0
+}
+
+// applyComposerStyles paints every textarea style state with the composer
+// background.
+//
+// lipgloss emits a reset sequence at the end of each styled span, which clears
+// the background set by an enclosing container. Filling the bar therefore has
+// to happen on the innermost styles rather than on the wrapper, or the result
+// is a bar that flickers back to the terminal background wherever the textarea
+// changed color (placeholder, text, cursor line).
+func applyComposerStyles(styles *textarea.Styles, theme style.Theme) {
+	bg := lipgloss.NewStyle().Background(theme.InputBg)
+
+	for _, state := range []*textarea.StyleState{&styles.Focused, &styles.Blurred} {
+		state.Base = bg
+		state.Text = bg.Foreground(theme.Text)
+		state.Placeholder = bg.Foreground(theme.VeryMuted)
+		state.Prompt = bg
+		state.CursorLine = bg
+		state.EndOfBuffer = bg
+	}
+}
+
+// UpdateTheme repaints the composer with colors from the current theme.
+// Called after /theme switches the active palette.
+func (s *InputComponent) UpdateTheme() {
+	styles := s.textarea.Styles()
+	applyComposerStyles(&styles, style.GetTheme())
+	s.textarea.SetStyles(styles)
 }

--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -139,6 +139,11 @@ const inputChromeWidth = 2
 // scrolling its own content.
 const inputMaxRows = 8
 
+// inputMaxContentRows bounds how much text the composer will hold. It exists
+// only to keep a runaway paste from exhausting memory; it is far beyond any
+// prompt a person would type, so in practice input is unlimited.
+const inputMaxContentRows = 10000
+
 // defaultPlaceholder doubles as the submit hint. Folding the hint into the
 // placeholder means the composer needs no separate help line, and the hint
 // disappears exactly when it stops being useful — as soon as the user types.
@@ -174,9 +179,15 @@ func NewInputComponent(width int, appCtrl AppController) *InputComponent {
 	// The composer starts as a single row and grows with the text, so an empty
 	// prompt costs one line instead of four. Beyond inputMaxRows the textarea
 	// scrolls internally rather than eating the transcript.
+	//
+	// MaxContentHeight must be set explicitly: with only MaxHeight the
+	// textarea treats it as a content limit and silently refuses newlines past
+	// that many logical lines, which would cap a prompt at inputMaxRows.
+	// Setting it separately keeps MaxHeight governing the viewport alone.
 	ta.DynamicHeight = true
 	ta.MinHeight = 1
 	ta.MaxHeight = inputMaxRows
+	ta.MaxContentHeight = inputMaxContentRows
 	ta.SetHeight(1)
 	ta.Focus()
 

--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -211,7 +211,7 @@ func NewInputComponent(width int, appCtrl AppController) *InputComponent {
 	ic.popup.ShowSearch = false
 	ic.popup.HideCount = true
 	ic.popup.MaxVisible = ic.popupHeight
-	ic.popup.FooterHint = "↑↓ navigate • tab complete • ↵ select • esc dismiss"
+	ic.popup.FooterHint = "↑↓ navigate · tab complete · ↵ select · esc dismiss"
 	return ic
 }
 

--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -167,7 +167,10 @@ func NewInputComponent(width int, appCtrl AppController) *InputComponent {
 	ta.ShowLineNumbers = false
 	ta.Prompt = ""
 	ta.CharLimit = 0
-	ta.SetWidth(width - inputChromeWidth)
+	// Clamp to at least one column: on a pathologically narrow terminal
+	// width-inputChromeWidth would go non-positive and SetWidth would receive
+	// a negative width.
+	ta.SetWidth(max(width-inputChromeWidth, 1))
 
 	// The composer starts as a single row and grows with the text, so an empty
 	// prompt costs one line instead of four. Beyond inputMaxRows the textarea
@@ -254,7 +257,7 @@ func (s *InputComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		s.width = msg.Width
-		s.textarea.SetWidth(msg.Width - inputChromeWidth)
+		s.textarea.SetWidth(max(msg.Width-inputChromeWidth, 1))
 		return s, nil
 
 	case clipboardImageMsg:

--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -83,13 +83,6 @@ type InputComponent struct {
 	// May be nil in tests; nil-safe.
 	appCtrl AppController
 
-	// hideHint suppresses the "enter submit · ctrl+j..." hint text.
-	hideHint bool
-
-	// agentBusy indicates the agent is currently working. When true, the
-	// hint text shows steering shortcut (Ctrl+X s) instead of submit.
-	agentBusy bool
-
 	// pendingImages holds clipboard images attached to the next submission.
 	// Images are added via Ctrl+V and cleared on submit or Ctrl+U.
 	pendingImages []core.ImageAttachment
@@ -213,7 +206,6 @@ func NewInputComponent(width int, appCtrl AppController) *InputComponent {
 		width:       width,
 		popupHeight: 7,
 		appCtrl:     appCtrl,
-		hideHint:    true,
 	}
 	ic.popup = NewPopupList("", nil, width, 0)
 	ic.popup.ShowSearch = false

--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -161,7 +161,9 @@ func (r *MessageRenderer) RenderUserMessage(content string, timestamp time.Time)
 		content,
 		r.width,
 		WithAlign(lipgloss.Left),
-		WithBorderColor(theme.Success),
+		// The gutter marks attribution, so its color says "you". Gold was
+		// theme.Success, which reads as an outcome rather than an author.
+		WithBorderColor(theme.Accent),
 		WithPaddingTop(0),
 		WithPaddingBottom(0),
 		WithMarginBottom(1),
@@ -313,21 +315,21 @@ func (r *MessageRenderer) RenderToolMessage(toolName, toolArgs, toolResult strin
 		params = formatToolParams(toolArgs, paramBudget)
 	}
 
-	var icon string
-	iconColor := style.GetTheme().Success
+	// Routine successes get a dim marker rather than a green check. A check
+	// on every tool call spends the reader's attention on the unremarkable
+	// and leaves nothing to signal the turn actually finishing; reserving
+	// ✓ for turn completion keeps it meaningful. Failures still get a loud
+	// mark, because those genuinely need finding.
+	theme := style.GetTheme()
+	icon := "·"
+	iconColor := theme.VeryMuted
+	nameColor := theme.Muted
 	if isError {
 		icon = "×"
-		iconColor = style.GetTheme().Error
-	} else {
-		icon = "✓"
-	}
-
-	// Style the tool name with color
-	theme := style.GetTheme()
-	nameColor := theme.Info
-	if isError {
+		iconColor = theme.Error
 		nameColor = theme.Error
 	}
+
 	styledName := lipgloss.NewStyle().Foreground(nameColor).Bold(true).Render(displayName)
 	styledIcon := lipgloss.NewStyle().Foreground(iconColor).Render(icon)
 

--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -323,7 +323,9 @@ func (r *MessageRenderer) RenderToolMessage(toolName, toolArgs, toolResult strin
 	theme := style.GetTheme()
 	icon := "·"
 	iconColor := theme.VeryMuted
-	nameColor := theme.Muted
+	// theme.Tool exists so a theme can give tool calls their own identity;
+	// it defaults to the same amber as Secondary.
+	nameColor := theme.Tool
 	if isError {
 		icon = "×"
 		iconColor = theme.Error

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -296,9 +296,12 @@ type StatusBarEntryData struct {
 // The zero value shows everything (backward compatible).
 type UIVisibility struct {
 	HideStartupMessage bool // Hide the "Model loaded..." startup block
-	HideStatusBar      bool // Hide the "provider · model  Tokens: ..." line
-	HideSeparator      bool // Hide the "────────" divider between stream and input
-	HideInputHint      bool // Hide the "enter submit · ctrl+j..." hint below input
+	HideStatusBar      bool // Hide the "~/path (branch) ... provider · model" line
+	HideSeparator      bool // Hide the queued/steering count above the composer
+	// HideInputHint is retained for compatibility and has no effect. The
+	// submit hint is no longer a separate line below the composer; it lives
+	// in the placeholder and disappears as soon as the user types.
+	HideInputHint bool
 }
 
 // AppModelOptions holds configuration passed to NewAppModel.
@@ -2669,14 +2672,6 @@ func (m *AppModel) View() tea.View {
 	// Render scrollback content from ScrollList (replaces renderStream() in alt screen mode)
 	scrollbackView := m.renderScrollback()
 
-	// Propagate hint visibility to the input component before rendering.
-	// Hints are hidden by default for a cleaner UI; extensions cannot
-	// override this.
-	if ic, ok := m.input.(*InputComponent); ok {
-		ic.hideHint = true
-		ic.agentBusy = m.state == stateWorking
-	}
-
 	// When a prompt is active, it replaces the input area for consistency
 	// (appears below the separator, in the same position as the input).
 	var inputView string
@@ -4276,15 +4271,6 @@ func (m *AppModel) distributeHeight() {
 	if activityView := m.renderActivityRow(); activityView != "" {
 		activityLines = lipgloss.Height(activityView)
 		m.chrome.activity = activityView
-	}
-
-	// Propagate hint visibility before measuring input height.
-	// Hints are always hidden for a cleaner UI.
-	// agentBusy must match what View() sets, since the rendered input is
-	// cached in m.chrome and reused by View() in the same frame.
-	if ic, ok := m.input.(*InputComponent); ok {
-		ic.hideHint = true
-		ic.agentBusy = m.state == stateWorking
 	}
 
 	// Measure the actual rendered input (or prompt overlay) height so we

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -2200,6 +2200,11 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.Err != nil {
 			m.printErrorResponse(msg)
 		}
+		// Close the turn with a failure receipt, consistent with the Done and
+		// Interrupted receipts on the other terminal events. The error block
+		// above says what went wrong; the receipt records the turn's shape
+		// (tool count, elapsed) that the error itself omits.
+		m.printTurnReceipt(turnFailed)
 		m.state = stateInput
 		m.canceling = false
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -781,6 +781,15 @@ type AppModel struct {
 	// cwd is the working directory for @file path resolution.
 	cwd string
 
+	// gitBranch is the current git branch name, resolved once when cwd is
+	// set. Empty when the working directory is not a git repository. Shown
+	// in the ambient status bar.
+	gitBranch string
+
+	// turnStartedAt records when the current agent turn began, so the
+	// activity row can show elapsed time. Zero when idle.
+	turnStartedAt time.Time
+
 	// mcpResourceReader is an optional callback to read MCP resources when
 	// processing @mcp:server:uri tokens at submit time. Set by the parent.
 	mcpResourceReader fileutil.MCPResourceReader
@@ -849,6 +858,12 @@ type streamComponentIface interface {
 	// Returns "" when the spinner is not active. The parent renders this in the
 	// status bar so the spinner never changes the view height.
 	SpinnerView() string
+	// ActivityDot returns the animated indicator glyph on its own, for the
+	// activity row. Returns "" when nothing is in flight.
+	ActivityDot() string
+	// ActivityPhrase returns a present-tense description of the work currently
+	// in flight, e.g. "Running go test ./...".
+	ActivityPhrase() string
 	// SetThinkingVisible sets whether reasoning blocks are shown or collapsed.
 	SetThinkingVisible(visible bool)
 	// HasReasoning returns true if any reasoning content has been accumulated.
@@ -954,6 +969,10 @@ func NewAppModel(appCtrl AppController, opts AppModelOptions) *AppModel {
 	if ic, ok := m.input.(*InputComponent); ok && opts.Cwd != "" {
 		ic.SetCwd(opts.Cwd)
 	}
+
+	// Resolve the git branch once at startup for the ambient status bar.
+	// A miss is not an error — the branch is simply omitted.
+	m.gitBranch = detectGitBranch(opts.Cwd)
 
 	// Wire up MCP resource provider for @ autocomplete.
 	if ic, ok := m.input.(*InputComponent); ok && opts.GetMCPResources != nil {
@@ -1143,16 +1162,12 @@ func (m *AppModel) AddStartupMessageToScrollList() {
 		}
 	}
 
-	// Add a visual separator after startup info: blank line + HR + blank line.
-	// Uses a single pre-rendered item so there are no left borders on the spacing.
-	theme := style.GetTheme()
-	separator := strings.Repeat("─", m.width)
-	separatorStyled := lipgloss.NewStyle().
-		Foreground(theme.Border).
-		Render(separator)
-	separatorBlock := "\n" + separatorStyled + "\n"
-	separatorMsg := NewStyledMessageItem(generateMessageID(), "separator", separatorBlock, separatorBlock)
-	m.messages = append(m.messages, separatorMsg)
+	// Separate the startup banner from the conversation with whitespace
+	// rather than a rule. A blank line is enough to break the two apart, and
+	// it does not add a heavy horizontal element to an otherwise quiet screen.
+	spacer := "\n"
+	spacerMsg := NewStyledMessageItem(generateMessageID(), "separator", spacer, spacer)
+	m.messages = append(m.messages, spacerMsg)
 
 	// Refresh ScrollList once with all startup messages
 	m.refreshContent()
@@ -1174,6 +1189,19 @@ func tildeHome(path string) string {
 // incoming messages to children and handles state transitions.
 func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
+
+	// Stamp the turn clock on entry to / exit from the working state, so the
+	// activity row can report elapsed time without every transition site
+	// having to remember to do it. Deferred so it observes the state as it
+	// stands after this Update has run.
+	stateBefore := m.state
+	defer func() {
+		if m.state == stateWorking && stateBefore != stateWorking {
+			m.turnStartedAt = time.Now()
+		} else if m.state != stateWorking && stateBefore == stateWorking {
+			m.turnStartedAt = time.Time{}
+		}
+	}()
 
 	// Coalesced streaming: chunk events are buffered and applied on a ~16ms
 	// flush tick instead of per chunk (a full markdown re-render per chunk is
@@ -2543,8 +2571,9 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 // View implements tea.Model. It renders the stacked layout:
-// stream region + separator + [queued messages] + input region + status bar.
-// The status bar is always present (1 line) to avoid layout shifts.
+// stream region + separator + [queued messages] + [activity row] + input
+// region + status bar. The status bar is always present (1 line) to avoid
+// layout shifts; the activity row appears only while the agent is working.
 // When the tree selector is active, it replaces the stream region.
 func (m *AppModel) View() tea.View {
 	// When quitting, disable alt screen for clean terminal restoration.
@@ -2670,7 +2699,11 @@ func (m *AppModel) View() tea.View {
 	}
 
 	if !vis.HideSeparator {
-		parts = append(parts, m.renderSeparator())
+		// The separator only materialises when it has something to say, so
+		// an idle screen carries no rule between transcript and composer.
+		if sep := m.renderSeparator(); sep != "" {
+			parts = append(parts, sep)
+		}
 	}
 
 	// Render "above" widgets between separator and queued messages.
@@ -2688,6 +2721,16 @@ func (m *AppModel) View() tea.View {
 	}
 	if queuedView != "" {
 		parts = append(parts, queuedView)
+	}
+
+	// Live activity sits immediately above the composer so the eye finds it
+	// in the same place it is about to type. It costs zero lines when idle.
+	activityView := m.chrome.activity
+	if !m.chrome.valid {
+		activityView = m.renderActivityRow()
+	}
+	if activityView != "" {
+		parts = append(parts, activityView)
 	}
 
 	parts = append(parts, inputView)
@@ -2799,95 +2842,81 @@ func (m *AppModel) renderScrollback() string {
 // priority). Right side: provider · model + usage stats.
 // This bar is always present so its height is constant, eliminating layout
 // shifts from spinner or usage info appearing/disappearing.
+// renderStatusBar renders the ambient footer: a single muted line carrying
+// context that is true regardless of what the agent is doing.
+//
+//	~/Workspace/kit (main)        anthropic · claude-opus-5 · 7.2K · $0.02
+//
+// Live activity deliberately does not appear here — it owns the activity row
+// directly above the composer (see renderActivityRow). Keeping the two apart
+// means a long-running command can never be squeezed out by a token counter.
 func (m *AppModel) renderStatusBar() string {
 	theme := style.GetTheme()
+	muted := lipgloss.NewStyle().Foreground(theme.Muted)
+	veryMuted := lipgloss.NewStyle().Foreground(theme.VeryMuted)
 
-	// Left side: spinner animation (when active).
+	// Left: working directory, plus the git branch when one is known.
 	var leftSide string
-	if m.stream != nil {
-		leftSide = m.stream.SpinnerView()
+	if m.cwd != "" {
+		left := tildeHome(m.cwd)
+		if m.gitBranch != "" {
+			left += " (" + m.gitBranch + ")"
+		}
+		leftSide = " " + muted.Render(left)
 	}
 
-	// Middle: thinking level (when reasoning model) + extension status bar entries.
+	// Extension status entries and the thinking level sit next to the path.
+	// They are ambient facts, not activity.
 	var middleParts []string
 	if m.isReasoningModel && m.thinkingLevel != "" && m.thinkingLevel != "off" {
-		thinkingLabel := "Thinking: " + m.thinkingLevel
-		middleParts = append(middleParts, lipgloss.NewStyle().
-			Foreground(theme.Secondary).
-			Render(thinkingLabel))
+		middleParts = append(middleParts, veryMuted.Render("thinking: "+m.thinkingLevel))
 	}
 	if m.getStatusBarEntries != nil {
-		entries := m.getStatusBarEntries()
-		for _, e := range entries {
-			middleParts = append(middleParts, lipgloss.NewStyle().
-				Foreground(theme.Muted).
-				Render(e.Text))
+		for _, e := range m.getStatusBarEntries() {
+			middleParts = append(middleParts, veryMuted.Render(e.Text))
 		}
 	}
-	middleSide := strings.Join(middleParts, "  ")
+	middleSide := strings.Join(middleParts, veryMuted.Render(" · "))
 	if middleSide != "" && leftSide != "" {
-		middleSide = "  " + middleSide
+		middleSide = veryMuted.Render(" · ") + middleSide
 	}
 
-	// Right side: help hint + provider · model + usage stats.
-	// Order matters for progressive truncation — least important first.
+	// Right: provider, model, then usage. Ordered least-important-first so
+	// progressive truncation drops cost before it drops the model name.
 	var rightParts []string
-
-	rightParts = append(rightParts, lipgloss.NewStyle().
-		Foreground(theme.VeryMuted).
-		Render("/help for help"))
-
-	var modelLabel string
 	if m.providerName != "" && m.modelName != "" {
-		modelLabel = m.providerName + " · " + m.modelName
+		rightParts = append(rightParts, muted.Render(m.providerName+" · "+m.modelName))
 	} else if m.modelName != "" {
-		modelLabel = m.modelName
+		rightParts = append(rightParts, muted.Render(m.modelName))
 	}
-	if modelLabel != "" {
-		rightParts = append(rightParts, lipgloss.NewStyle().
-			Foreground(theme.Muted).
-			Render(modelLabel))
-	}
-
 	if m.usageTracker != nil {
 		if usage := m.usageTracker.RenderUsageInfo(); usage != "" {
 			rightParts = append(rightParts, usage)
 		}
 	}
+	sep := veryMuted.Render(" · ")
+	rightSide := strings.Join(rightParts, sep)
 
-	rightSide := strings.Join(rightParts, "  |  ")
-
-	// Progressive truncation to keep the status bar on one line.
-	// When content exceeds terminal width, drop sections in order:
-	// middle (extensions/thinking) → help hint → usage → model → all.
-	leftW := lipgloss.Width(leftSide)
-	middleW := lipgloss.Width(middleSide)
-	rightW := lipgloss.Width(rightSide)
-
-	// Need at least 1 space gap between left+middle and right.
-	if leftW+middleW+rightW+1 > m.width {
-		// Drop middle section first (extensions/thinking status).
+	// Progressive truncation, in order: extension/thinking entries, then
+	// usage, then the model label, then the path.
+	fits := func(l, mid, r string) bool {
+		return lipgloss.Width(l)+lipgloss.Width(mid)+lipgloss.Width(r)+1 <= m.width
+	}
+	if !fits(leftSide, middleSide, rightSide) {
 		middleSide = ""
-		middleW = 0
 	}
-	if leftW+rightW+1 > m.width && len(rightParts) > 2 {
-		// Drop help hint first.
-		rightParts = rightParts[1:]
-		rightSide = strings.Join(rightParts, "  |  ")
-		rightW = lipgloss.Width(rightSide)
-	}
-	if leftW+rightW+1 > m.width && len(rightParts) > 1 {
-		// Drop usage (last) next, keep model label.
+	if !fits(leftSide, middleSide, rightSide) && len(rightParts) > 1 {
 		rightParts = rightParts[:len(rightParts)-1]
-		rightSide = strings.Join(rightParts, "  |  ")
-		rightW = lipgloss.Width(rightSide)
+		rightSide = strings.Join(rightParts, sep)
 	}
-	if leftW+rightW+1 > m.width {
+	if !fits(leftSide, middleSide, rightSide) {
+		leftSide = ""
+	}
+	if !fits(leftSide, middleSide, rightSide) {
 		rightSide = ""
-		rightW = 0
 	}
 
-	gap := max(m.width-leftW-middleW-rightW, 1)
+	gap := max(m.width-lipgloss.Width(leftSide)-lipgloss.Width(middleSide)-lipgloss.Width(rightSide), 1)
 	return leftSide + middleSide + strings.Repeat(" ", gap) + rightSide
 }
 
@@ -2923,34 +2952,38 @@ func (m *AppModel) cycleThinkingLevel() {
 	go func() { _ = prefs.SaveThinkingLevelPreference(next) }()
 }
 
-// renderSeparator renders the separator line with an optional queue/steer count badge.
+// renderSeparator renders the queue/steer announcement shown between the
+// transcript and the composer.
+//
+// There is deliberately no full-width rule here. The transcript and the
+// composer are already separated by the composer's own filled background and
+// by whitespace; drawing a horizontal line as well was the single heaviest
+// element on screen and carried no information. When there is nothing queued
+// or steering, this returns "" and costs no vertical space.
 func (m *AppModel) renderSeparator() string {
-	theme := style.GetTheme()
-	lineStyle := lipgloss.NewStyle().Foreground(theme.Border)
 	queueLen := len(m.queuedMessages)
 	steerLen := len(m.steeringMessages)
-
-	if steerLen > 0 || queueLen > 0 {
-		var parts []string
-		if steerLen > 0 {
-			parts = append(parts, lipgloss.NewStyle().
-				Foreground(theme.Warning).
-				Render(fmt.Sprintf("%d steering", steerLen)))
-		}
-		if queueLen > 0 {
-			parts = append(parts, lipgloss.NewStyle().
-				Foreground(theme.Secondary).
-				Render(fmt.Sprintf("%d queued", queueLen)))
-		}
-		badge := strings.Join(parts, " ")
-
-		// Fill the separator with dashes up to the badge.
-		dashWidth := max(m.width-lipgloss.Width(badge)-1, 0)
-		dashes := lineStyle.Render(repeatRune('─', dashWidth))
-		return dashes + " " + badge
+	if steerLen == 0 && queueLen == 0 {
+		return ""
 	}
 
-	return lineStyle.Render(repeatRune('─', m.width))
+	theme := style.GetTheme()
+	var parts []string
+	if steerLen > 0 {
+		parts = append(parts, lipgloss.NewStyle().
+			Foreground(theme.Warning).
+			Render(fmt.Sprintf("%d steering", steerLen)))
+	}
+	if queueLen > 0 {
+		parts = append(parts, lipgloss.NewStyle().
+			Foreground(theme.Secondary).
+			Render(fmt.Sprintf("%d queued", queueLen)))
+	}
+	badge := strings.Join(parts, " ")
+
+	// Right-align the badge so it reads as chrome rather than as content.
+	pad := max(m.width-lipgloss.Width(badge)-1, 1)
+	return strings.Repeat(" ", pad) + badge
 }
 
 // renderInput returns the input region content. If an editor interceptor
@@ -4022,13 +4055,14 @@ type pendingStreamChunk struct {
 // chromeCache holds the rendered layout chrome measured by distributeHeight()
 // for reuse by View() within the same frame.
 type chromeCache struct {
-	valid  bool
-	header string
-	footer string
-	above  string
-	below  string
-	queued string
-	input  string
+	valid    bool
+	header   string
+	footer   string
+	above    string
+	below    string
+	queued   string
+	activity string
+	input    string
 }
 
 // streamAppendFlushMsg fires when buffered stream chunks should be applied
@@ -4162,10 +4196,11 @@ func (m *AppModel) currentScrollbackBounds() (yOffset, viewportHeight int) {
 // Layout (line counts):
 //
 //	header         = measured dynamically (0 if not set)
-//	stream region  = total - header - separator(1) - widgets - queued(N*5) - input(measured) - widgets - statusBar(1) - footer
-//	separator      = 1 line
+//	stream region  = total - header - separator - widgets - queued - activity - input - widgets - statusBar - footer
+//	separator      = measured dynamically (0 when it renders nothing)
 //	above widgets  = measured dynamically
 //	queued msgs    = measured dynamically via lipgloss.Height()
+//	activity row   = 1 line while working, 0 when idle
 //	input region   = measured dynamically via lipgloss.Height()
 //	below widgets  = measured dynamically
 //	status bar     = 1 line (always present)
@@ -4173,9 +4208,13 @@ func (m *AppModel) currentScrollbackBounds() (yOffset, viewportHeight int) {
 func (m *AppModel) distributeHeight() {
 	vis := m.uiVis()
 
-	separatorLines := 1
-	if vis.HideSeparator {
-		separatorLines = 0
+	// The separator is measured rather than assumed: it collapses to nothing
+	// unless there are queued or steering messages to announce.
+	separatorLines := 0
+	if !vis.HideSeparator {
+		if sep := m.renderSeparator(); sep != "" {
+			separatorLines = lipgloss.Height(sep)
+		}
 	}
 	statusBarLines := 1
 	if vis.HideStatusBar {
@@ -4195,6 +4234,14 @@ func (m *AppModel) distributeHeight() {
 		m.chrome.queued = queuedView
 	}
 
+	// Measure the activity row so the scrollback shrinks by exactly one line
+	// when the agent starts working and grows back when it stops.
+	var activityLines int
+	if activityView := m.renderActivityRow(); activityView != "" {
+		activityLines = lipgloss.Height(activityView)
+		m.chrome.activity = activityView
+	}
+
 	// Propagate hint visibility before measuring input height.
 	// Hints are always hidden for a cleaner UI.
 	// agentBusy must match what View() sets, since the rendered input is
@@ -4208,7 +4255,7 @@ func (m *AppModel) distributeHeight() {
 	// don't rely on a fragile constant that drifts when styling changes.
 	// Use renderInput() which includes the editor interceptor's Render
 	// wrapper so the measured height matches what View() actually renders.
-	inputLines := 8 // fallback: marginTop(1)+textarea(4)+border-chrome(2)+marginBottom(1)
+	inputLines := 3 // fallback: composer bar padding(1) + one text row + padding(1)
 	if m.state == statePrompt && m.prompt != nil {
 		if rendered := m.prompt.Render(); rendered != "" {
 			inputLines = lipgloss.Height(rendered)
@@ -4258,7 +4305,7 @@ func (m *AppModel) distributeHeight() {
 		warningLines++
 	}
 
-	streamHeight := max(m.height-separatorLines-widgetLines-headerFooterLines-queuedLines-inputLines-statusBarLines-warningLines, 0)
+	streamHeight := max(m.height-separatorLines-widgetLines-headerFooterLines-queuedLines-activityLines-inputLines-statusBarLines-warningLines, 0)
 
 	// In alt screen mode, give the calculated height to ScrollList instead of stream.
 	// The stream component still exists but is embedded as the last item in scrollList.
@@ -4464,6 +4511,12 @@ func (m *AppModel) handleThemeCommand(args string) tea.Cmd {
 
 	m.renderer.UpdateTheme()
 	m.stream.UpdateTheme()
+	// The composer paints its own background, so it has to be repainted too
+	// or the bar keeps the previous theme's fill until restart.
+	if ic, ok := m.input.(*InputComponent); ok {
+		ic.UpdateTheme()
+	}
+	m.layoutDirty = true
 	m.printSystemMessage(fmt.Sprintf("Switched to theme: %s", args))
 	return nil
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -790,6 +790,10 @@ type AppModel struct {
 	// activity row can show elapsed time. Zero when idle.
 	turnStartedAt time.Time
 
+	// turnToolCount counts tool calls completed during the current turn, for
+	// the turn-completion receipt. Reset when a turn begins.
+	turnToolCount int
+
 	// mcpResourceReader is an optional callback to read MCP resources when
 	// processing @mcp:server:uri tokens at submit time. Set by the parent.
 	mcpResourceReader fileutil.MCPResourceReader
@@ -1087,21 +1091,28 @@ func (m *AppModel) AddStartupMessageToScrollList() {
 		return
 	}
 
-	// Add the ASCII logo at the very top.
-	logo := style.KitBanner()
-	logoMsg := NewStyledMessageItem(generateMessageID(), "logo", logo, logo)
-	m.messages = append(m.messages, logoMsg)
+	// The splash is one block: a gradient stripe carrying the wordmark, the
+	// active model, and an aligned list of what was loaded. Everything is
+	// built as plain lines first, then given the stripe, so the bar height
+	// always matches the content height.
+	theme := style.GetTheme()
+	labelStyle := lipgloss.NewStyle().Foreground(theme.VeryMuted)
+	valueStyle := lipgloss.NewStyle().Foreground(theme.Muted)
 
-	// Build key-value pairs for startup info.
-	ty := createTypography(style.GetTheme())
-	var pairs [][2]string
+	var content []string
+	content = append(content, lipgloss.NewStyle().Bold(true).Render("KIT"))
 
 	if m.providerName != "" && m.modelName != "" {
-		pairs = append(pairs, [2]string{"Model", fmt.Sprintf("%s (%s)", m.providerName, m.modelName)})
+		content = append(content, valueStyle.Render(m.providerName+" · "+m.modelName))
+	} else if m.modelName != "" {
+		content = append(content, valueStyle.Render(m.modelName))
 	}
 
+	// Build key-value pairs for startup info.
+	var pairs [][2]string
+
 	if m.loadingMessage != "" {
-		pairs = append(pairs, [2]string{"Status", m.loadingMessage})
+		pairs = append(pairs, [2]string{"status", m.loadingMessage})
 	}
 
 	// Context — loaded AGENTS.md files.
@@ -1110,7 +1121,7 @@ func (m *AppModel) AddStartupMessageToScrollList() {
 		if len(m.contextPaths) > 1 {
 			contextStr += fmt.Sprintf(" +%d more", len(m.contextPaths)-1)
 		}
-		pairs = append(pairs, [2]string{"Context", contextStr})
+		pairs = append(pairs, [2]string{"context", contextStr})
 	}
 
 	// Skills — listed by name.
@@ -1119,11 +1130,11 @@ func (m *AppModel) AddStartupMessageToScrollList() {
 		for i, si := range m.skillItems {
 			names[i] = si.Name
 		}
-		pairs = append(pairs, [2]string{"Skills", strings.Join(names, ", ")})
+		pairs = append(pairs, [2]string{"skills", strings.Join(names, ", ")})
 	}
 
-	// Extensions — listed by filename. Each extension shows its basename
-	// without the .go suffix, matching the [Skills] section's style.
+	// Extensions — listed by filename, with a tool count when they register
+	// tools. Falls back to a bare count if the CLI supplied no item list.
 	if len(m.extensionItems) > 0 {
 		names := make([]string, len(m.extensionItems))
 		for i, ei := range m.extensionItems {
@@ -1133,26 +1144,33 @@ func (m *AppModel) AddStartupMessageToScrollList() {
 		if m.extensionToolCount > 0 {
 			value += fmt.Sprintf(" (%d tools)", m.extensionToolCount)
 		}
-		pairs = append(pairs, [2]string{"Extensions", value})
+		pairs = append(pairs, [2]string{"extensions", value})
 	} else if m.extensionToolCount > 0 {
-		// Fallback: tool count only (extensions registered tools but the CLI
-		// did not provide ExtensionItems for some reason).
-		pairs = append(pairs, [2]string{"Extensions", fmt.Sprintf("%d tools", m.extensionToolCount)})
+		pairs = append(pairs, [2]string{"extensions", fmt.Sprintf("%d tools", m.extensionToolCount)})
 	}
 
 	// MCP tool count (only shown when > 0).
 	if m.mcpToolCount > 0 {
-		pairs = append(pairs, [2]string{"MCP", fmt.Sprintf("%d tools", m.mcpToolCount)})
+		pairs = append(pairs, [2]string{"mcp", fmt.Sprintf("%d tools", m.mcpToolCount)})
 	}
 
 	if len(pairs) > 0 {
-		rendered := ty.KVGroup(pairs)
-		rendered = styleMarginBottom1.Render(rendered)
-
-		// Add as a styled system message to ScrollList
-		msg := NewStyledMessageItem(generateMessageID(), "system", rendered, rendered)
-		m.messages = append(m.messages, msg)
+		// Align values into a column so the list scans vertically.
+		labelWidth := 0
+		for _, p := range pairs {
+			if w := lipgloss.Width(p[0]); w > labelWidth {
+				labelWidth = w
+			}
+		}
+		content = append(content, "")
+		for _, p := range pairs {
+			label := labelStyle.Render(p[0] + strings.Repeat(" ", labelWidth-lipgloss.Width(p[0])))
+			content = append(content, label+"  "+valueStyle.Render(p[1]))
+		}
 	}
+
+	splash := style.SplashBar(content, theme.Primary, theme.Accent)
+	m.messages = append(m.messages, NewStyledMessageItem(generateMessageID(), "logo", splash, splash))
 
 	// Add extension startup messages if any
 	if len(m.startupExtensionMessages) > 0 {
@@ -1198,6 +1216,7 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	defer func() {
 		if m.state == stateWorking && stateBefore != stateWorking {
 			m.turnStartedAt = time.Now()
+			m.turnToolCount = 0
 		} else if m.state != stateWorking && stateBefore == stateWorking {
 			m.turnStartedAt = time.Time{}
 		}
@@ -2127,6 +2146,7 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				streamMsg.MarkComplete()
 			}
 		}
+		m.printTurnReceipt(turnDone)
 		m.state = stateInput
 		m.canceling = false
 
@@ -2144,6 +2164,7 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				streamMsg.MarkComplete()
 			}
 		}
+		m.printTurnReceipt(turnCancelled)
 		m.state = stateInput
 		m.canceling = false
 
@@ -3305,6 +3326,8 @@ func (m *AppModel) printAssistantMessage(text string) {
 
 // printToolResult renders a tool result message into the ScrollList.
 func (m *AppModel) printToolResult(evt app.ToolResultEvent) {
+	m.turnToolCount++
+
 	// Render styled tool message using MessageRenderer
 	styledMsg := m.renderer.RenderToolMessage(evt.ToolName, evt.ToolArgs, evt.Result, evt.IsError)
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1100,18 +1100,16 @@ func (m *AppModel) AddStartupMessageToScrollList() {
 		return
 	}
 
-	// The splash is one block: a gradient stripe carrying the wordmark, the
-	// active model, and an aligned list of what was loaded. Everything is
-	// built as plain lines first, then given the stripe, so the bar height
-	// always matches the content height.
+	// The splash is one block: the wordmark, the active model, and an aligned
+	// list of what was loaded, indented to the shared content column.
 	theme := style.GetTheme()
 	labelStyle := lipgloss.NewStyle().Foreground(theme.VeryMuted)
 	valueStyle := lipgloss.NewStyle().Foreground(theme.Muted)
 
-	// The wordmark leads. SplashBar prefixes each line with 6 columns of
-	// stripe and gutter, so that is what the logo has to fit inside.
+	// The wordmark leads. The block is indented by ContentOffset, so that is
+	// what the logo has to fit inside.
 	var content []string
-	content = append(content, style.KitLogoLines(m.width-style.SplashGutterWidth)...)
+	content = append(content, style.KitLogoLines(m.width-style.ContentOffset)...)
 	content = append(content, "")
 
 	if m.providerName != "" && m.modelName != "" {
@@ -1181,7 +1179,7 @@ func (m *AppModel) AddStartupMessageToScrollList() {
 		}
 	}
 
-	splash := style.SplashBar(content, theme.Primary, theme.Accent)
+	splash := style.SplashBlock(content)
 	m.messages = append(m.messages, NewStyledMessageItem(generateMessageID(), "logo", splash, splash))
 
 	// Add extension startup messages if any

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -794,6 +794,12 @@ type AppModel struct {
 	// the turn-completion receipt. Reset when a turn begins.
 	turnToolCount int
 
+	// lastInputHeight is the composer height measured by the last
+	// distributeHeight. The composer grows and shrinks with its content, so
+	// this is compared after every input update to detect a size change that
+	// requires the transcript to be resized. See syncInputHeight.
+	lastInputHeight int
+
 	// mcpResourceReader is an optional callback to read MCP resources when
 	// processing @mcp:server:uri tokens at submit time. Set by the parent.
 	mcpResourceReader fileutil.MCPResourceReader
@@ -1703,6 +1709,7 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 							updated, cmd := m.input.Update(remapped)
 							m.input, _ = updated.(inputComponentIface)
 							cmds = append(cmds, cmd)
+							m.syncInputHeight()
 							intercepted = true
 						}
 						// If remap target is unrecognized, fall through to normal handling.
@@ -1731,6 +1738,9 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				updated, cmd := m.input.Update(msg)
 				m.input, _ = updated.(inputComponentIface)
 				cmds = append(cmds, cmd)
+				// The composer is dynamically sized, so a keystroke that wraps
+				// or unwraps a line changes how much room the transcript has.
+				m.syncInputHeight()
 			}
 		}
 
@@ -4293,6 +4303,9 @@ func (m *AppModel) distributeHeight() {
 			m.chrome.input = rendered
 		}
 	}
+	// Remember what the composer measured so syncInputHeight can detect the
+	// next time it grows or shrinks.
+	m.lastInputHeight = inputLines
 
 	// Measure widget heights.
 	var widgetLines int

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1099,8 +1099,11 @@ func (m *AppModel) AddStartupMessageToScrollList() {
 	labelStyle := lipgloss.NewStyle().Foreground(theme.VeryMuted)
 	valueStyle := lipgloss.NewStyle().Foreground(theme.Muted)
 
+	// The wordmark leads. SplashBar prefixes each line with 6 columns of
+	// stripe and gutter, so that is what the logo has to fit inside.
 	var content []string
-	content = append(content, lipgloss.NewStyle().Bold(true).Render("KIT"))
+	content = append(content, style.KitLogoLines(m.width-style.SplashGutterWidth)...)
+	content = append(content, "")
 
 	if m.providerName != "" && m.modelName != "" {
 		content = append(content, valueStyle.Render(m.providerName+" · "+m.modelName))

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -2706,22 +2706,15 @@ func (m *AppModel) View() tea.View {
 		parts = append(parts, scrollbackView)
 	}
 
-	// Add canceling warning between scrollback and separator
-	// (doesn't go inside scrollback viewport to avoid affecting scroll position)
+	// Confirmation prompts for destructive keys live in the activity row while
+	// the agent is working, since that row is already showing the interrupt
+	// affordance and is where the eye is. When idle there is no activity row,
+	// so the prompt gets its own line here instead.
 	theme := style.GetTheme()
-	if m.canceling {
+	if m.ctrlCPressedOnce && m.state != stateWorking {
 		warning := lipgloss.NewStyle().
 			Foreground(theme.Warning).
-			Bold(true).
-			Render("  ⚠ Press ESC again to cancel")
-		parts = append(parts, warning)
-	}
-
-	if m.ctrlCPressedOnce {
-		warning := lipgloss.NewStyle().
-			Foreground(theme.Warning).
-			Bold(true).
-			Render("  ⚠ Press Ctrl+C again to quit")
+			Render(strings.Repeat(" ", style.ContentOffset) + "ctrl+c again to quit")
 		parts = append(parts, warning)
 	}
 
@@ -4315,16 +4308,14 @@ func (m *AppModel) distributeHeight() {
 		m.chrome.footer = footerView
 	}
 
-	// Account for transient warning rows that View() injects between the
-	// scrollback and the separator. These flags are toggled by ESC/Ctrl+C
-	// handlers; without subtracting them here the joined view exceeds
-	// m.height by one line per active warning and the bottom of the screen
-	// gets silently clipped — which in turn invalidates scrollbackYOffset.
+	// Account for the transient confirmation row that View() injects between
+	// the scrollback and the composer. Without subtracting it here the joined
+	// view exceeds m.height and the bottom of the screen gets silently
+	// clipped — which in turn invalidates scrollbackYOffset. While working
+	// the confirmation lives in the activity row, which is measured
+	// separately, so it costs nothing extra here.
 	var warningLines int
-	if m.canceling {
-		warningLines++
-	}
-	if m.ctrlCPressedOnce {
+	if m.ctrlCPressedOnce && m.state != stateWorking {
 		warningLines++
 	}
 

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -112,6 +112,8 @@ func (s *stubStreamComponent) View() tea.View             { return tea.NewView("
 func (s *stubStreamComponent) Reset()                     { s.resetCalled++; s.renderedContent = "" }
 func (s *stubStreamComponent) GetRenderedContent() string { return s.renderedContent }
 func (s *stubStreamComponent) SpinnerView() string        { return "" }
+func (s *stubStreamComponent) ActivityDot() string        { return "" }
+func (s *stubStreamComponent) ActivityPhrase() string     { return "" }
 func (s *stubStreamComponent) SetThinkingVisible(bool)    {}
 func (s *stubStreamComponent) HasReasoning() bool         { return false }
 func (s *stubStreamComponent) UpdateTheme()               {}
@@ -520,12 +522,34 @@ func TestWindowResize_distributeHeight(t *testing.T) {
 	ctrl := &stubAppController{}
 	m, _, _ := newTestAppModel(ctrl)
 
-	// With height=30, scroll height = 30 - 1 (separator) - 8 (input) - 1 (statusBar) = 20
+	// With height=30: the separator collapses to 0 when nothing is queued,
+	// the stub input falls back to the 3-line composer estimate, the activity
+	// row is absent while idle, and the status bar is always 1 line.
+	// 30 - 0 - 3 - 0 - 1 = 26.
 	m = sendMsg(m, tea.WindowSizeMsg{Width: 80, Height: 30})
 	_ = m
 
-	if m.scrollList.height != 20 {
-		t.Fatalf("expected scroll list height=20, got %d", m.scrollList.height)
+	if m.scrollList.height != 26 {
+		t.Fatalf("expected scroll list height=26, got %d", m.scrollList.height)
+	}
+}
+
+// TestActivityRow_ReservesLineWhileWorking verifies the activity row costs
+// exactly one line of transcript while the agent is working, and none at rest.
+func TestActivityRow_ReservesLineWhileWorking(t *testing.T) {
+	ctrl := &stubAppController{}
+	m, _, _ := newTestAppModel(ctrl)
+	m = sendMsg(m, tea.WindowSizeMsg{Width: 80, Height: 30})
+
+	idleHeight := m.scrollList.height
+
+	m.state = stateWorking
+	m.layoutDirty = true
+	m.distributeHeight()
+
+	if got := m.scrollList.height; got != idleHeight-1 {
+		t.Fatalf("expected working height=%d (one line for the activity row), got %d",
+			idleHeight-1, got)
 	}
 }
 

--- a/internal/ui/popup_list.go
+++ b/internal/ui/popup_list.go
@@ -461,9 +461,9 @@ func (p *PopupList) Render() string {
 	footerHint := p.FooterHint
 	if footerHint == "" {
 		if innerW >= 50 {
-			footerHint = "↑↓ navigate • enter select • esc cancel • type to filter"
+			footerHint = "↑↓ navigate · ↵ select · esc cancel · type to filter"
 		} else if innerW >= 30 {
-			footerHint = "↑↓ nav • ↵ select • esc"
+			footerHint = "↑↓ nav · ↵ select · esc"
 		} else {
 			footerHint = "↑↓ ↵ esc"
 		}
@@ -473,11 +473,15 @@ func (p *PopupList) Render() string {
 		footerParts = append(footerParts, p.ExtraFooter)
 	}
 
+	// Clamp the footer to a single line. Custom hints are written for a wide
+	// popup, and lipgloss wraps rather than truncates, so an unclamped hint
+	// silently becomes a three-line paragraph at narrow widths — more visual
+	// weight than the list it describes.
 	footer := lipgloss.NewStyle().
 		Background(popupBg).
 		Foreground(theme.VeryMuted).
 		Italic(true).
-		Render(strings.Join(footerParts, "  "))
+		Render(truncateLine(strings.Join(footerParts, "  "), innerW))
 
 	return popupStyle.Render(content + "\n\n" + footer)
 }

--- a/internal/ui/render/blocks.go
+++ b/internal/ui/render/blocks.go
@@ -40,21 +40,8 @@ func AssistantBlock(content string, width int, theme style.Theme) string {
 	// content column rather than starting at the screen edge. Without this it
 	// sits two columns left of every other block and the margin reads ragged.
 	rendered := style.ToMarkdown(content, width-style.ContentOffset-1)
-	rendered = indentLines(rendered, style.ContentOffset)
+	rendered = style.Indent(rendered, style.ContentOffset)
 	return styleMarginBottom(theme, rendered)
-}
-
-// indentLines prefixes every line of s with n spaces. Lines that are empty
-// stay empty, so the indent never leaves trailing whitespace behind.
-func indentLines(s string, n int) string {
-	pad := strings.Repeat(" ", n)
-	lines := strings.Split(s, "\n")
-	for i, line := range lines {
-		if line != "" {
-			lines[i] = pad + line
-		}
-	}
-	return strings.Join(lines, "\n")
 }
 
 // ReasoningBlock renders a reasoning/thinking block with muted italic text.

--- a/internal/ui/render/blocks.go
+++ b/internal/ui/render/blocks.go
@@ -36,8 +36,25 @@ func AssistantBlock(content string, width int, theme style.Theme) string {
 		return ""
 	}
 
-	rendered := style.ToMarkdown(content, width-4)
+	// Assistant prose carries no marker, so it is indented to the shared
+	// content column rather than starting at the screen edge. Without this it
+	// sits two columns left of every other block and the margin reads ragged.
+	rendered := style.ToMarkdown(content, width-style.ContentOffset-1)
+	rendered = indentLines(rendered, style.ContentOffset)
 	return styleMarginBottom(theme, rendered)
+}
+
+// indentLines prefixes every line of s with n spaces. Lines that are empty
+// stay empty, so the indent never leaves trailing whitespace behind.
+func indentLines(s string, n int) string {
+	pad := strings.Repeat(" ", n)
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		if line != "" {
+			lines[i] = pad + line
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 // ReasoningBlock renders a reasoning/thinking block with muted italic text.

--- a/internal/ui/session_selector.go
+++ b/internal/ui/session_selector.go
@@ -109,7 +109,7 @@ func NewSessionSelector(cwd string, width, height int) *SessionSelectorComponent
 
 	ss.popup = NewPopupList("Resume Session", nil, width, height)
 	ss.popup.FullScreen = true
-	ss.popup.FooterHint = "↑↓ nav • ↵ open • esc cancel • tab scope • ^N named • d delete • type to search"
+	ss.popup.FooterHint = "↑↓ nav · ↵ open · esc cancel · tab scope · ^N named · d delete · type to search"
 	ss.popup.RenderItem = ss.renderEntry
 
 	ss.rebuild()
@@ -228,7 +228,7 @@ func (ss *SessionSelectorComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // View implements tea.Model.
 func (ss *SessionSelectorComponent) View() tea.View {
 	// Compose dynamic footer extras: scope + filter + (delete confirm).
-	extra := fmt.Sprintf("scope: %s • filter: %s", ss.scope, ss.filter)
+	extra := fmt.Sprintf("scope: %s · filter: %s", ss.scope, ss.filter)
 	if ss.confirmDelete >= 0 && ss.confirmDelete < len(ss.filtered) {
 		name := truncateRunes(sessionDisplayName(ss.filtered[ss.confirmDelete]), 30)
 		extra = fmt.Sprintf("delete %q? y/N", name)

--- a/internal/ui/spinner_tool_exec_test.go
+++ b/internal/ui/spinner_tool_exec_test.go
@@ -162,7 +162,8 @@ func TestSpinnerShowsToolNameDuringExecution(t *testing.T) {
 		ToolCallID: "call-1", ToolName: "bash", ToolArgs: `{"command":"ls"}`,
 	})
 	// Capture the tick cmd here so step 4 can drive a mid-execution tick.
-	_, tickCmd := sendMsgExec(m, app.ToolExecutionEvent{
+	var tickCmd tea.Cmd
+	m, tickCmd = sendMsgExec(m, app.ToolExecutionEvent{
 		ToolCallID: "call-1", ToolName: "bash", ToolArgs: `{"command":"ls"}`, IsStarting: true,
 	})
 

--- a/internal/ui/spinner_tool_exec_test.go
+++ b/internal/ui/spinner_tool_exec_test.go
@@ -93,9 +93,12 @@ func TestSpinnerShowsToolName_TextThenTool(t *testing.T) {
 	if !stream.spinning {
 		t.Fatalf("expected spinner restarted after flushStreamContent Reset + ToolExecutionEvent")
 	}
-	statusBar := m.renderStatusBar()
-	if !strings.Contains(statusBar, "bash") {
-		t.Fatalf("expected status bar to show 'bash' after text-then-tool flow, got: %q", statusBar)
+	// Live activity now renders in the activity row above the composer, not
+	// in the ambient status bar.
+	m.state = stateWorking
+	activity := m.renderActivityRow()
+	if !strings.Contains(activity, "Running") {
+		t.Fatalf("expected activity row to show the bash command after text-then-tool flow, got: %q", activity)
 	}
 
 	// Simulate a LONG-running bash: drive several spinner ticks and confirm
@@ -108,8 +111,8 @@ func TestSpinnerShowsToolName_TextThenTool(t *testing.T) {
 		if stream.spinnerFrame != frameBefore+1 {
 			t.Fatalf("tick %d: expected frame advance, got %d -> %d", i, frameBefore, stream.spinnerFrame)
 		}
-		if sb := m.renderStatusBar(); !strings.Contains(sb, "bash") {
-			t.Fatalf("tick %d: status bar lost 'bash' label mid-execution, got: %q", i, sb)
+		if row := m.renderActivityRow(); !strings.Contains(row, "Running") {
+			t.Fatalf("tick %d: activity row lost the bash phrase mid-execution, got: %q", i, row)
 		}
 	}
 }
@@ -130,10 +133,11 @@ func TestSpinnerShowsToolNameDuringExecution(t *testing.T) {
 		t.Fatalf("expected stream.spinning=true after SpinnerEvent{Show:true}")
 	}
 
-	// The status bar should already show the spinner frame.
-	statusBar := m.renderStatusBar()
-	if !strings.Contains(statusBar, "▪") {
-		t.Fatalf("expected spinner frame in status bar after step start, got: %q", statusBar)
+	// The activity row should already show the spinner frame.
+	m.state = stateWorking
+	activity := m.renderActivityRow()
+	if !strings.Contains(activity, "▪") {
+		t.Fatalf("expected spinner frame in activity row after step start, got: %q", activity)
 	}
 
 	// 2. Drive one spinner tick to confirm the tick loop is forwarded through
@@ -162,11 +166,11 @@ func TestSpinnerShowsToolNameDuringExecution(t *testing.T) {
 		ToolCallID: "call-1", ToolName: "bash", ToolArgs: `{"command":"ls"}`, IsStarting: true,
 	})
 
-	// THE CORE ASSERTION: while bash is "running", the status bar must visibly
-	// show the tool name so the user has an indication the tool is executing.
-	statusBar = m.renderStatusBar()
-	if !strings.Contains(statusBar, "bash") {
-		t.Fatalf("expected status bar to show 'bash' while tool is executing, got: %q", statusBar)
+	// THE CORE ASSERTION: while bash is "running", the activity row must
+	// visibly describe the work so the user knows the tool is executing.
+	activity = m.renderActivityRow()
+	if !strings.Contains(activity, "Running ls") {
+		t.Fatalf("expected activity row to show the running command, got: %q", activity)
 	}
 
 	// 4. Simulate the spinner tick firing mid-execution (bash takes time).
@@ -184,9 +188,10 @@ func TestSpinnerShowsToolNameDuringExecution(t *testing.T) {
 		midTick = streamSpinnerTickMsg{generation: stream.spinnerGeneration}
 	}
 	m, _ = sendMsgExec(m, midTick)
-	statusBar = m.renderStatusBar()
-	if !strings.Contains(statusBar, "bash") {
-		t.Fatalf("expected status bar to STILL show 'bash' after a mid-execution tick, got: %q", statusBar)
+	m.state = stateWorking
+	activity = m.renderActivityRow()
+	if !strings.Contains(activity, "Running ls") {
+		t.Fatalf("expected activity row to STILL show the command after a mid-execution tick, got: %q", activity)
 	}
 	if !stream.spinning {
 		t.Fatalf("expected spinner to still be spinning during tool execution")

--- a/internal/ui/stream.go
+++ b/internal/ui/stream.go
@@ -158,8 +158,8 @@ type StreamComponent struct {
 	// spinnerFrame is the current frame index.
 	spinnerFrame int
 
-	// activeTools maps ToolCallID -> display label for currently running tools.
-	activeTools map[string]string
+	// activeTools maps ToolCallID -> descriptor for currently running tools.
+	activeTools map[string]activeTool
 
 	// activeToolOrder preserves deterministic display order for active tools.
 	activeToolOrder []string
@@ -424,7 +424,7 @@ func (s *StreamComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if msg.IsStarting {
 			if s.activeTools == nil {
-				s.activeTools = make(map[string]string)
+				s.activeTools = make(map[string]activeTool)
 			}
 			if _, exists := s.activeTools[toolID]; !exists {
 				s.activeToolOrder = append(s.activeToolOrder, toolID)
@@ -433,7 +433,11 @@ func (s *StreamComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if msg.ToolName == "subagent" {
 				agentName = extractAgentNameFromArgs(msg.ToolArgs)
 			}
-			s.activeTools[toolID] = formatToolExecutionMessage(msg.ToolName, agentName)
+			s.activeTools[toolID] = activeTool{
+				name:      msg.ToolName,
+				args:      msg.ToolArgs,
+				agentName: agentName,
+			}
 			s.spinnerFrame = 0
 			if !s.spinning {
 				s.phase = streamPhaseActive
@@ -530,28 +534,50 @@ func (s *StreamComponent) HasReasoning() bool {
 
 // SpinnerView returns the rendered spinner line for the parent to embed in the
 // status bar. Returns "" when the spinner is not active.
+//
+// Deprecated: live activity now renders in the dedicated activity row above
+// the composer (see AppModel.renderActivityRow). This remains only for
+// embedders that still place a spinner in the status bar.
 func (s *StreamComponent) SpinnerView() string {
 	if !s.spinning {
 		return ""
 	}
-	frame := s.spinnerFrames[s.spinnerFrame%len(s.spinnerFrames)]
-	tools := s.activeToolDisplays()
-	if len(tools) == 0 {
-		return "  " + frame
-	}
-	theme := GetTheme()
-	msgStyle := lipgloss.NewStyle().
-		Foreground(theme.Text).
-		Italic(true)
+	return "  " + s.ActivityDot()
+}
 
-	// Format active tools list
-	var toolsMsg string
-	if len(tools) == 1 {
-		toolsMsg = tools[0]
-	} else {
-		toolsMsg = "Running: " + strings.Join(tools, ", ")
+// ActivityDot returns just the animated indicator glyph, without any label.
+// Returns "" when the spinner is not running.
+func (s *StreamComponent) ActivityDot() string {
+	if !s.spinning {
+		return ""
 	}
-	return "  " + frame + " " + msgStyle.Render(toolsMsg)
+	return s.spinnerFrames[s.spinnerFrame%len(s.spinnerFrames)]
+}
+
+// ActivityPhrase returns a present-tense description of what the agent is
+// currently doing, for the activity row. Concurrent tool calls collapse to a
+// count so the row stays a single line; a turn with no tool in flight reports
+// that the model is thinking.
+func (s *StreamComponent) ActivityPhrase() string {
+	tools := s.activeToolList()
+	switch len(tools) {
+	case 0:
+		return "Thinking"
+	case 1:
+		t := tools[0]
+		if t.name == "subagent" && t.agentName != "" {
+			return "Delegating to " + t.agentName
+		}
+		return activityVerb(t.name, t.args)
+	default:
+		return fmt.Sprintf("Running %d tools", len(tools))
+	}
+}
+
+// IsSpinning reports whether the stream is currently animating, i.e. whether
+// there is live activity worth showing.
+func (s *StreamComponent) IsSpinning() bool {
+	return s.spinning
 }
 
 // renderStreamingText renders the accumulated streaming text as a live assistant
@@ -568,14 +594,24 @@ func (s *StreamComponent) renderStreamingText(text string) string {
 	return msg.Content
 }
 
-func (s *StreamComponent) activeToolDisplays() []string {
+// activeTool describes a tool call that is currently in flight. The raw
+// arguments are retained so the activity row can render a specific,
+// present-tense phrase ("Reading internal/ui/model.go") rather than a bare
+// tool name.
+type activeTool struct {
+	name      string
+	args      string
+	agentName string
+}
+
+func (s *StreamComponent) activeToolList() []activeTool {
 	if len(s.activeTools) == 0 {
 		return nil
 	}
-	out := make([]string, 0, len(s.activeToolOrder))
+	out := make([]activeTool, 0, len(s.activeToolOrder))
 	for _, id := range s.activeToolOrder {
-		if display, ok := s.activeTools[id]; ok {
-			out = append(out, display)
+		if t, ok := s.activeTools[id]; ok {
+			out = append(out, t)
 		}
 	}
 	return out
@@ -632,15 +668,6 @@ func extractAgentNameFromArgs(toolArgs string) string {
 		return sanitizeAgentName(agent)
 	}
 	return ""
-}
-
-// formatToolExecutionMessage creates a descriptive spinner message for tool execution.
-// For subagents, includes the agent type in parentheses (e.g., "subagent (explore)").
-func formatToolExecutionMessage(toolName, agentName string) string {
-	if toolName == "subagent" && agentName != "" {
-		return fmt.Sprintf("subagent (%s)", agentName)
-	}
-	return toolName
 }
 
 // UpdateTheme refreshes the component's typography instance and spinner

--- a/internal/ui/style/enhanced.go
+++ b/internal/ui/style/enhanced.go
@@ -388,18 +388,6 @@ func GutterBorder() lipgloss.Border {
 	}
 }
 
-// Gutter prefixes every line of s with a colored gutter glyph and a single
-// space. Unlike a lipgloss border it does not re-wrap or re-measure the
-// content, so it is safe to apply to text that is already laid out.
-func Gutter(s string, c color.Color) string {
-	bar := lipgloss.NewStyle().Foreground(c).Render(GutterGlyph)
-	lines := strings.Split(s, "\n")
-	for i, line := range lines {
-		lines[i] = bar + " " + line
-	}
-	return strings.Join(lines, "\n")
-}
-
 // --------------------------------------------------------------------------
 // Splash
 // --------------------------------------------------------------------------

--- a/internal/ui/style/enhanced.go
+++ b/internal/ui/style/enhanced.go
@@ -156,6 +156,11 @@ type Theme struct {
 	GutterBg color.Color // Line-number gutter background
 	WriteBg  color.Color // Green-tinted bg for Write tool content
 
+	// InputBg fills the composer bar. It is a shade off the terminal
+	// background — enough to read as a distinct surface, not enough to
+	// compete with message content for attention.
+	InputBg color.Color
+
 	// Markdown rendering and syntax highlighting colors
 	Markdown MarkdownThemeColors
 }
@@ -193,6 +198,9 @@ func DefaultTheme() Theme {
 		CodeBg:   AdaptiveColor("#E8E8E8", "#161616"), // Matches DiffEqualBg
 		GutterBg: AdaptiveColor("#E0E0E0", "#111111"), // Slightly darker
 		WriteBg:  AdaptiveColor("#F0E8D0", "#2A2410"), // Warm amber tint
+
+		// Composer surface — one step off the terminal background.
+		InputBg: AdaptiveColor("#E6E6E6", "#141414"),
 
 		// Markdown & syntax highlighting — all warm tones
 		Markdown: MarkdownThemeColors{

--- a/internal/ui/style/enhanced.go
+++ b/internal/ui/style/enhanced.go
@@ -282,9 +282,11 @@ func ApplyGradient(text string, colorA, colorB color.Color) string {
 	return result.String()
 }
 
-// kitLogoArt is the KIT wordmark in block letters. Every line is exactly
-// kitLogoWidth columns wide, so the scanner bar beneath it lines up exactly
-// and the whole block can be placed at any left offset without re-centering.
+// kitLogoArt is the KIT wordmark in block letters. Lines are left-aligned and
+// not padded to a uniform width — trailing space would only be invisible
+// gradient — so the widest line (the top row and the scanner bar) sets the
+// block's footprint. The block can be placed at any left offset without
+// re-centering.
 var kitLogoArt = []string{
 	"██╗  ██╗ ██╗ ████████╗",
 	"██║ ██╔╝ ██║ ╚══██╔══╝",
@@ -292,11 +294,13 @@ var kitLogoArt = []string{
 	"██╔═██╗  ██║    ██║",
 	"██║  ██╗ ██║    ██║",
 	"╚═╝  ╚═╝ ╚═╝    ╚═╝",
-	// KITT's scanner bar, sized to match the wordmark above it.
+	// KITT's scanner bar, sized to the wordmark's widest row.
 	"░░ ▒▒ ▓▓ ████ ▓▓ ▒▒ ░░",
 }
 
-// kitLogoWidth is the column width of every line in kitLogoArt.
+// kitLogoWidth is the width of the widest line in kitLogoArt, i.e. the number
+// of columns the block needs to render without wrapping. KitLogoLines falls
+// back to a plain wordmark below this width.
 const kitLogoWidth = 22
 
 // KitLogoLines returns the KIT wordmark as gradient-colored lines, sized for a

--- a/internal/ui/style/enhanced.go
+++ b/internal/ui/style/enhanced.go
@@ -428,6 +428,8 @@ func SplashBar(lines []string, from, to color.Color) string {
 	}
 
 	var b strings.Builder
+	// The gap between stripe and text is constant, so build it once.
+	gap := strings.Repeat(" ", ContentOffset-1)
 	for i, line := range lines {
 		if i > 0 {
 			b.WriteString("\n")
@@ -439,7 +441,9 @@ func SplashBar(lines []string, from, to color.Color) string {
 		bar := lipgloss.NewStyle().
 			Foreground(interpolateColor(from, to, pos)).
 			Render("█")
-		b.WriteString(bar + strings.Repeat(" ", ContentOffset-1) + line)
+		b.WriteString(bar)
+		b.WriteString(gap)
+		b.WriteString(line)
 	}
 	return b.String()
 }

--- a/internal/ui/style/enhanced.go
+++ b/internal/ui/style/enhanced.go
@@ -297,3 +297,85 @@ func KitBanner() string {
 	}
 	return result.String()
 }
+
+// --------------------------------------------------------------------------
+// Gutter
+// --------------------------------------------------------------------------
+
+// GutterGlyph is the single character used to mark a block's left edge
+// throughout the UI: user messages, alerts, permission prompts and any other
+// element that needs to be visually attributed.
+//
+// One glyph, colored by role, replaces what used to be three competing
+// conventions (a thick ┃ for user messages, a light │ for alerts, and bare
+// indentation for tool bodies). A half-block reads as a deliberate stripe at
+// any font weight, where box-drawing characters vary between terminals and
+// invite the eye to look for a matching corner that never comes.
+const GutterGlyph = "▌"
+
+// GutterBorder returns a lipgloss border consisting only of a left edge drawn
+// with GutterGlyph. Callers enable just the left side; the remaining fields
+// exist because lipgloss requires a complete Border value.
+func GutterBorder() lipgloss.Border {
+	return lipgloss.Border{
+		Left:        GutterGlyph,
+		Right:       "",
+		Top:         "",
+		Bottom:      "",
+		TopLeft:     "",
+		TopRight:    "",
+		BottomLeft:  "",
+		BottomRight: "",
+	}
+}
+
+// Gutter prefixes every line of s with a colored gutter glyph and a single
+// space. Unlike a lipgloss border it does not re-wrap or re-measure the
+// content, so it is safe to apply to text that is already laid out.
+func Gutter(s string, c color.Color) string {
+	bar := lipgloss.NewStyle().Foreground(c).Render(GutterGlyph)
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = bar + " " + line
+	}
+	return strings.Join(lines, "\n")
+}
+
+// --------------------------------------------------------------------------
+// Splash
+// --------------------------------------------------------------------------
+
+// SplashBar renders a gradient stripe down the left of a block of content
+// lines, in the manner of a magazine pull-quote:
+//
+//	█   KIT
+//	█   anthropic · claude-opus-5
+//	█
+//	█   context   ~/project/AGENTS.md
+//	█   skills    btca-cli, kit-extensions
+//
+// The stripe scales to the number of content lines, so the banner costs
+// exactly as many rows as it has something to say — unlike block-letter ASCII
+// art, whose height is fixed no matter how little information accompanies it.
+// It also adapts to narrow terminals, where wide ASCII art simply wraps.
+func SplashBar(lines []string, from, to color.Color) string {
+	if len(lines) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	for i, line := range lines {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		pos := 0.0
+		if len(lines) > 1 {
+			pos = float64(i) / float64(len(lines)-1)
+		}
+		bar := lipgloss.NewStyle().
+			Foreground(interpolateColor(from, to, pos)).
+			Render("█")
+		b.WriteString("  " + bar + "   " + line)
+	}
+	return b.String()
+}

--- a/internal/ui/style/enhanced.go
+++ b/internal/ui/style/enhanced.go
@@ -404,48 +404,40 @@ func Gutter(s string, c color.Color) string {
 // Splash
 // --------------------------------------------------------------------------
 
-// SplashBar renders a gradient stripe down the left of a block of content
-// lines, in the manner of a magazine pull-quote:
+// SplashBlock renders the startup splash: content lines indented to the shared
+// content column, with no left stripe.
 //
-//	█   KIT
-//	█   anthropic · claude-opus-5
-//	█
-//	█   context   ~/project/AGENTS.md
-//	█   skills    btca-cli, kit-extensions
+//	KIT
+//	anthropic · claude-opus-5
 //
-// The stripe scales to the number of content lines, so the banner costs
-// exactly as many rows as it has something to say — unlike block-letter ASCII
-// art, whose height is fixed no matter how little information accompanies it.
-// It also adapts to narrow terminals, where wide ASCII art simply wraps.
-// SplashGutterWidth is the number of columns SplashBar consumes to the left of
-// its content. It matches ContentOffset so the splash stripe lines up with
-// every other gutter in the UI.
-const SplashGutterWidth = ContentOffset
-
-func SplashBar(lines []string, from, to color.Color) string {
+//	context   ~/project/AGENTS.md
+//	skills    btca-cli, kit-extensions
+//
+// The splash carries no gutter glyph because it is not attributed to anyone —
+// it is the application introducing itself, not a message from the user, the
+// assistant or a tool. A stripe here would compete with the wordmark it sits
+// beside and imply an authorship the block does not have.
+//
+// The block costs exactly as many rows as it has something to say, so a
+// session with no skills or extensions loaded produces a shorter splash.
+func SplashBlock(lines []string) string {
 	if len(lines) == 0 {
 		return ""
 	}
+	return Indent(strings.Join(lines, "\n"), ContentOffset)
+}
 
-	var b strings.Builder
-	// The gap between stripe and text is constant, so build it once.
-	gap := strings.Repeat(" ", ContentOffset-1)
+// Indent prefixes every non-empty line of s with n spaces. Empty lines are
+// left untouched so the indent never leaves trailing whitespace behind.
+func Indent(s string, n int) string {
+	pad := strings.Repeat(" ", n)
+	lines := strings.Split(s, "\n")
 	for i, line := range lines {
-		if i > 0 {
-			b.WriteString("\n")
+		if line != "" {
+			lines[i] = pad + line
 		}
-		pos := 0.0
-		if len(lines) > 1 {
-			pos = float64(i) / float64(len(lines)-1)
-		}
-		bar := lipgloss.NewStyle().
-			Foreground(interpolateColor(from, to, pos)).
-			Render("█")
-		b.WriteString(bar)
-		b.WriteString(gap)
-		b.WriteString(line)
 	}
-	return b.String()
+	return strings.Join(lines, "\n")
 }
 
 // --------------------------------------------------------------------------

--- a/internal/ui/style/enhanced.go
+++ b/internal/ui/style/enhanced.go
@@ -361,6 +361,17 @@ func KitBanner() string {
 // invite the eye to look for a matching corner that never comes.
 const GutterGlyph = "▌"
 
+// ContentOffset is the column at which every block's text begins.
+//
+// The UI keeps one left-edge contract: a marker (gutter glyph, tool bullet,
+// receipt check) occupies column 0, a single space follows, and text starts at
+// ContentOffset. Blocks with no marker — assistant prose — are indented to the
+// same column, so the transcript reads as one aligned text column with markers
+// hanging in the left margin. Anything that draws a left edge must honour this,
+// or the eye sees a ragged margin and reads it as misalignment rather than as
+// structure.
+const ContentOffset = 2
+
 // GutterBorder returns a lipgloss border consisting only of a left edge drawn
 // with GutterGlyph. Callers enable just the left side; the remaining fields
 // exist because lipgloss requires a complete Border value.
@@ -407,9 +418,9 @@ func Gutter(s string, c color.Color) string {
 // art, whose height is fixed no matter how little information accompanies it.
 // It also adapts to narrow terminals, where wide ASCII art simply wraps.
 // SplashGutterWidth is the number of columns SplashBar consumes to the left of
-// its content: two spaces, the stripe glyph, then three more spaces. Callers
-// subtract this from the terminal width when sizing content for the block.
-const SplashGutterWidth = 6
+// its content. It matches ContentOffset so the splash stripe lines up with
+// every other gutter in the UI.
+const SplashGutterWidth = ContentOffset
 
 func SplashBar(lines []string, from, to color.Color) string {
 	if len(lines) == 0 {
@@ -428,7 +439,7 @@ func SplashBar(lines []string, from, to color.Color) string {
 		bar := lipgloss.NewStyle().
 			Foreground(interpolateColor(from, to, pos)).
 			Render("█")
-		b.WriteString("  " + bar + "   " + line)
+		b.WriteString(bar + strings.Repeat(" ", ContentOffset-1) + line)
 	}
 	return b.String()
 }

--- a/internal/ui/style/enhanced.go
+++ b/internal/ui/style/enhanced.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
+	"github.com/alecthomas/chroma/v2"
+	"github.com/alecthomas/chroma/v2/styles"
 )
 
 // Enhanced styling utilities and theme definitions
@@ -42,6 +44,7 @@ func SetTheme(theme Theme) {
 	markdownTypographyCache = nil // invalidate cached renderer; colors may have changed
 	uiTypographyCache = nil       // invalidate cached block typography; colors may have changed
 	styleCache = nil              // invalidate cached styles; colors may have changed
+	syntaxStyleCache = nil        // invalidate cached chroma style; colors may have changed
 }
 
 // CachedStyles holds pre-built lipgloss styles that are reused across
@@ -167,15 +170,21 @@ type Theme struct {
 
 // DefaultTheme creates and returns the default KIT theme inspired by the
 // Knight Rider KITT aesthetic — scanner reds, amber dashboard glows, and a
-// dark cockpit. No blues or bright greens; everything stays in the warm
-// red/amber/gray family of KITT's instrument panel.
+// dark cockpit. Everything stays in the warm red/amber/gray family of KITT's
+// instrument panel, with two deliberate exceptions.
+//
+// Success and Error must never be mistaken for Warning or for the brand red,
+// because they carry opposite meanings and they appear in the same places (the
+// turn receipt, the activity row, tool markers). Success therefore leans
+// olive-green and Error leans crimson: both still warm, both unmistakably not
+// amber and not scanner red.
 func DefaultTheme() Theme {
 	return Theme{
 		Primary:     AdaptiveColor("#CC1100", "#FF2200"), // KITT scanner red
 		Secondary:   AdaptiveColor("#CC6600", "#FF8800"), // Amber dashboard glow
-		Success:     AdaptiveColor("#998800", "#CCAA00"), // Warm gold — system OK
+		Success:     AdaptiveColor("#5F7A1F", "#A3BE4C"), // Olive green — distinct from amber
 		Warning:     AdaptiveColor("#CC8800", "#FFB800"), // Amber caution light
-		Error:       AdaptiveColor("#CC0000", "#FF3333"), // Alert red
+		Error:       AdaptiveColor("#C21038", "#FF4466"), // Crimson — distinct from scanner red
 		Info:        AdaptiveColor("#BB6600", "#DD8833"), // Warm amber readout
 		Text:        AdaptiveColor("#1A1A1A", "#E0E0E0"), // Console text
 		Muted:       AdaptiveColor("#707070", "#808080"), // Dimmed readout
@@ -206,12 +215,12 @@ func DefaultTheme() Theme {
 		Markdown: MarkdownThemeColors{
 			Text:    AdaptiveColor("#1A1A1A", "#E0E0E0"), // Console text
 			Muted:   AdaptiveColor("#707070", "#808080"), // Dimmed readout
-			Heading: AdaptiveColor("#CC1100", "#FF4444"), // Scanner red accent
+			Heading: AdaptiveColor("#CC1100", "#FF2200"), // Scanner red, matching Primary
 			Emph:    AdaptiveColor("#CC8800", "#FFB800"), // Amber emphasis
 			Strong:  AdaptiveColor("#1A1A1A", "#E0E0E0"), // Bright text
 			Link:    AdaptiveColor("#CC4400", "#FF7744"), // Warm orange link
 			Code:    AdaptiveColor("#333333", "#CCCCCC"), // Inline code
-			Error:   AdaptiveColor("#CC0000", "#FF3333"), // Alert red
+			Error:   AdaptiveColor("#C21038", "#FF4466"), // Crimson, matching Theme.Error
 			Keyword: AdaptiveColor("#CC3300", "#FF6644"), // Orange-red keyword
 			String:  AdaptiveColor("#BB7700", "#DDAA33"), // Amber string
 			Number:  AdaptiveColor("#CC8800", "#FFB800"), // Amber number
@@ -273,8 +282,47 @@ func ApplyGradient(text string, colorA, colorB color.Color) string {
 	return result.String()
 }
 
+// kitLogoArt is the KIT wordmark in block letters. Every line is exactly
+// kitLogoWidth columns wide, so the scanner bar beneath it lines up exactly
+// and the whole block can be placed at any left offset without re-centering.
+var kitLogoArt = []string{
+	"██╗  ██╗ ██╗ ████████╗",
+	"██║ ██╔╝ ██║ ╚══██╔══╝",
+	"█████╔╝  ██║    ██║",
+	"██╔═██╗  ██║    ██║",
+	"██║  ██╗ ██║    ██║",
+	"╚═╝  ╚═╝ ╚═╝    ╚═╝",
+	// KITT's scanner bar, sized to match the wordmark above it.
+	"░░ ▒▒ ▓▓ ████ ▓▓ ▒▒ ░░",
+}
+
+// kitLogoWidth is the column width of every line in kitLogoArt.
+const kitLogoWidth = 22
+
+// KitLogoLines returns the KIT wordmark as gradient-colored lines, sized for a
+// block that will be rendered at the given content width.
+//
+// Fixed-width block art cannot wrap, so below the width it needs the wordmark
+// degrades to a plain bold "KIT" rather than spilling across the terminal.
+func KitLogoLines(contentWidth int) []string {
+	theme := GetTheme()
+	if contentWidth < kitLogoWidth {
+		return []string{lipgloss.NewStyle().Bold(true).Foreground(theme.Primary).Render("KIT")}
+	}
+
+	out := make([]string, 0, len(kitLogoArt))
+	for _, line := range kitLogoArt {
+		out = append(out, ApplyGradient(line, theme.Primary, theme.Accent))
+	}
+	return out
+}
+
 // KitBanner returns the KIT ASCII art title with KITT scanner lights,
 // rendered with a KITT red gradient.
+//
+// This is the banner used in `--help` output, where the art stands alone and
+// is centered by its own leading padding. The TUI splash uses KitLogoLines
+// instead, which is unpadded so it can sit inside a gutter-marked block.
 func KitBanner() string {
 	kittDark := lipgloss.Color("#8B0000")
 	kittBright := lipgloss.Color("#FF2200")
@@ -358,6 +406,11 @@ func Gutter(s string, c color.Color) string {
 // exactly as many rows as it has something to say — unlike block-letter ASCII
 // art, whose height is fixed no matter how little information accompanies it.
 // It also adapts to narrow terminals, where wide ASCII art simply wraps.
+// SplashGutterWidth is the number of columns SplashBar consumes to the left of
+// its content: two spaces, the stripe glyph, then three more spaces. Callers
+// subtract this from the terminal width when sizing content for the block.
+const SplashGutterWidth = 6
+
 func SplashBar(lines []string, from, to color.Color) string {
 	if len(lines) == 0 {
 		return ""
@@ -378,4 +431,68 @@ func SplashBar(lines []string, from, to color.Color) string {
 		b.WriteString("  " + bar + "   " + line)
 	}
 	return b.String()
+}
+
+// --------------------------------------------------------------------------
+// Syntax highlighting
+// --------------------------------------------------------------------------
+
+// syntaxStyleCache holds the chroma style derived from the active theme.
+// Building a chroma style allocates a map of token entries, so it must not
+// happen inside a per-frame render path. Invalidated by SetTheme.
+var syntaxStyleCache *chroma.Style
+
+// hexOf renders a color as a chroma-compatible "#rrggbb" string.
+func hexOf(c color.Color) string {
+	r, g, b, _ := c.RGBA()
+	return fmt.Sprintf("#%02x%02x%02x", uint8(r>>8), uint8(g>>8), uint8(b>>8))
+}
+
+// SyntaxStyle returns a chroma style built from the active theme's markdown
+// colors.
+//
+// Syntax highlighting used to be pinned to an external palette, which meant a
+// warm red/amber theme rendered code in blues, purples and greens — a second,
+// unrelated color scheme living inside the first. Deriving the style from the
+// theme keeps code blocks in the same family as everything around them, and
+// makes every user theme (and every custom theme file) apply to code as well.
+//
+// Token backgrounds are left unset so the containing lipgloss style controls
+// the fill; setting both produces visible seams at each token boundary.
+func SyntaxStyle() *chroma.Style {
+	if syntaxStyleCache != nil {
+		return syntaxStyleCache
+	}
+
+	md := GetTheme().Markdown
+	keyword := hexOf(md.Keyword)
+	str := hexOf(md.String)
+	number := hexOf(md.Number)
+	comment := hexOf(md.Comment)
+	text := hexOf(md.Text)
+	name := hexOf(md.Link)
+
+	builder := chroma.NewStyleBuilder("kit-theme")
+	builder.Add(chroma.Text, text)
+	builder.Add(chroma.Keyword, keyword+" bold")
+	builder.Add(chroma.KeywordType, keyword)
+	builder.Add(chroma.NameBuiltin, keyword)
+	builder.Add(chroma.NameClass, name+" bold")
+	builder.Add(chroma.NameFunction, name)
+	builder.Add(chroma.LiteralString, str)
+	builder.Add(chroma.LiteralNumber, number)
+	builder.Add(chroma.Comment, comment+" italic")
+	builder.Add(chroma.CommentPreproc, keyword)
+	builder.Add(chroma.Operator, text)
+	builder.Add(chroma.Punctuation, text)
+	builder.Add(chroma.GenericError, hexOf(GetTheme().Error))
+
+	built, err := builder.Build()
+	if err != nil {
+		// A malformed entry should degrade to no highlighting rather than
+		// take down a render.
+		built = styles.Fallback
+	}
+	syntaxStyleCache = built
+	return built
 }

--- a/internal/ui/style/palette_test.go
+++ b/internal/ui/style/palette_test.go
@@ -1,0 +1,104 @@
+package style
+
+import (
+	"github.com/alecthomas/chroma/v2"
+
+	"image/color"
+	"math"
+	"testing"
+)
+
+// rgb returns the 8-bit components of a color.
+func rgb(c color.Color) (float64, float64, float64) {
+	r, g, b, _ := c.RGBA()
+	return float64(r >> 8), float64(g >> 8), float64(b >> 8)
+}
+
+// distance returns the Euclidean distance between two colors in RGB space.
+// It is a crude perceptual proxy, but sufficient to catch the case this test
+// exists for: two semantic slots drifting close enough to be confusable.
+func distance(a, b color.Color) float64 {
+	ar, ag, ab := rgb(a)
+	br, bg, bb := rgb(b)
+	return math.Sqrt((ar-br)*(ar-br) + (ag-bg)*(ag-bg) + (ab-bb)*(ab-bb))
+}
+
+// TestSemanticColorsAreDistinguishable guards the pairs whose confusion would
+// actually mislead: an outcome must never look like a caution, and a failure
+// must never look like the brand.
+func TestSemanticColorsAreDistinguishable(t *testing.T) {
+	const minDistance = 60
+
+	theme := DefaultTheme()
+	pairs := []struct {
+		nameA, nameB string
+		a, b         color.Color
+	}{
+		{"Success", "Warning", theme.Success, theme.Warning},
+		{"Error", "Primary", theme.Error, theme.Primary},
+		{"Error", "Warning", theme.Error, theme.Warning},
+		{"Success", "Error", theme.Success, theme.Error},
+	}
+
+	for _, p := range pairs {
+		if d := distance(p.a, p.b); d < minDistance {
+			t.Errorf("%s and %s are too similar to tell apart (distance %.0f, want >= %d)",
+				p.nameA, p.nameB, d, minDistance)
+		}
+	}
+}
+
+// TestSyntaxStyleFollowsTheme verifies code highlighting is derived from the
+// active theme rather than a fixed external palette, and that switching
+// themes actually rebuilds it.
+func TestSyntaxStyleFollowsTheme(t *testing.T) {
+	SetTheme(DefaultTheme())
+	first := SyntaxStyle()
+
+	if first == nil {
+		t.Fatal("expected a syntax style")
+	}
+	// The keyword color must come from the theme, not from elsewhere.
+	wantKeyword := hexOf(DefaultTheme().Markdown.Keyword)
+	if got := first.Get(chromaKeyword()).Colour.String(); got != wantKeyword {
+		t.Errorf("keyword color = %s, want the theme's %s", got, wantKeyword)
+	}
+
+	// A theme change must invalidate the cache.
+	if err := ApplyThemeWithoutSave("nord"); err != nil {
+		t.Fatalf("ApplyThemeWithoutSave(nord): %v", err)
+	}
+	second := SyntaxStyle()
+	if second.Get(chromaKeyword()).Colour.String() == wantKeyword {
+		t.Error("syntax style did not change after switching themes")
+	}
+
+	// Restore so later tests see the default palette.
+	if err := ApplyThemeWithoutSave("kitt"); err != nil {
+		t.Fatalf("ApplyThemeWithoutSave(kitt): %v", err)
+	}
+	if SyntaxStyle().Get(chromaKeyword()).Colour.String() != wantKeyword {
+		t.Error("syntax style did not return to the default palette")
+	}
+}
+
+// TestThemeFieldsAreWired guards against semantic slots that exist in config
+// but drive no rendering. System and Tool were both settable and both dead.
+func TestThemeFieldsAreWired(t *testing.T) {
+	SetTheme(DefaultTheme())
+	theme := GetTheme()
+
+	if theme.System == nil {
+		t.Error("Theme.System must have a value; it colors system notices")
+	}
+	if theme.Tool == nil {
+		t.Error("Theme.Tool must have a value; it colors tool call names")
+	}
+	if theme.InputBg == nil {
+		t.Error("Theme.InputBg must have a value; it fills the composer bar")
+	}
+}
+
+// chromaKeyword returns the chroma token type for a keyword. It lives here so
+// the test does not need a chroma import at the top of the file.
+func chromaKeyword() chroma.TokenType { return chroma.Keyword }

--- a/internal/ui/style/palette_test.go
+++ b/internal/ui/style/palette_test.go
@@ -1,11 +1,11 @@
 package style
 
 import (
-	"github.com/alecthomas/chroma/v2"
-
 	"image/color"
 	"math"
 	"testing"
+
+	"github.com/alecthomas/chroma/v2"
 )
 
 // rgb returns the 8-bit components of a color.
@@ -60,7 +60,7 @@ func TestSyntaxStyleFollowsTheme(t *testing.T) {
 	}
 	// The keyword color must come from the theme, not from elsewhere.
 	wantKeyword := hexOf(DefaultTheme().Markdown.Keyword)
-	if got := first.Get(chromaKeyword()).Colour.String(); got != wantKeyword {
+	if got := first.Get(chroma.Keyword).Colour.String(); got != wantKeyword {
 		t.Errorf("keyword color = %s, want the theme's %s", got, wantKeyword)
 	}
 
@@ -69,7 +69,7 @@ func TestSyntaxStyleFollowsTheme(t *testing.T) {
 		t.Fatalf("ApplyThemeWithoutSave(nord): %v", err)
 	}
 	second := SyntaxStyle()
-	if second.Get(chromaKeyword()).Colour.String() == wantKeyword {
+	if second.Get(chroma.Keyword).Colour.String() == wantKeyword {
 		t.Error("syntax style did not change after switching themes")
 	}
 
@@ -77,7 +77,7 @@ func TestSyntaxStyleFollowsTheme(t *testing.T) {
 	if err := ApplyThemeWithoutSave("kitt"); err != nil {
 		t.Fatalf("ApplyThemeWithoutSave(kitt): %v", err)
 	}
-	if SyntaxStyle().Get(chromaKeyword()).Colour.String() != wantKeyword {
+	if SyntaxStyle().Get(chroma.Keyword).Colour.String() != wantKeyword {
 		t.Error("syntax style did not return to the default palette")
 	}
 }
@@ -98,7 +98,3 @@ func TestThemeFieldsAreWired(t *testing.T) {
 		t.Error("Theme.InputBg must have a value; it fills the composer bar")
 	}
 }
-
-// chromaKeyword returns the chroma token type for a keyword. It lives here so
-// the test does not need a chroma import at the top of the file.
-func chromaKeyword() chroma.TokenType { return chroma.Keyword }

--- a/internal/ui/style/styles.go
+++ b/internal/ui/style/styles.go
@@ -50,6 +50,9 @@ func GetUITypography() *herald.Typography {
 			Caution:   theme.Error,
 		}),
 		herald.WithCodeLineNumbers(true),
+		// Alerts use the same gutter glyph as every other attributed block, so
+		// the UI speaks one visual language instead of mixing bar weights.
+		herald.WithAlertBar(GutterGlyph),
 		// Customize alert labels
 		herald.WithAlertLabel(herald.AlertNote, "Info"),
 		herald.WithAlertLabel(herald.AlertTip, ""),

--- a/internal/ui/style/styles.go
+++ b/internal/ui/style/styles.go
@@ -43,7 +43,9 @@ func GetUITypography() *herald.Typography {
 			Base:      theme.CodeBg,
 		}),
 		herald.WithAlertPalette(herald.AlertPalette{
-			Note:      theme.Info,
+			// theme.System colors system notices, so a theme can distinguish
+			// the agent talking about itself from ordinary informational text.
+			Note:      theme.System,
 			Tip:       theme.Success,
 			Important: theme.Accent,
 			Warning:   theme.Warning,
@@ -85,33 +87,37 @@ func GetMarkdownTypography() *herald.Typography {
 		H5: lipgloss.NewStyle().Foreground(md.Heading).Bold(true),
 		H6: lipgloss.NewStyle().Foreground(md.Muted).Bold(true),
 
-		// Text blocks
-		Paragraph:  lipgloss.NewStyle().Foreground(md.Text),
+		// Body text carries no explicit foreground so it inherits whatever the
+		// user's terminal uses for normal text. Pinning it to a theme color
+		// overrides a deliberate color scheme and can land a near-invisible
+		// gray on an unusual background. Color is spent only where it carries
+		// meaning: headings, links, emphasis and semantic badges.
+		Paragraph:  lipgloss.NewStyle(),
 		Blockquote: lipgloss.NewStyle().Foreground(md.Muted).Italic(true),
 		CodeInline: lipgloss.NewStyle().Foreground(md.Code),
 		CodeBlock:  lipgloss.NewStyle().Foreground(md.Code),
 		HR:         lipgloss.NewStyle().Foreground(md.Muted),
 
 		// Lists
-		ListBullet: lipgloss.NewStyle().Foreground(md.Text),
-		ListItem:   lipgloss.NewStyle().Foreground(md.Text),
+		ListBullet: lipgloss.NewStyle().Foreground(md.Muted),
+		ListItem:   lipgloss.NewStyle(),
 
 		// Inline styles
-		Bold:          lipgloss.NewStyle().Foreground(md.Strong).Bold(true),
+		Bold:          lipgloss.NewStyle().Bold(true),
 		Italic:        lipgloss.NewStyle().Foreground(md.Emph).Italic(true),
 		Strikethrough: lipgloss.NewStyle().Foreground(md.Muted).Strikethrough(true),
 		Link:          lipgloss.NewStyle().Foreground(md.Link).Underline(true),
 
 		// Definition lists
-		DT: lipgloss.NewStyle().Foreground(md.Text).Bold(true),
+		DT: lipgloss.NewStyle().Bold(true),
 		DD: lipgloss.NewStyle().Foreground(md.Muted),
 
 		// Key-value
-		KVKey:   lipgloss.NewStyle().Foreground(md.Text).Bold(true),
-		KVValue: lipgloss.NewStyle().Foreground(md.Text),
+		KVKey:   lipgloss.NewStyle().Bold(true),
+		KVValue: lipgloss.NewStyle().Foreground(md.Muted),
 
 		// Badges/Tags - use semantic colors
-		Badge:        lipgloss.NewStyle().Foreground(md.Text).Bold(true),
+		Badge:        lipgloss.NewStyle().Bold(true),
 		SuccessBadge: lipgloss.NewStyle().Foreground(theme.Success).Bold(true),
 		WarningBadge: lipgloss.NewStyle().Foreground(theme.Warning).Bold(true),
 		ErrorBadge:   lipgloss.NewStyle().Foreground(theme.Error).Bold(true),

--- a/internal/ui/style/themes.go
+++ b/internal/ui/style/themes.go
@@ -55,6 +55,20 @@ func blendHex(base, tint string, amount float64) string {
 	return fmt.Sprintf("#%02x%02x%02x", r, g, b)
 }
 
+// deriveInputBg computes the composer surface from the theme background. The
+// tint is deliberately lighter than the code-block blend: the composer must
+// read as a distinct surface without becoming the brightest thing on screen.
+func deriveInputBg(bgPair [2]string) color.Color {
+	idx := 0
+	contrast := "#000000"
+	if isDarkBg {
+		idx = 1
+		contrast = "#ffffff"
+	}
+	shade := blendHex(bgPair[idx], contrast, 0.04)
+	return AdaptiveColor(shade, shade)
+}
+
 // deriveDiffBg computes diff / code background colors from the theme's
 // background, success, and error hex pairs. Returns an adaptive color for each
 // diff element. The tint amounts are tuned for subtle differentiation.
@@ -167,6 +181,7 @@ func makeTheme(p presetColors) Theme {
 	// Derive diff/code backgrounds from the theme's own palette.
 	t.DiffInsertBg, t.DiffDeleteBg, t.DiffEqualBg, t.DiffMissingBg,
 		t.CodeBg, t.GutterBg, t.WriteBg = deriveDiffBg(p.background, p.success, p.error_)
+	t.InputBg = deriveInputBg(p.background)
 	// Markdown colors.
 	t.Markdown = MarkdownThemeColors{
 		Text:    t.Text,
@@ -626,6 +641,7 @@ type themeFileConfig struct {
 	CodeBg        adaptiveColorPair `json:"code-bg,omitzero" yaml:"code-bg,omitempty"`
 	GutterBg      adaptiveColorPair `json:"gutter-bg,omitzero" yaml:"gutter-bg,omitempty"`
 	WriteBg       adaptiveColorPair `json:"write-bg,omitzero" yaml:"write-bg,omitempty"`
+	InputBg       adaptiveColorPair `json:"input-bg,omitzero" yaml:"input-bg,omitempty"`
 
 	Markdown struct {
 		Text    adaptiveColorPair `json:"text,omitzero" yaml:"text,omitempty"`
@@ -718,6 +734,7 @@ func fileConfigToTheme(cfg themeFileConfig) Theme {
 		CodeBg:        cfg.CodeBg.resolve(derivedCodeBg),
 		GutterBg:      cfg.GutterBg.resolve(derivedGutterBg),
 		WriteBg:       cfg.WriteBg.resolve(derivedWriteBg),
+		InputBg:       cfg.InputBg.resolve(deriveInputBg(bgPair)),
 
 		Markdown: MarkdownThemeColors{
 			Text:    cfg.Markdown.Text.resolve(def.Markdown.Text),

--- a/internal/ui/tool_renderers.go
+++ b/internal/ui/tool_renderers.go
@@ -403,7 +403,7 @@ func renderFindBody(toolResult string, width int) string {
 		if total == 1 {
 			count = "1 result"
 		}
-		return count + " • " + fmt.Sprintf("%d more", hidden)
+		return count + " · " + fmt.Sprintf("%d more", hidden)
 	})
 }
 
@@ -415,7 +415,7 @@ func renderGrepBody(toolResult string, width int) string {
 		if total == 1 {
 			count = "1 match"
 		}
-		return count + " • " + fmt.Sprintf("%d more", hidden)
+		return count + " · " + fmt.Sprintf("%d more", hidden)
 	})
 }
 
@@ -544,7 +544,7 @@ func renderReadBody(toolArgs, toolResult string, width int) string {
 		captionParts = append(captionParts, fmt.Sprintf("offset=%d to continue", nextOffset))
 	}
 
-	caption := strings.Join(captionParts, " • ")
+	caption := strings.Join(captionParts, " · ")
 
 	// Use Figure with caption below content (default behavior)
 	// Apply theme to ensure caption is positioned below
@@ -723,7 +723,7 @@ func renderBashBody(toolArgs, toolResult string, width int) string {
 			FigureCaption:         lipgloss.NewStyle().Foreground(theme.Muted),
 			FigureCaptionPosition: herald.CaptionBottom,
 		}))
-		caption := strings.Join(captionParts, " • ")
+		caption := strings.Join(captionParts, " · ")
 		result := ty.Figure(content, caption)
 
 		// Indent entire block (content + caption) to match other tools

--- a/internal/ui/tool_renderers.go
+++ b/internal/ui/tool_renderers.go
@@ -10,10 +10,8 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
-	"github.com/alecthomas/chroma/v2"
 	"github.com/alecthomas/chroma/v2/formatters"
 	"github.com/alecthomas/chroma/v2/lexers"
-	"github.com/alecthomas/chroma/v2/styles"
 	udiff "github.com/aymanbagabas/go-udiff"
 	xansi "github.com/charmbracelet/x/ansi"
 	"github.com/indaco/herald"
@@ -767,24 +765,10 @@ func syntaxHighlight(source, fileName string) string {
 		return source
 	}
 
-	// Pick style matching our UI theme
-	styleName := "catppuccin-mocha"
-	if !IsDarkBackground() {
-		styleName = "catppuccin-latte"
-	}
-	baseStyle := styles.Get(styleName)
-	if baseStyle == nil {
-		baseStyle = styles.Fallback
-	}
-
-	// Clear token backgrounds so the containing lipgloss style controls bg.
-	style, err := baseStyle.Builder().Transform(func(entry chroma.StyleEntry) chroma.StyleEntry {
-		entry.Background = 0
-		return entry
-	}).Build()
-	if err != nil {
-		style = baseStyle
-	}
+	// Build the highlighting palette from the active theme so code sits in
+	// the same color family as the UI around it. Token backgrounds are unset
+	// there, letting the containing lipgloss style own the fill.
+	chromaStyle := SyntaxStyle()
 
 	iterator, err := lexer.Tokenise(nil, source)
 	if err != nil {
@@ -792,7 +776,7 @@ func syntaxHighlight(source, fileName string) string {
 	}
 
 	var buf bytes.Buffer
-	if err := formatter.Format(&buf, style, iterator); err != nil {
+	if err := formatter.Format(&buf, chromaStyle, iterator); err != nil {
 		return source
 	}
 

--- a/internal/ui/tree_selector.go
+++ b/internal/ui/tree_selector.go
@@ -119,7 +119,7 @@ func NewTreeSelectorForFork(tm *session.TreeManager, width, height int) *TreeSel
 func (ts *TreeSelectorComponent) initPopup() {
 	ts.popup = NewPopupList("Session Tree", nil, ts.width, ts.height)
 	ts.popup.FullScreen = true
-	ts.popup.FooterHint = "↑↓ nav • ←→ page • ↵ select • esc cancel • ^O filter • type to search"
+	ts.popup.FooterHint = "↑↓ nav · ←→ page · ↵ select · esc cancel · ^O filter · type to search"
 	ts.popup.RenderItem = ts.renderNode
 }
 

--- a/internal/ui/usage_tracker.go
+++ b/internal/ui/usage_tracker.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"charm.land/lipgloss/v2"
@@ -219,38 +220,38 @@ func (ut *UsageTracker) RenderUsageInfo() string {
 
 		percentageStr = baseStyle.
 			Foreground(percentageColor).
-			Render(fmt.Sprintf(" (%.0f%%)", percentage))
+			Render(fmt.Sprintf(" %.0f%%", percentage))
 	}
 
-	// Format cost with appropriate styling
+	// Format cost. Two decimal places is the right resolution for a status
+	// bar; four implied a precision nobody reads at a glance. Sub-cent
+	// sessions collapse to a bare "$0" rather than a row of zeroes.
 	var costStr string
-	if ut.isOAuth {
+	switch {
+	case ut.isOAuth:
+		costStr = ""
+	case ut.sessionStats.TotalCost <= 0:
+		costStr = baseStyle.Foreground(theme.Muted).Render("$0")
+	case ut.sessionStats.TotalCost < 0.01:
+		costStr = baseStyle.Foreground(theme.Muted).Render("<$0.01")
+	default:
 		costStr = baseStyle.
-			Foreground(theme.Primary).
-			Render("$0.00")
-	} else {
-		costStr = baseStyle.
-			Foreground(theme.Primary).
-			Render(fmt.Sprintf("$%.4f", ut.sessionStats.TotalCost))
+			Foreground(theme.Muted).
+			Render(fmt.Sprintf("$%.2f", ut.sessionStats.TotalCost))
 	}
 
-	// Create styled components
-	tokensLabel := baseStyle.
-		Foreground(theme.Muted).
-		Render("Tokens: ")
-
+	// The token count is self-describing — a "Tokens:" label costs nine
+	// columns to say what the number already says. Values are joined with the
+	// same middle dot the rest of the status bar uses.
 	tokensValue := baseStyle.
-		Foreground(theme.Text).
-		Bold(true).
+		Foreground(theme.Muted).
 		Render(tokenStr)
 
-	costLabel := baseStyle.
-		Foreground(theme.Muted).
-		Render(" | Cost: ")
-
-	// Build the enhanced display (no trailing newline — callers control spacing).
-	return fmt.Sprintf("%s%s%s%s%s",
-		tokensLabel, tokensValue, percentageStr, costLabel, costStr)
+	parts := []string{tokensValue + percentageStr}
+	if costStr != "" {
+		parts = append(parts, costStr)
+	}
+	return strings.Join(parts, baseStyle.Foreground(theme.VeryMuted).Render(" · "))
 }
 
 // GetSessionStats returns a copy of the cumulative session statistics including

--- a/internal/ui/usage_tracker_render_test.go
+++ b/internal/ui/usage_tracker_render_test.go
@@ -90,19 +90,12 @@ func TestUsageTracker_RenderUsageInfo_StartupState(t *testing.T) {
 		t.Errorf("Expected non-empty output on startup, got empty string")
 	}
 
-	// Should show 0 tokens
-	if !strings.Contains(rendered, "0") {
-		t.Errorf("Expected a zero token count on startup, got: %s", rendered)
-	}
-
-	// Should NOT show percentage when tokens are 0
-	if strings.Contains(rendered, "%") {
-		t.Errorf("Expected no percentage on startup with 0 tokens, got: %s", rendered)
-	}
-
-	// A zero-cost session collapses to a bare "$0".
-	if !strings.Contains(rendered, "$0") {
-		t.Errorf("Expected '$0' on startup, got: %s", rendered)
+	// Startup renders the exact zero-state segment: a bare token count and a
+	// bare cost, no percentage. Matching the whole string rather than a loose
+	// "0" substring keeps the token count from being satisfied by the "0" in
+	// "$0" if it were to vanish.
+	if rendered != "0 · $0" {
+		t.Errorf("Expected startup render to be exactly '0 · $0', got: %q", rendered)
 	}
 
 	// Test startup state (no requests made yet) - OAuth
@@ -114,12 +107,10 @@ func TestUsageTracker_RenderUsageInfo_StartupState(t *testing.T) {
 		t.Errorf("Expected non-empty output on startup for OAuth, got empty string")
 	}
 
-	// Should show 0 tokens for OAuth, and no cost at all.
-	if !strings.Contains(oauthRendered, "0") {
-		t.Errorf("Expected a zero token count on startup for OAuth, got: %s", oauthRendered)
-	}
-	if strings.Contains(oauthRendered, "$") {
-		t.Errorf("Expected OAuth startup render to omit cost, got: %s", oauthRendered)
+	// OAuth omits cost entirely, so its zero state is exactly the bare token
+	// count.
+	if oauthRendered != "0" {
+		t.Errorf("Expected OAuth startup render to be exactly '0', got: %q", oauthRendered)
 	}
 }
 
@@ -145,8 +136,10 @@ func TestUsageTracker_RenderUsageInfo_UnreportedWarning(t *testing.T) {
 	if strings.Contains(defaultRender, "usage not reported") {
 		t.Fatalf("default state should NOT show unreported warning, got: %s", defaultRender)
 	}
-	if !strings.Contains(defaultRender, "0") {
-		t.Fatalf("default state should show a zero token count, got: %s", defaultRender)
+	// The zero state is the exact bare-token/bare-cost segment, not just a
+	// stray "0" that "$0" would also satisfy.
+	if defaultRender != "0 · $0" {
+		t.Fatalf("default state should render exactly '0 · $0', got: %q", defaultRender)
 	}
 
 	// After a turn where the provider reported nothing → warning appears.

--- a/internal/ui/usage_tracker_render_test.go
+++ b/internal/ui/usage_tracker_render_test.go
@@ -37,15 +37,16 @@ func TestUsageTracker_RenderUsageInfo_OAuth(t *testing.T) {
 
 	rendered := stripAnsi(oauthTracker.RenderUsageInfo())
 
-	// Should show tokens and percentage, but cost should show "$0.00"
-	if !strings.Contains(rendered, "Tokens: 2.0K") {
-		t.Errorf("Expected rendered output to contain 'Tokens: 2.0K', got: %s", rendered)
+	// The token count is unlabelled and OAuth sessions omit cost entirely,
+	// since there is no per-token charge to report.
+	if !strings.Contains(rendered, "2.0K") {
+		t.Errorf("Expected rendered output to contain '2.0K', got: %s", rendered)
 	}
-	if !strings.Contains(rendered, "(1%)") { // 2000/200000 = 1%
+	if !strings.Contains(rendered, "1%") { // 2000/200000 = 1%
 		t.Errorf("Expected rendered output to contain percentage, got: %s", rendered)
 	}
-	if !strings.Contains(rendered, "Cost: $0.00") {
-		t.Errorf("Expected rendered output to contain 'Cost: $0.00', got: %s", rendered)
+	if strings.Contains(rendered, "$") {
+		t.Errorf("Expected OAuth render to omit cost entirely, got: %s", rendered)
 	}
 
 	// Test regular API key rendering (should show actual cost)
@@ -55,15 +56,12 @@ func TestUsageTracker_RenderUsageInfo_OAuth(t *testing.T) {
 
 	regularRendered := stripAnsi(regularTracker.RenderUsageInfo())
 
-	// Should show tokens and actual cost
-	if !strings.Contains(regularRendered, "Tokens: 2.0K") {
-		t.Errorf("Expected regular rendered output to contain 'Tokens: 2.0K', got: %s", regularRendered)
+	// Should show tokens and actual cost, rounded to cents.
+	if !strings.Contains(regularRendered, "2.0K") {
+		t.Errorf("Expected regular rendered output to contain '2.0K', got: %s", regularRendered)
 	}
-	if strings.Contains(regularRendered, "Cost: $0.00") {
-		t.Errorf("Expected regular rendered output to NOT show $0.00, got: %s", regularRendered)
-	}
-	// Should show actual calculated cost (1500*3 + 500*15)/1000000 = 0.0120
-	if !strings.Contains(regularRendered, "Cost: $0.0120") { // Now showing 4 decimal places
+	// (1500*3 + 500*15)/1000000 = $0.0120 → "$0.01" at status-bar resolution.
+	if !strings.Contains(regularRendered, "$0.01") {
 		t.Errorf("Expected regular rendered output to show actual cost, got: %s", regularRendered)
 	}
 }
@@ -93,18 +91,18 @@ func TestUsageTracker_RenderUsageInfo_StartupState(t *testing.T) {
 	}
 
 	// Should show 0 tokens
-	if !strings.Contains(rendered, "Tokens: 0") {
-		t.Errorf("Expected 'Tokens: 0' on startup, got: %s", rendered)
+	if !strings.Contains(rendered, "0") {
+		t.Errorf("Expected a zero token count on startup, got: %s", rendered)
 	}
 
 	// Should NOT show percentage when tokens are 0
-	if strings.Contains(rendered, "(%") {
+	if strings.Contains(rendered, "%") {
 		t.Errorf("Expected no percentage on startup with 0 tokens, got: %s", rendered)
 	}
 
-	// Should show $0.0000 cost for regular API key
-	if !strings.Contains(rendered, "Cost: $0.0000") {
-		t.Errorf("Expected 'Cost: $0.0000' on startup, got: %s", rendered)
+	// A zero-cost session collapses to a bare "$0".
+	if !strings.Contains(rendered, "$0") {
+		t.Errorf("Expected '$0' on startup, got: %s", rendered)
 	}
 
 	// Test startup state (no requests made yet) - OAuth
@@ -116,14 +114,12 @@ func TestUsageTracker_RenderUsageInfo_StartupState(t *testing.T) {
 		t.Errorf("Expected non-empty output on startup for OAuth, got empty string")
 	}
 
-	// Should show 0 tokens for OAuth
-	if !strings.Contains(oauthRendered, "Tokens: 0") {
-		t.Errorf("Expected 'Tokens: 0' on startup for OAuth, got: %s", oauthRendered)
+	// Should show 0 tokens for OAuth, and no cost at all.
+	if !strings.Contains(oauthRendered, "0") {
+		t.Errorf("Expected a zero token count on startup for OAuth, got: %s", oauthRendered)
 	}
-
-	// Should show $0.00 cost for OAuth
-	if !strings.Contains(oauthRendered, "Cost: $0.00") {
-		t.Errorf("Expected 'Cost: $0.00' on startup for OAuth, got: %s", oauthRendered)
+	if strings.Contains(oauthRendered, "$") {
+		t.Errorf("Expected OAuth startup render to omit cost, got: %s", oauthRendered)
 	}
 }
 
@@ -149,8 +145,8 @@ func TestUsageTracker_RenderUsageInfo_UnreportedWarning(t *testing.T) {
 	if strings.Contains(defaultRender, "usage not reported") {
 		t.Fatalf("default state should NOT show unreported warning, got: %s", defaultRender)
 	}
-	if !strings.Contains(defaultRender, "Tokens: 0") {
-		t.Fatalf("default state should show 'Tokens: 0', got: %s", defaultRender)
+	if !strings.Contains(defaultRender, "0") {
+		t.Fatalf("default state should show a zero token count, got: %s", defaultRender)
 	}
 
 	// After a turn where the provider reported nothing → warning appears.
@@ -176,8 +172,8 @@ func TestUsageTracker_RenderUsageInfo_UnreportedWarning(t *testing.T) {
 	if strings.Contains(restored, "usage not reported") {
 		t.Fatalf("restored state should NOT show unreported warning, got: %s", restored)
 	}
-	if !strings.Contains(restored, "Tokens: 2.0K") {
-		t.Fatalf("restored state should show 'Tokens: 2.0K', got: %s", restored)
+	if !strings.Contains(restored, "2.0K") {
+		t.Fatalf("restored state should show '2.0K', got: %s", restored)
 	}
 
 	// Reset (new conversation) must clear the flag so a fresh session with


### PR DESCRIPTION
## Description

A focused pass over the TUI (`internal/ui/`) to make it read as more minimal and coherent, without dropping any of Kit's existing capabilities (22 themes, adaptive light/dark, image previews, the extension system).

The central change is giving **live activity its own row** directly above the composer. Previously the only feedback during a long-running tool call was a bare spinner wedged into the left of the status bar, competing with the model name, token count and cost — a 12-second `bash` call showed no elapsed time, no command, and no interrupt hint. Now:

```
 ▪▪▪▪▪▪▪▪ Running go test ./... · 12s              ↵ queue · esc interrupt
```

The row costs zero lines when idle and drops the key hint before it truncates the activity phrase. The status bar becomes ambient-only (cwd, branch, model, usage).

The rest of the branch removes visual clutter and unifies conventions that had drifted apart:

- **One gutter vocabulary.** Five competing left edges (`┃`, `│`, bare indent, none) collapse to a single `▌` glyph colored by role, and every block aligns on one content column. herald alerts join the same vocabulary via `WithAlertBar`.
- **Quieter tool output.** Routine tool calls get a dim `·`; `✓` is reserved for a single turn-completion receipt (`✓ Done · 3 tools · 12s`).
- **Dynamic composer.** Starts at one row and grows with content (was a fixed 8-line block), rendered as a filled bar instead of a bordered box.
- **Theme-derived syntax highlighting.** Code blocks were pinned to an external palette (blues/purples/greens) regardless of theme; they now derive from the active theme's colors and switch at runtime.
- **Palette hygiene.** Success/Warning and Error/Primary were near-indistinguishable despite carrying opposite meanings; they are now separated, with a test pinning the minimum distance. Two previously dead theme fields (`System`, `Tool`) are wired to real roles.

## Type of Change

- [ ] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [x] Refactor / UI polish (no change to external behavior or public API)
- [ ] Documentation update

## How Has This Been Tested

- `go test -race ./internal/... ./cmd/...` — green
- `go vet ./internal/... ./cmd/...` and `staticcheck ./internal/ui/...` — clean
- New tests cover the activity row, dynamic composer sizing, left-edge alignment, palette distinguishability, theme-derived syntax colors, and the confirmation-prompt / separator-glyph fixes. Each regression test was checked to fail against the pre-fix code.
- Verified interactively in tmux at multiple widths (narrow-terminal splash fallback, composer growth past the cap, `/theme` repaint, ESC/Ctrl+C confirmations).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (`go vet`, `staticcheck`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Information

**New files**

- `internal/ui/activity.go` — activity row, present-tense tool verbs, turn receipt, git-branch detection
- `internal/ui/activity_test.go`, `internal/ui/style/palette_test.go` — coverage for the above

**Notable changes**

- `internal/ui/model.go` — activity row + separator measured in `distributeHeight`; ambient status bar; full-width rules removed; single-source confirmation prompts
- `internal/ui/input.go` — dynamic-height filled-bar composer; submit hint folded into the placeholder
- `internal/ui/stream.go` — `ActivityDot` / `ActivityPhrase` accessors (deprecated `SpinnerView` retained)
- `internal/ui/style/{enhanced,styles,themes}.go` — gutter glyph, `ContentOffset`, `SplashBlock`, theme-derived `SyntaxStyle`, `InputBg`, palette fixes

**Backward compatibility**

- No public SDK (`pkg/kit/`) changes.
- The extension `HideInputHint` visibility flag is retained as a documented no-op (the hint line it controlled no longer exists), so existing extensions still compile and behave the same.
- `StreamComponent.SpinnerView()` is kept as a deprecated shim for embedders that still place a spinner in the status bar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a live activity row (elapsed time + context-aware cancel/quit hints) and updated it to reflect tool execution.
  * Added turn receipts for completed/cancelled/failed turns (with reduced noise for trivial turns).
  * Display current Git branch in the ambient status bar.
  * Added composer improvements (filled input bar, built-in “send” placeholder hint, theme-aware repainting).
* **Improvements**
  * Refreshed borders/spacing and aligned content to a consistent left offset; improved narrow-width wrapping/truncation for popups/footers.
  * Updated tool/user message indicators, usage display (tokens/percent/cost rules), and syntax highlighting based on theme.
* **Bug Fixes**
  * Reduced flicker/layout clipping, prevented duplicated prompts/hints, and corrected rendering for receipts/activity under errors and narrow layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->