### PR TITLE
feat(ui): add message navigation and composite overlays over the view

### DIFF
--- a/internal/ui/composite.go
+++ b/internal/ui/composite.go
@@ -1,0 +1,110 @@
+package ui
+
+import (
+	"image"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+// --------------------------------------------------------------------------
+// Overlay compositing
+// --------------------------------------------------------------------------
+
+// compositeOverlay draws a rendered box on top of a full-screen base view at
+// the given top-left cell coordinates and returns the merged frame.
+//
+// Compositing happens at the cell level via an ultraviolet ScreenBuffer: the
+// base is drawn first, then the box is drawn into its own sub-rectangle, so
+// only the cells the box actually covers are replaced. Content above, below,
+// and — critically — to the left and right of the box survives, with its ANSI
+// styling intact on both sides of the splice.
+//
+// The naive alternative (merging whole lines, preferring the overlay whenever
+// its line is non-blank) blanks the full width of every row the box occupies,
+// which is what made popups appear to punch a hole through the transcript.
+//
+// x and y are clamped so a box larger than the terminal is pinned to the top
+// left rather than drawn off-screen.
+func compositeOverlay(base, box string, x, y, termW, termH int) string {
+	if termW <= 0 || termH <= 0 {
+		return base
+	}
+	if strings.TrimSpace(box) == "" {
+		return base
+	}
+
+	box = trimTrailingBlankLines(box)
+	if box == "" {
+		return base
+	}
+
+	boxW := lipgloss.Width(box)
+	boxH := lipgloss.Height(box)
+
+	x = clamp(x, 0, max(termW-boxW, 0))
+	y = clamp(y, 0, max(termH-boxH, 0))
+
+	buf := uv.NewScreenBuffer(termW, termH)
+	uv.NewStyledString(base).Draw(&buf, image.Rect(0, 0, termW, termH))
+	uv.NewStyledString(box).Draw(&buf, image.Rect(x, y, x+boxW, y+boxH))
+
+	return buf.Render()
+}
+
+// compositeCentered draws a box centred over the base view.
+func compositeCentered(base, box string, termW, termH int) string {
+	if strings.TrimSpace(box) == "" {
+		return base
+	}
+	x := (termW - lipgloss.Width(box)) / 2
+	y := (termH - lipgloss.Height(box)) / 2
+	return compositeOverlay(base, box, x, y, termW, termH)
+}
+
+// compositeAnchored draws a box over the base view using one of the named
+// vertical anchors ("top-center", "bottom-center", or centred by default).
+// The box is always centred horizontally.
+func compositeAnchored(base, box, anchor string, termW, termH int) string {
+	if strings.TrimSpace(box) == "" {
+		return base
+	}
+
+	box = trimTrailingBlankLines(box)
+	boxH := lipgloss.Height(box)
+	x := (termW - lipgloss.Width(box)) / 2
+
+	var y int
+	switch anchor {
+	case "top-center":
+		// One blank row of breathing room above the box.
+		y = 1
+	case "bottom-center":
+		y = termH - boxH - 1
+	default:
+		y = (termH - boxH) / 2
+	}
+
+	return compositeOverlay(base, box, x, y, termW, termH)
+}
+
+// trimTrailingBlankLines drops trailing rows that consist only of plain
+// spaces.
+//
+// Such rows are invisible when a box is placed on an empty canvas, but the
+// compositor draws every cell it is given — so an unstyled padding row would
+// punch a blank band through the content behind the box. A row carrying an
+// escape sequence (e.g. a themed background) is deliberately kept: it is part
+// of the box's appearance, not stray padding.
+func trimTrailingBlankLines(s string) string {
+	lines := strings.Split(s, "\n")
+	end := len(lines)
+	for end > 0 && strings.TrimSpace(lines[end-1]) == "" {
+		end--
+	}
+	if end == len(lines) {
+		return s
+	}
+	return strings.Join(lines[:end], "\n")
+}

--- a/internal/ui/composite.go
+++ b/internal/ui/composite.go
@@ -58,6 +58,10 @@ func compositeCentered(base, box string, termW, termH int) string {
 	if strings.TrimSpace(box) == "" {
 		return base
 	}
+	// Trim before measuring: compositeOverlay trims internally, so centring
+	// on the untrimmed height would place the box using a taller size than
+	// the one actually drawn and shift it off true centre.
+	box = trimTrailingBlankLines(box)
 	x := (termW - lipgloss.Width(box)) / 2
 	y := (termH - lipgloss.Height(box)) / 2
 	return compositeOverlay(base, box, x, y, termW, termH)

--- a/internal/ui/composite_test.go
+++ b/internal/ui/composite_test.go
@@ -304,3 +304,32 @@ func TestOverlayDialog_LastLineReachable(t *testing.T) {
 		t.Errorf("last line unreachable at maximum scroll:\n%s", got)
 	}
 }
+
+// TestCompositeCentered_TrimsBeforeMeasuring guards a centring bug: because
+// compositeOverlay trims trailing blank rows internally, measuring the
+// untrimmed height here would position the box as if it were taller than the
+// one actually drawn, shifting it off true centre.
+func TestCompositeCentered_TrimsBeforeMeasuring(t *testing.T) {
+	const w, h = 21, 9
+	base := fullScreenBase(w, h, "x")
+
+	// Same visible box, one with unstyled padding rows below it.
+	plain := "abc"
+	padded := "abc\n   \n   "
+
+	rowOf := func(rendered string) int {
+		for i, line := range strings.Split(rendered, "\n") {
+			if strings.Contains(xansi.Strip(line), "abc") {
+				return i
+			}
+		}
+		return -1
+	}
+
+	want := rowOf(compositeCentered(base, plain, w, h))
+	got := rowOf(compositeCentered(base, padded, w, h))
+
+	if got != want {
+		t.Errorf("padded box centred at row %d, want %d (trailing padding shifted it)", got, want)
+	}
+}

--- a/internal/ui/composite_test.go
+++ b/internal/ui/composite_test.go
@@ -1,7 +1,10 @@
 package ui
 
 import (
+	"fmt"
 	"strings"
+
+	"charm.land/lipgloss/v2"
 	"testing"
 
 	xansi "github.com/charmbracelet/x/ansi"
@@ -210,5 +213,94 @@ func TestPopupList_RenderHasNoUnstyledTrailingRow(t *testing.T) {
 	}
 	if !strings.Contains(last, "╰") {
 		t.Errorf("expected the bottom border to be the last row, got %q", xansi.Strip(last))
+	}
+}
+
+// --------------------------------------------------------------------------
+// Overlay dialog body wrapping
+// --------------------------------------------------------------------------
+
+// longLineBody builds n lines that are each far wider than any dialog, the
+// shape grep and ls output take (path + line number + matched source).
+func longLineBody(n int) string {
+	lines := make([]string, n)
+	for i := range lines {
+		lines[i] = "internal/ui/some/deeply/nested/path/file.go:1234:\tfunc SomeReasonablyLongFunctionName(ctx context.Context) error {"
+	}
+	return strings.Join(lines, "\n")
+}
+
+// TestOverlayDialog_WrapsLongLinesWithinBudget guards the bug that made grep
+// and ls results unreadable: the box style wrapped over-long lines itself, so
+// one source line became several rows and the height budget was blown — a
+// 30-row terminal produced a 48-row dialog that overflowed the screen.
+func TestOverlayDialog_WrapsLongLinesWithinBudget(t *testing.T) {
+	for _, tc := range []struct{ termW, termH int }{
+		{120, 30}, {80, 24}, {200, 50}, {60, 20},
+	} {
+		o := newOverlayDialog("Tool Result", longLineBody(60), false, "", "", 0, 0, "center", nil, tc.termW, tc.termH)
+
+		h := lipgloss.Height(o.Render())
+		if want := tc.termH * 80 / 100; h > want {
+			t.Errorf("%dx%d: height %d exceeds the %d budget", tc.termW, tc.termH, h, want)
+		}
+		if h > tc.termH {
+			t.Errorf("%dx%d: height %d overflows the terminal", tc.termW, tc.termH, h)
+		}
+	}
+}
+
+// TestOverlayDialog_NoRowExceedsBoxWidth verifies wrapping happens before
+// rendering, so no row is clipped by the compositor.
+func TestOverlayDialog_NoRowExceedsBoxWidth(t *testing.T) {
+	o := newOverlayDialog("Tool Result", longLineBody(40), false, "", "", 0, 0, "center", nil, 100, 30)
+
+	out := o.Render()
+	boxW := lipgloss.Width(out)
+	for i, line := range strings.Split(out, "\n") {
+		if got := xansi.StringWidth(line); got != boxW {
+			t.Errorf("row %d width %d != box width %d: %q", i, got, boxW, xansi.Strip(line))
+		}
+	}
+}
+
+// TestOverlayDialog_ScrollCountsDisplayRows verifies the "of N lines" counter
+// reports rows the reader actually scrolls through. Counting unwrapped source
+// lines made the indicator disagree with the content and left the tail of a
+// long result unreachable.
+func TestOverlayDialog_ScrollCountsDisplayRows(t *testing.T) {
+	const sourceLines = 60
+	o := newOverlayDialog("Tool Result", longLineBody(sourceLines), false, "", "", 0, 0, "center", nil, 100, 30)
+	o.Render()
+
+	if o.totalLines <= sourceLines {
+		t.Errorf("totalLines = %d, want > %d (wrapped rows, not source lines)", o.totalLines, sourceLines)
+	}
+
+	// The end of the content must be reachable and stay within budget.
+	o.scrollOff = o.totalLines
+	end := o.Render()
+	if h := lipgloss.Height(end); h > 30 {
+		t.Errorf("scrolled-to-end height %d overflows the terminal", h)
+	}
+	if o.scrollOff >= o.totalLines {
+		t.Errorf("scroll offset %d not clamped below %d", o.scrollOff, o.totalLines)
+	}
+}
+
+// TestOverlayDialog_LastLineReachable walks to the bottom and confirms the
+// final line of a long tool result is actually displayed.
+func TestOverlayDialog_LastLineReachable(t *testing.T) {
+	var lines []string
+	for i := 1; i <= 80; i++ {
+		lines = append(lines, fmt.Sprintf("internal/ui/path/to/file_%02d.go:%d:\tmatched source text here", i, i))
+	}
+	o := newOverlayDialog("Tool Result", strings.Join(lines, "\n"), false, "", "", 0, 0, "center", nil, 110, 30)
+
+	// totalLines is computed during Render, so measure before seeking.
+	o.Render()
+	o.scrollOff = o.totalLines
+	if got := xansi.Strip(o.Render()); !strings.Contains(got, "file_80.go") {
+		t.Errorf("last line unreachable at maximum scroll:\n%s", got)
 	}
 }

--- a/internal/ui/composite_test.go
+++ b/internal/ui/composite_test.go
@@ -1,0 +1,214 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	xansi "github.com/charmbracelet/x/ansi"
+)
+
+// fullScreenBase builds a w x h base view where every row is a repeated
+// marker character, so any cell the compositor wrongly overwrites is visible.
+func fullScreenBase(w, h int, ch string) string {
+	rows := make([]string, h)
+	for i := range rows {
+		rows[i] = strings.Repeat(ch, w)
+	}
+	return strings.Join(rows, "\n")
+}
+
+// TestCompositeOverlay_PreservesContentBesideBox is the core guarantee: the
+// box replaces only the cells it covers, so the view remains visible to the
+// left and right of it. The previous whole-line merge blanked the full width
+// of every row the box touched.
+func TestCompositeOverlay_PreservesContentBesideBox(t *testing.T) {
+	const w, h = 40, 9
+	base := fullScreenBase(w, h, "x")
+	box := "╭────╮\n│ hi │\n╰────╯"
+
+	got := compositeOverlay(base, box, 15, 3, w, h)
+	lines := strings.Split(got, "\n")
+
+	if len(lines) != h {
+		t.Fatalf("got %d rows, want %d", len(lines), h)
+	}
+
+	// Rows the box covers keep base content on both sides.
+	for _, row := range []int{3, 4, 5} {
+		plain := xansi.Strip(lines[row])
+		if !strings.HasPrefix(plain, strings.Repeat("x", 15)) {
+			t.Errorf("row %d: content to the LEFT of the box was erased: %q", row, plain)
+		}
+		if !strings.HasSuffix(strings.TrimRight(plain, " "), strings.Repeat("x", 19)) {
+			t.Errorf("row %d: content to the RIGHT of the box was erased: %q", row, plain)
+		}
+		if !strings.Contains(plain, "│") && !strings.Contains(plain, "╭") && !strings.Contains(plain, "╰") {
+			t.Errorf("row %d: box not drawn: %q", row, plain)
+		}
+	}
+
+	// Rows outside the box are untouched.
+	for _, row := range []int{0, 1, 2, 6, 7, 8} {
+		if plain := xansi.Strip(lines[row]); plain != strings.Repeat("x", w) {
+			t.Errorf("row %d outside the box was modified: %q", row, plain)
+		}
+	}
+}
+
+// TestCompositeOverlay_PreservesANSI verifies styling survives on both sides
+// of the splice — the compositor works on cells, not raw strings.
+func TestCompositeOverlay_PreservesANSI(t *testing.T) {
+	base := strings.Join([]string{
+		"\x1b[31m" + strings.Repeat("r", 30) + "\x1b[0m",
+		"\x1b[31m" + strings.Repeat("r", 30) + "\x1b[0m",
+		"\x1b[31m" + strings.Repeat("r", 30) + "\x1b[0m",
+	}, "\n")
+
+	got := compositeOverlay(base, "\x1b[32mBOX\x1b[0m", 10, 1, 30, 3)
+	row := strings.Split(got, "\n")[1]
+
+	if !strings.Contains(row, "BOX") {
+		t.Fatalf("box missing: %q", row)
+	}
+	// Red (31) from the base and green (32) from the box coexist on the row.
+	if !strings.Contains(row, "31") {
+		t.Errorf("base styling lost: %q", row)
+	}
+	if !strings.Contains(row, "32") {
+		t.Errorf("box styling lost: %q", row)
+	}
+}
+
+// TestCompositeOverlay_ClampsToScreen verifies an out-of-bounds or oversized
+// box is pinned on screen rather than drawn into the void.
+func TestCompositeOverlay_ClampsToScreen(t *testing.T) {
+	const w, h = 20, 5
+	base := fullScreenBase(w, h, "x")
+	box := "╭──╮\n╰──╯"
+
+	// Far past the right/bottom edge.
+	got := compositeOverlay(base, box, 500, 500, w, h)
+	if !strings.Contains(got, "╭") {
+		t.Error("box was clipped out of existence")
+	}
+	for i, line := range strings.Split(got, "\n") {
+		if got := xansi.StringWidth(line); got > w {
+			t.Errorf("row %d width %d exceeds screen width %d", i, got, w)
+		}
+	}
+
+	// Negative coordinates.
+	if got := compositeOverlay(base, box, -50, -50, w, h); !strings.Contains(got, "╭") {
+		t.Error("box lost at negative coordinates")
+	}
+}
+
+// TestCompositeOverlay_TrimsUnstyledTrailingRows guards the regression where
+// a popup's bottom margin — a row of plain spaces — punched a blank band
+// through the content below the box.
+func TestCompositeOverlay_TrimsUnstyledTrailingRows(t *testing.T) {
+	const w, h = 20, 5
+	base := fullScreenBase(w, h, "x")
+
+	// Box with two unstyled padding rows below it.
+	box := "╭──╮\n╰──╯\n    \n    "
+
+	got := compositeOverlay(base, box, 0, 0, w, h)
+	lines := strings.Split(got, "\n")
+
+	for _, row := range []int{2, 3} {
+		if plain := xansi.Strip(lines[row]); plain != strings.Repeat("x", w) {
+			t.Errorf("row %d was erased by trailing padding: %q", row, plain)
+		}
+	}
+}
+
+// TestTrimTrailingBlankLines_KeepsStyledRows verifies a row carrying a
+// background colour is preserved — it is part of the box's appearance, not
+// stray padding.
+func TestTrimTrailingBlankLines_KeepsStyledRows(t *testing.T) {
+	styled := "box\n\x1b[48;2;13;13;13m   \x1b[m"
+	if got := trimTrailingBlankLines(styled); got != styled {
+		t.Errorf("styled trailing row was dropped:\ngot  %q\nwant %q", got, styled)
+	}
+
+	plain := "box\n   \n  "
+	if got := trimTrailingBlankLines(plain); got != "box" {
+		t.Errorf("plain trailing rows not trimmed: %q", got)
+	}
+
+	if got := trimTrailingBlankLines("   "); got != "" {
+		t.Errorf("all-blank input should trim to empty, got %q", got)
+	}
+}
+
+// TestCompositeCentered_Centres verifies the box lands in the middle.
+func TestCompositeCentered_Centres(t *testing.T) {
+	const w, h = 21, 7
+	base := fullScreenBase(w, h, "x")
+	box := "abc" // 3 wide, 1 tall
+
+	got := compositeCentered(base, box, w, h)
+	lines := strings.Split(got, "\n")
+
+	mid := xansi.Strip(lines[3]) // (7-1)/2 = 3
+	if !strings.Contains(mid, "abc") {
+		t.Fatalf("box not on the centre row: %q", mid)
+	}
+	if idx := strings.Index(mid, "abc"); idx != (w-3)/2 {
+		t.Errorf("box at column %d, want %d", idx, (w-3)/2)
+	}
+}
+
+// TestCompositeAnchored_Anchors covers the three vertical anchors extensions
+// can request.
+func TestCompositeAnchored_Anchors(t *testing.T) {
+	const w, h = 20, 10
+	base := fullScreenBase(w, h, "x")
+	box := "BOX"
+
+	rowOf := func(rendered string) int {
+		for i, line := range strings.Split(rendered, "\n") {
+			if strings.Contains(xansi.Strip(line), "BOX") {
+				return i
+			}
+		}
+		return -1
+	}
+
+	if got := rowOf(compositeAnchored(base, box, "top-center", w, h)); got != 1 {
+		t.Errorf("top-center row = %d, want 1", got)
+	}
+	if got := rowOf(compositeAnchored(base, box, "bottom-center", w, h)); got != h-2 {
+		t.Errorf("bottom-center row = %d, want %d", got, h-2)
+	}
+	if got := rowOf(compositeAnchored(base, box, "center", w, h)); got != (h-1)/2 {
+		t.Errorf("center row = %d, want %d", got, (h-1)/2)
+	}
+}
+
+// TestCompositeOverlay_EmptyBoxIsNoop verifies an inactive overlay leaves the
+// view untouched.
+func TestCompositeOverlay_EmptyBoxIsNoop(t *testing.T) {
+	base := fullScreenBase(10, 3, "x")
+	for _, box := range []string{"", "   ", "\n\n"} {
+		if got := compositeOverlay(base, box, 0, 0, 10, 3); got != base {
+			t.Errorf("box %q modified the base view", box)
+		}
+	}
+}
+
+// TestPopupList_RenderHasNoUnstyledTrailingRow pins the root cause of the
+// blank-band regression at its source.
+func TestPopupList_RenderHasNoUnstyledTrailingRow(t *testing.T) {
+	p := NewPopupList("Commands", []PopupItem{{Label: "/help", Description: "show help"}}, 100, 30)
+
+	lines := strings.Split(p.Render(), "\n")
+	last := lines[len(lines)-1]
+	if strings.TrimSpace(xansi.Strip(last)) == "" && !strings.Contains(last, "\x1b") {
+		t.Errorf("popup ends with an unstyled blank row that would erase content: %q", last)
+	}
+	if !strings.Contains(last, "╰") {
+		t.Errorf("expected the bottom border to be the last row, got %q", xansi.Strip(last))
+	}
+}

--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -698,14 +698,16 @@ func (s *InputComponent) View() tea.View {
 	return tea.NewView(view.String())
 }
 
-// RenderPopupCentered renders the autocomplete popup for / or @ as a
-// centered overlay. Returns "" when the popup is not currently shown.
+// RenderPopupBox renders the autocomplete popup for / or @ as a bare box.
+// Returns "" when the popup is not currently shown. The caller composites it
+// over the main view so the transcript stays visible around it.
+//
 // The actual filtering / selection state lives on InputComponent — this
 // method merely converts the filtered FuzzyMatch list into PopupItems
 // and asks the shared PopupList to draw it. As a result the / popup, the
 // @ popup, the model picker, the tree selector and the session selector
 // all share identical chrome.
-func (s *InputComponent) RenderPopupCentered(termWidth, termHeight int) string {
+func (s *InputComponent) RenderPopupBox(termWidth, termHeight int) string {
 	if !s.showPopup || len(s.filtered) == 0 {
 		return ""
 	}
@@ -728,7 +730,7 @@ func (s *InputComponent) RenderPopupCentered(termWidth, termHeight int) string {
 	s.popup.SetSize(termWidth, termHeight)
 	s.popup.SetItems(items)
 	s.popup.SetCursor(s.selected)
-	return s.popup.RenderCentered(termWidth, termHeight)
+	return s.popup.Render()
 }
 
 // completeArgs checks whether the input line matches a command with a Complete

--- a/internal/ui/message_items.go
+++ b/internal/ui/message_items.go
@@ -41,6 +41,22 @@ func (m *TextMessageItem) ID() string {
 	return m.id
 }
 
+// RawContent returns the original, untruncated source text for this message.
+// The scrollback stores a display-oriented (styled and possibly truncated)
+// rendering in preRendered; RawContent is what the message inspector shows so
+// the user can read content that was elided for display.
+func (m *TextMessageItem) RawContent() string {
+	if m.content != "" {
+		return m.content
+	}
+	return m.preRendered
+}
+
+// Role returns the message role ("user", "assistant", "tool", ...).
+func (m *TextMessageItem) Role() string {
+	return m.role
+}
+
 func (m *TextMessageItem) Render(width int) string {
 	// If we have pre-rendered styled content, return it
 	if m.preRendered != "" {
@@ -134,6 +150,16 @@ func NewStreamingMessageItem(id, role string, modelName string) *StreamingMessag
 // ID returns the unique identifier.
 func (s *StreamingMessageItem) ID() string {
 	return s.id
+}
+
+// RawContent returns the accumulated streaming text without styling.
+func (s *StreamingMessageItem) RawContent() string {
+	return s.content.String()
+}
+
+// Role returns the message role ("assistant" or "reasoning").
+func (s *StreamingMessageItem) Role() string {
+	return s.role
 }
 
 // Render renders the streaming message with live content.
@@ -243,6 +269,28 @@ func NewStreamingBashOutputItem(id string, command string) *StreamingBashOutputI
 
 func (m *StreamingBashOutputItem) ID() string {
 	return m.id
+}
+
+// RawContent returns the captured command output as plain text, prefixed with
+// the command itself. Streaming bash output is capped to maxLines for display,
+// so this returns whatever the item still retains.
+func (m *StreamingBashOutputItem) RawContent() string {
+	var b strings.Builder
+	if m.command != "" {
+		b.WriteString("$ " + m.command + "\n\n")
+	}
+	for _, line := range m.stdoutLines {
+		b.WriteString(line + "\n")
+	}
+	for _, line := range m.stderrLines {
+		b.WriteString(line + "\n")
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// Role returns the message role.
+func (m *StreamingBashOutputItem) Role() string {
+	return "bash"
 }
 
 func (m *StreamingBashOutputItem) Render(width int) string {

--- a/internal/ui/message_nav.go
+++ b/internal/ui/message_nav.go
@@ -1,0 +1,298 @@
+package ui
+
+import (
+	"image/color"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	xansi "github.com/charmbracelet/x/ansi"
+)
+
+// --------------------------------------------------------------------------
+// Message navigation — select a message in the scrollback and inspect it
+// --------------------------------------------------------------------------
+
+// InspectableItem is implemented by MessageItems that can expose their
+// original source text. The scrollback stores a display-oriented rendering
+// (styled, width-wrapped, and frequently truncated); the message inspector
+// needs the underlying text so the user can read what was elided.
+//
+// MessageItems that do not implement this interface are still selectable —
+// the inspector falls back to their rendered content.
+type InspectableItem interface {
+	// RawContent returns the untruncated source text for the message.
+	RawContent() string
+	// Role returns the message role, used to pick a title and decide
+	// whether the inspector should render the body as markdown.
+	Role() string
+}
+
+// selectionBorderChars are the glyphs used to frame the selected message.
+// A thin rounded box keeps the highlight legible without competing with the
+// per-role gutter glyphs that already occupy column 0 of every block.
+const (
+	selBorderTopLeft     = "╭"
+	selBorderTopRight    = "╮"
+	selBorderBottomLeft  = "╰"
+	selBorderBottomRight = "╯"
+	selBorderHorizontal  = "─"
+	selBorderVertical    = "│"
+)
+
+// selectionBorderOverhead is the number of extra lines a selection border
+// adds to an item (one for the top edge, one for the bottom edge).
+const selectionBorderOverhead = 2
+
+// enterMessageNav switches the model into scrollback navigation mode,
+// selecting the last selectable message. It is a no-op when there is
+// nothing to select.
+func (m *AppModel) enterMessageNav() {
+	if m.scrollList == nil {
+		return
+	}
+
+	idx := m.lastSelectableIndex()
+	if idx < 0 {
+		m.printSystemMessage("No messages to navigate.")
+		return
+	}
+
+	// A live text selection would render highlight spans on top of the
+	// navigation border, so clear it on entry.
+	m.scrollList.ClearSelection()
+
+	m.state = stateMessageNav
+	m.selectMessage(idx)
+
+	// Navigation implies the user wants to look at history: pin the
+	// viewport so incoming stream output can't yank it away.
+	m.scrollList.autoScroll = false
+	m.layoutDirty = true
+}
+
+// exitMessageNav leaves navigation mode, clears the selection border, and
+// returns to the input state.
+func (m *AppModel) exitMessageNav() {
+	if m.scrollList != nil {
+		m.scrollList.SetSelectedIndex(-1)
+		// Resume following new output only if the user is already at the end.
+		if m.scrollList.AtBottom() {
+			m.scrollList.autoScroll = true
+		}
+	}
+	m.state = stateInput
+	m.layoutDirty = true
+}
+
+// selectMessage moves the selection to idx and scrolls it into view.
+func (m *AppModel) selectMessage(idx int) {
+	if m.scrollList == nil {
+		return
+	}
+	m.scrollList.SetSelectedIndex(idx)
+	m.scrollList.EnsureVisible(idx)
+	m.layoutDirty = true
+}
+
+// isSelectableIndex reports whether the item at idx can be selected.
+// Items that render to nothing (e.g. a reasoning block before any reasoning
+// has streamed) occupy no rows, so framing them would draw a border around
+// empty space and let the cursor "disappear".
+func (m *AppModel) isSelectableIndex(idx int) bool {
+	if m.scrollList == nil {
+		return false
+	}
+	item := m.scrollList.ItemAt(idx)
+	if item == nil {
+		return false
+	}
+	return strings.TrimSpace(item.Render(m.scrollList.width)) != ""
+}
+
+// lastSelectableIndex returns the index of the last selectable message,
+// or -1 when the scrollback has none.
+func (m *AppModel) lastSelectableIndex() int {
+	if m.scrollList == nil {
+		return -1
+	}
+	for idx := m.scrollList.Len() - 1; idx >= 0; idx-- {
+		if m.isSelectableIndex(idx) {
+			return idx
+		}
+	}
+	return -1
+}
+
+// firstSelectableIndex returns the index of the first selectable message,
+// or -1 when the scrollback has none.
+func (m *AppModel) firstSelectableIndex() int {
+	if m.scrollList == nil {
+		return -1
+	}
+	for idx := range m.scrollList.Len() {
+		if m.isSelectableIndex(idx) {
+			return idx
+		}
+	}
+	return -1
+}
+
+// moveMessageSelection moves the selection by delta items, skipping
+// unselectable (empty) entries and stopping at the ends of the list.
+func (m *AppModel) moveMessageSelection(delta int) {
+	if m.scrollList == nil || delta == 0 {
+		return
+	}
+
+	current := m.scrollList.SelectedIndex()
+	if current < 0 {
+		if idx := m.lastSelectableIndex(); idx >= 0 {
+			m.selectMessage(idx)
+		}
+		return
+	}
+
+	step := 1
+	if delta < 0 {
+		step = -1
+	}
+
+	for idx := current + step; idx >= 0 && idx < m.scrollList.Len(); idx += step {
+		if m.isSelectableIndex(idx) {
+			m.selectMessage(idx)
+			return
+		}
+	}
+	// No selectable neighbour in that direction — keep the current selection.
+}
+
+// inspectSelectedMessage opens the selected message's full source text in
+// the scrollable overlay dialog.
+//
+// The scrollback stores a display rendering that is frequently truncated
+// (tool results are capped at ~10 lines, diffs at 20, and so on), so the
+// inspector shows RawContent when the item can supply it. Dismissing the
+// dialog returns to navigation mode via preOverlayState.
+func (m *AppModel) inspectSelectedMessage() {
+	if m.scrollList == nil {
+		return
+	}
+
+	idx := m.scrollList.SelectedIndex()
+	item := m.scrollList.ItemAt(idx)
+	if item == nil {
+		return
+	}
+
+	title, content, markdown := messageInspectorContent(item, m.scrollList.width)
+	if strings.TrimSpace(content) == "" {
+		return
+	}
+
+	m.preOverlayState = stateMessageNav
+	m.state = stateOverlay
+	// No response channel: this overlay is driven by the UI, not by a
+	// blocking extension goroutine, so resolveOverlay has nothing to notify.
+	m.overlayResponseCh = nil
+	m.overlay = newOverlayDialog(
+		title, content, markdown,
+		"", "",
+		0, 0, "center",
+		nil,
+		m.width, m.height,
+	)
+	if m.overlay != nil {
+		// Read-only dialog: Enter and Esc both just close it.
+		m.overlay.dismissOnly = true
+	}
+}
+
+// messageInspectorContent resolves the title, body, and markdown flag used
+// when displaying a message in the inspector.
+func messageInspectorContent(item MessageItem, width int) (title, content string, markdown bool) {
+	inspectable, ok := item.(InspectableItem)
+	if !ok {
+		// Fall back to the rendered form for items with no raw source.
+		return "Message", item.Render(width), false
+	}
+
+	content = inspectable.RawContent()
+	if strings.TrimSpace(content) == "" {
+		content = item.Render(width)
+	}
+
+	role := inspectable.Role()
+	switch role {
+	case "user":
+		// User text is authored as markdown and is safe to render as such.
+		return "You", content, true
+	case "assistant":
+		return "Assistant", content, true
+	case "reasoning":
+		return "Reasoning", content, false
+	case "tool":
+		// Tool output is literal text (diffs, logs, JSON): rendering it as
+		// markdown would reflow and mangle it.
+		return "Tool Result", content, false
+	case "bash", "shell":
+		return "Command Output", content, false
+	case "error":
+		return "Error", content, false
+	case "system":
+		return "System", content, false
+	}
+
+	if role == "" {
+		role = "Message"
+	}
+	return strings.ToUpper(role[:1]) + role[1:], content, false
+}
+
+// applySelectionBorder frames pre-rendered content in a thin box exactly
+// totalWidth columns wide.
+//
+// The border is drawn manually rather than with a lipgloss border style
+// because scrollback content is already fully styled and padded to the
+// viewport width: handing it to lipgloss would re-wrap every line and change
+// the item's height unpredictably. Drawing the frame by hand keeps the
+// geometry exact — the result is always len(lines)+2 rows tall and
+// totalWidth columns wide — which is what the ScrollList height cache and
+// mouse hit-testing depend on.
+//
+// Lines wider than the inner width are truncated (ANSI-aware) and shorter
+// lines are padded, so the right edge always lines up.
+func applySelectionBorder(content string, totalWidth int, clr color.Color) string {
+	// Below this width there is no room for a frame plus content.
+	if totalWidth < 4 {
+		return content
+	}
+
+	innerWidth := totalWidth - 2
+	borderStyle := lipgloss.NewStyle().Foreground(clr)
+
+	left := borderStyle.Render(selBorderVertical)
+	right := borderStyle.Render(selBorderVertical)
+
+	horizontal := strings.Repeat(selBorderHorizontal, innerWidth)
+	top := borderStyle.Render(selBorderTopLeft + horizontal + selBorderTopRight)
+	bottom := borderStyle.Render(selBorderBottomLeft + horizontal + selBorderBottomRight)
+
+	lines := strings.Split(content, "\n")
+	out := make([]string, 0, len(lines)+selectionBorderOverhead)
+	out = append(out, top)
+
+	for _, line := range lines {
+		// Truncate first so an over-wide line can't push the right edge out,
+		// then pad so a short line can't pull it in.
+		if xansi.StringWidth(line) > innerWidth {
+			line = xansi.Truncate(line, innerWidth, "")
+		}
+		if pad := innerWidth - xansi.StringWidth(line); pad > 0 {
+			line += strings.Repeat(" ", pad)
+		}
+		out = append(out, left+line+right)
+	}
+
+	out = append(out, bottom)
+	return strings.Join(out, "\n")
+}

--- a/internal/ui/message_nav.go
+++ b/internal/ui/message_nav.go
@@ -43,6 +43,40 @@ const (
 // adds to an item (one for the top edge, one for the bottom edge).
 const selectionBorderOverhead = 2
 
+// selectionTabWidth is the number of columns a tab occupies when a selected
+// message is framed. It matches the terminal's default tab stop.
+const selectionTabWidth = 8
+
+// expandTabs replaces tabs with spaces, advancing to the next tab stop so the
+// result occupies the same columns the terminal would use. Width-aware so
+// wide runes and ANSI sequences before a tab are accounted for.
+func expandTabs(s string, tabWidth int) string {
+	if !strings.Contains(s, "\t") || tabWidth <= 0 {
+		return s
+	}
+
+	var out strings.Builder
+	for i, line := range strings.Split(s, "\n") {
+		if i > 0 {
+			out.WriteByte('\n')
+		}
+		col := 0
+		for j, part := range strings.Split(line, "\t") {
+			// Every segment after the first was preceded by a tab. Keyed on
+			// the segment index rather than the column, so a line that opens
+			// with a tab (column zero) still advances to the first stop.
+			if j > 0 {
+				pad := tabWidth - (col % tabWidth)
+				out.WriteString(strings.Repeat(" ", pad))
+				col += pad
+			}
+			out.WriteString(part)
+			col += xansi.StringWidth(part)
+		}
+	}
+	return out.String()
+}
+
 // enterMessageNav switches the model into scrollback navigation mode,
 // selecting the last selectable message. It is a no-op when there is
 // nothing to select.
@@ -194,10 +228,19 @@ func (m *AppModel) inspectSelectedMessage() {
 	// No response channel: this overlay is driven by the UI, not by a
 	// blocking extension goroutine, so resolveOverlay has nothing to notify.
 	m.overlayResponseCh = nil
+
+	// The inspector is a reader, not a dialog, so it claims more of the
+	// screen than the extension-facing defaults (60% x 80%). Tool output is
+	// full of long lines — grep matches carry a path, a line number and the
+	// matched source — and every column saved here is a wrapped row the
+	// reader doesn't have to scroll past.
+	dialogWidth := m.width * 90 / 100
+	dialogHeight := m.height * 90 / 100
+
 	m.overlay = newOverlayDialog(
 		title, content, markdown,
 		"", "",
-		0, 0, "center",
+		dialogWidth, dialogHeight, "center",
 		nil,
 		m.width, m.height,
 	)
@@ -266,6 +309,13 @@ func applySelectionBorder(content string, totalWidth int, clr color.Color) strin
 	if totalWidth < 4 {
 		return content
 	}
+
+	// Expand tabs before measuring. Width calculations treat a tab as a
+	// single cell, but the terminal advances to the next tab stop, so a row
+	// padded on the tab-is-one-cell assumption renders wider than the frame
+	// and pushes the right border out of alignment. Tool output is full of
+	// tabs (grep matches carry the indentation of the matched source).
+	content = expandTabs(content, selectionTabWidth)
 
 	innerWidth := totalWidth - 2
 	borderStyle := lipgloss.NewStyle().Foreground(clr)

--- a/internal/ui/message_nav_test.go
+++ b/internal/ui/message_nav_test.go
@@ -552,3 +552,28 @@ func TestOverlayDialog_ExpandsTabsInBody(t *testing.T) {
 		}
 	}
 }
+
+// TestScrollList_ClampedSelectionHeightInvalidated guards the scroll maths
+// after a list shrink. The item that ends up under the clamped selection may
+// have a cached height measured without the selection border; leaving it
+// stale throws offsets off by selectionBorderOverhead until it next renders.
+func TestScrollList_ClampedSelectionHeightInvalidated(t *testing.T) {
+	sl := NewScrollList(40, 20)
+	items := makeItems(10, 3)
+	sl.SetItems(items)
+
+	// Measure item 2 unselected so its height is cached without a border.
+	base := sl.itemHeight(2)
+	sl.SetSelectedIndex(9)
+
+	// Shrink so the selection clamps onto the already-cached item 2.
+	sl.SetItems(items[:3])
+	if got := sl.SelectedIndex(); got != 2 {
+		t.Fatalf("selected index = %d, want 2 after clamp", got)
+	}
+
+	if got := sl.itemHeight(2); got != base+selectionBorderOverhead {
+		t.Errorf("clamped selection height = %d, want %d (stale cache not invalidated)",
+			got, base+selectionBorderOverhead)
+	}
+}

--- a/internal/ui/message_nav_test.go
+++ b/internal/ui/message_nav_test.go
@@ -1,23 +1,12 @@
 package ui
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
 	xansi "github.com/charmbracelet/x/ansi"
-
-	"github.com/mark3labs/kit/internal/app"
 )
-
-// appToolResult builds a ToolResultEvent for the raw-content tests.
-func appToolResult(name, args, result string, isErr bool) app.ToolResultEvent {
-	return app.ToolResultEvent{
-		ToolName: name,
-		ToolArgs: args,
-		Result:   result,
-		IsError:  isErr,
-	}
-}
 
 // --------------------------------------------------------------------------
 // applySelectionBorder
@@ -281,7 +270,7 @@ func TestMessageInspectorContent_Titles(t *testing.T) {
 // complete result plus the call metadata needed to interpret it.
 func TestToolRawContent_IncludesFullResult(t *testing.T) {
 	result := strings.Repeat("line\n", 100)
-	got := toolRawContent(appToolResult("read", `{"path":"main.go"}`, result, false))
+	got := toolRawContent("read", `{"path":"main.go"}`, result, false)
 
 	if !strings.Contains(got, "read") {
 		t.Error("missing tool name")
@@ -296,7 +285,7 @@ func TestToolRawContent_IncludesFullResult(t *testing.T) {
 
 // TestToolRawContent_MarksErrors verifies error results are labelled.
 func TestToolRawContent_MarksErrors(t *testing.T) {
-	got := toolRawContent(appToolResult("bash", "{}", "boom", true))
+	got := toolRawContent("bash", "{}", "boom", true)
 	if !strings.Contains(got, "(error)") {
 		t.Errorf("error result not marked: %q", got)
 	}
@@ -314,7 +303,7 @@ func TestOverlayDialog_TitleSeparatorFitsOnOneLine(t *testing.T) {
 	o := newOverlayDialog("Tool Result", "body text", false, "", "", 0, 0, "center", nil, 100, 30)
 
 	var seen int
-	for _, line := range strings.Split(o.Render(), "\n") {
+	for line := range strings.SplitSeq(o.Render(), "\n") {
 		plain := strings.TrimSpace(xansi.Strip(line))
 		// Separator rows contain only box-drawing dashes between the frame.
 		inner := strings.Trim(plain, "│ ")
@@ -374,5 +363,76 @@ func TestOverlayDialog_DismissOnlyHint(t *testing.T) {
 	}
 	if strings.Contains(got, "Esc cancel") {
 		t.Error("inspector must not imply Esc cancels something")
+	}
+}
+
+// --------------------------------------------------------------------------
+// Tool argument display
+// --------------------------------------------------------------------------
+
+// TestToolRawContent_KeepsFullBashCommand is the argument-side counterpart to
+// the result-side truncation guarantee: the scrollback header elides a long
+// command with "...", so the inspector must carry the whole thing.
+func TestToolRawContent_KeepsFullBashCommand(t *testing.T) {
+	cmd := `cd /home/space_cowboy/Workspace/kit && btca ask -r https://github.com/owainlewis/neo ` +
+		`-q "Show the exact workflow tool definition and the internal/workflow package: ` +
+		`the Store/state model, item statuses, how transitions are validated"`
+
+	args, err := json.Marshal(map[string]string{"command": cmd})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The header summary is truncated...
+	if got := formatToolParams(string(args), 80); !strings.HasSuffix(got, "...") {
+		t.Fatalf("expected a truncated header summary, got %q", got)
+	}
+
+	// ...but the inspector keeps the command verbatim.
+	raw := toolRawContent("bash", string(args), "output", false)
+	if !strings.Contains(raw, cmd) {
+		t.Errorf("full command missing from inspector content:\n%s", raw)
+	}
+}
+
+// TestFormatToolArgsForInspector_StringsStayCopyPasteable verifies string
+// arguments are not JSON-escaped. Encoding them would turn every quote into
+// \" and every newline into \n, defeating the purpose of showing the command.
+func TestFormatToolArgsForInspector_StringsStayCopyPasteable(t *testing.T) {
+	args := `{"command":"echo \"hello world\" | grep hello"}`
+
+	got := formatToolArgsForInspector(args)
+	want := `command: echo "hello world" | grep hello`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if strings.Contains(got, `\"`) {
+		t.Error("quotes must not be escaped")
+	}
+}
+
+// TestFormatToolArgsForInspector_MultilineAndStructured covers the two
+// remaining shapes: multi-line strings start on their own line, and
+// non-string values fall back to indented JSON.
+func TestFormatToolArgsForInspector_MultilineAndStructured(t *testing.T) {
+	got := formatToolArgsForInspector(`{"content":"line one\nline two"}`)
+	if !strings.HasPrefix(got, "content:\n") || !strings.Contains(got, "line two") {
+		t.Errorf("multi-line value not laid out on its own line: %q", got)
+	}
+
+	got = formatToolArgsForInspector(`{"limit":50,"paths":["a","b"]}`)
+	if !strings.Contains(got, "limit: 50") {
+		t.Errorf("numeric value missing: %q", got)
+	}
+	if !strings.Contains(got, `"a"`) || !strings.Contains(got, `"b"`) {
+		t.Errorf("array value missing: %q", got)
+	}
+}
+
+// TestFormatToolArgsForInspector_NonObjectPassthrough verifies a non-JSON
+// argument payload is shown as-is rather than silently dropped.
+func TestFormatToolArgsForInspector_NonObjectPassthrough(t *testing.T) {
+	if got := formatToolArgsForInspector("not json"); got != "not json" {
+		t.Errorf("got %q, want passthrough", got)
 	}
 }

--- a/internal/ui/message_nav_test.go
+++ b/internal/ui/message_nav_test.go
@@ -494,3 +494,61 @@ func TestFormatToolArgsForInspector_NonObjectPassthrough(t *testing.T) {
 		t.Errorf("got %q, want passthrough", got)
 	}
 }
+
+// --------------------------------------------------------------------------
+// Tab handling
+// --------------------------------------------------------------------------
+
+// TestApplySelectionBorder_ExpandsTabs guards border alignment for
+// tab-indented content. Width calculations count a tab as one cell but the
+// terminal advances to the next tab stop, so an unexpanded tab pushes the
+// right border past the frame — visible on any selected grep result.
+func TestApplySelectionBorder_ExpandsTabs(t *testing.T) {
+	const width = 40
+	content := "plain line\n\tindented\ncol\tsep\tvals"
+
+	got := applySelectionBorder(content, width, nil)
+	for i, line := range strings.Split(got, "\n") {
+		if strings.Contains(line, "\t") {
+			t.Errorf("row %d still contains a raw tab: %q", i, line)
+		}
+		if w := xansi.StringWidth(line); w != width {
+			t.Errorf("row %d width = %d, want %d", i, w, width)
+		}
+	}
+}
+
+// TestExpandTabs_AdvancesToTabStops verifies tabs align to stops rather than
+// expanding to a fixed run of spaces, matching terminal behaviour.
+func TestExpandTabs_AdvancesToTabStops(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"a\tb", "a       b"},                // col 1 -> pad 7 -> col 8
+		{"\tx", "        x"},                 // col 0 -> pad 8
+		{"1234567\tz", "1234567 z"},          // col 7 -> pad 1 -> col 8
+		{"12345678\tz", "12345678        z"}, // col 8 -> pad 8 -> col 16
+		{"no tabs", "no tabs"},
+	}
+	for _, tt := range tests {
+		if got := expandTabs(tt.in, 8); got != tt.want {
+			t.Errorf("expandTabs(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// TestOverlayDialog_ExpandsTabsInBody verifies the dialog body carries no raw
+// tabs, which would otherwise wrap at a width the measurement did not predict.
+func TestOverlayDialog_ExpandsTabsInBody(t *testing.T) {
+	body := strings.Repeat("path/file.go:12:\tfunc Thing() error {\n", 40)
+	o := newOverlayDialog("Tool Result", body, false, "", "", 0, 0, "center", nil, 100, 30)
+
+	out := o.Render()
+	if strings.Contains(out, "\t") {
+		t.Error("dialog body contains raw tabs; wrapping measurements will not match the render")
+	}
+	boxW := lipgloss.Width(out)
+	for i, line := range strings.Split(out, "\n") {
+		if w := xansi.StringWidth(line); w != boxW {
+			t.Errorf("row %d width %d != box width %d", i, w, boxW)
+		}
+	}
+}

--- a/internal/ui/message_nav_test.go
+++ b/internal/ui/message_nav_test.go
@@ -2,6 +2,8 @@ package ui
 
 import (
 	"encoding/json"
+
+	"charm.land/lipgloss/v2"
 	"strings"
 	"testing"
 
@@ -329,9 +331,11 @@ func TestOverlayDialog_ScrollsLongContent(t *testing.T) {
 	}
 	o := newOverlayDialog("Tool Result", strings.Join(body, "\n"), false, "", "", 0, 0, "center", nil, 100, 30)
 
-	first := o.Render()
-	if !strings.Contains(xansi.Strip(first), "of 200 lines") {
-		t.Error("expected a scroll indicator for content taller than the dialog")
+	// A position indicator is shown; its exact form depends on how much room
+	// the footer has ("(1–20 of 200 lines)" or the compact "20/200").
+	first := xansi.Strip(o.Render())
+	if !strings.Contains(first, "of 200 lines") && !strings.Contains(first, "/200") {
+		t.Errorf("expected a scroll position indicator, got:\n%s", first)
 	}
 
 	// Scroll to the end; the offset must advance and stay clamped.
@@ -342,6 +346,60 @@ func TestOverlayDialog_ScrollsLongContent(t *testing.T) {
 	}
 	if o.scrollOff >= o.totalLines {
 		t.Errorf("scroll offset %d not clamped below total %d", o.scrollOff, o.totalLines)
+	}
+}
+
+// TestOverlayDialog_FooterIsInsideTheBox pins the footer's placement. Hints
+// rendered below the border would be a bare band of padding that the
+// compositor draws as opaque cells, cutting a blank strip through whatever
+// sits behind the dialog.
+func TestOverlayDialog_FooterIsInsideTheBox(t *testing.T) {
+	body := make([]string, 200)
+	for i := range body {
+		body[i] = "line"
+	}
+	o := newOverlayDialog("Tool Result", strings.Join(body, "\n"), false, "", "", 0, 0, "center", nil, 100, 30)
+	o.dismissOnly = true
+
+	lines := strings.Split(o.Render(), "\n")
+	last := xansi.Strip(lines[len(lines)-1])
+	if !strings.HasPrefix(last, "╰") {
+		t.Errorf("box must end with its bottom border, got %q", last)
+	}
+
+	// The hint text sits on a row framed by the border.
+	var found bool
+	for _, line := range lines {
+		plain := xansi.Strip(line)
+		if strings.Contains(plain, "close") {
+			found = true
+			if !strings.HasPrefix(plain, "│") || !strings.HasSuffix(plain, "│") {
+				t.Errorf("hint row is not enclosed by the border: %q", plain)
+			}
+		}
+	}
+	if !found {
+		t.Error("no hint row rendered")
+	}
+}
+
+// TestOverlayDialog_RespectsMaxHeight guards the footer's height accounting:
+// the row is part of the box, so the chrome budget must include it.
+func TestOverlayDialog_RespectsMaxHeight(t *testing.T) {
+	body := make([]string, 500)
+	for i := range body {
+		body[i] = "line"
+	}
+
+	for _, termH := range []int{12, 20, 30, 50} {
+		o := newOverlayDialog("T", strings.Join(body, "\n"), false, "", "", 0, 0, "center", nil, 100, termH)
+		got := lipgloss.Height(o.Render())
+		if want := termH * 80 / 100; got > want {
+			t.Errorf("termH=%d: box height %d exceeds the %d budget", termH, got, want)
+		}
+		if got > termH {
+			t.Errorf("termH=%d: box height %d exceeds the terminal", termH, got)
+		}
 	}
 }
 

--- a/internal/ui/message_nav_test.go
+++ b/internal/ui/message_nav_test.go
@@ -1,0 +1,378 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	xansi "github.com/charmbracelet/x/ansi"
+
+	"github.com/mark3labs/kit/internal/app"
+)
+
+// appToolResult builds a ToolResultEvent for the raw-content tests.
+func appToolResult(name, args, result string, isErr bool) app.ToolResultEvent {
+	return app.ToolResultEvent{
+		ToolName: name,
+		ToolArgs: args,
+		Result:   result,
+		IsError:  isErr,
+	}
+}
+
+// --------------------------------------------------------------------------
+// applySelectionBorder
+// --------------------------------------------------------------------------
+
+// TestApplySelectionBorder_Geometry verifies the framed result has exactly
+// the geometry the ScrollList height cache and mouse hit-testing assume:
+// two extra rows and a width that never exceeds the viewport.
+func TestApplySelectionBorder_Geometry(t *testing.T) {
+	const width = 20
+	content := "hello\nworld"
+
+	got := applySelectionBorder(content, width, nil)
+	lines := strings.Split(got, "\n")
+
+	wantLines := 2 + selectionBorderOverhead
+	if len(lines) != wantLines {
+		t.Fatalf("got %d lines, want %d\n%q", len(lines), wantLines, got)
+	}
+
+	for i, line := range lines {
+		if w := xansi.StringWidth(line); w != width {
+			t.Errorf("line %d width = %d, want %d (%q)", i, w, width, line)
+		}
+	}
+}
+
+// TestApplySelectionBorder_TruncatesOverWideLines ensures a line wider than
+// the frame is clipped rather than pushing the right edge out of alignment,
+// which would corrupt the fixed-width layout.
+func TestApplySelectionBorder_TruncatesOverWideLines(t *testing.T) {
+	const width = 12
+	content := strings.Repeat("x", 40)
+
+	got := applySelectionBorder(content, width, nil)
+	for i, line := range strings.Split(got, "\n") {
+		if w := xansi.StringWidth(line); w != width {
+			t.Errorf("line %d width = %d, want %d", i, w, width)
+		}
+	}
+}
+
+// TestApplySelectionBorder_NarrowWidthPassthrough verifies that a width with
+// no room for a frame returns the content untouched instead of producing
+// negative-width padding.
+func TestApplySelectionBorder_NarrowWidthPassthrough(t *testing.T) {
+	content := "abc"
+	if got := applySelectionBorder(content, 3, nil); got != content {
+		t.Errorf("got %q, want passthrough %q", got, content)
+	}
+}
+
+// --------------------------------------------------------------------------
+// ScrollList selection integration
+// --------------------------------------------------------------------------
+
+// TestScrollList_SelectionChangesItemHeight verifies the height cache tracks
+// the selection border. If the cached height went stale, the scrollback
+// layout and mouse hit-testing would drift by two rows.
+func TestScrollList_SelectionChangesItemHeight(t *testing.T) {
+	sl := NewScrollList(40, 30)
+	sl.SetItems(makeItems(5, 3))
+
+	base := sl.itemHeight(2)
+	if base != 3 {
+		t.Fatalf("unselected height = %d, want 3", base)
+	}
+
+	sl.SetSelectedIndex(2)
+	if got := sl.itemHeight(2); got != base+selectionBorderOverhead {
+		t.Errorf("selected height = %d, want %d", got, base+selectionBorderOverhead)
+	}
+
+	// Neighbours must be unaffected.
+	if got := sl.itemHeight(1); got != base {
+		t.Errorf("neighbour height = %d, want %d", got, base)
+	}
+
+	// Clearing the selection restores the original height.
+	sl.SetSelectedIndex(-1)
+	if got := sl.itemHeight(2); got != base {
+		t.Errorf("height after clearing = %d, want %d", got, base)
+	}
+}
+
+// TestScrollList_ViewRendersSelectionBorder verifies the border actually
+// reaches the painted output.
+func TestScrollList_ViewRendersSelectionBorder(t *testing.T) {
+	sl := NewScrollList(40, 30)
+	sl.SetItems(makeItems(3, 2))
+
+	if strings.Contains(sl.View(), selBorderTopLeft) {
+		t.Fatal("unselected view should not contain a selection border")
+	}
+
+	sl.SetSelectedIndex(1)
+	view := sl.View()
+	for _, glyph := range []string{selBorderTopLeft, selBorderTopRight, selBorderBottomLeft, selBorderBottomRight} {
+		if !strings.Contains(view, glyph) {
+			t.Errorf("view missing border glyph %q", glyph)
+		}
+	}
+}
+
+// TestScrollList_ViewHeightStableWithSelection guards the invariant that
+// View() always emits exactly `height` lines, so the composer and footer
+// stay pinned regardless of the selection border.
+func TestScrollList_ViewHeightStableWithSelection(t *testing.T) {
+	const height = 12
+	sl := NewScrollList(40, height)
+	sl.SetItems(makeItems(10, 3))
+
+	for _, sel := range []int{-1, 0, 5, 9} {
+		sl.SetSelectedIndex(sel)
+		got := len(strings.Split(sl.View(), "\n"))
+		if got != height {
+			t.Errorf("selected=%d: View() produced %d lines, want %d", sel, got, height)
+		}
+	}
+}
+
+// TestScrollList_EmptyItemNotFramed verifies zero-height items stay
+// zero-height when selected. Framing empty content would draw a box around
+// nothing and desynchronise height accounting with View().
+func TestScrollList_EmptyItemNotFramed(t *testing.T) {
+	sl := NewScrollList(40, 20)
+	sl.SetItems([]MessageItem{
+		&fakeItem{id: "empty", lines: 0},
+		&fakeItem{id: "full", lines: 2},
+	})
+
+	sl.SetSelectedIndex(0)
+	if got := sl.renderItem(0); got != "" {
+		t.Errorf("empty item rendered %q, want empty string", got)
+	}
+	if got := sl.itemHeight(0); got != 0 {
+		t.Errorf("empty item height = %d, want 0", got)
+	}
+}
+
+// TestScrollList_SelectionClampedOnShrink verifies a selection past the end
+// of a shrunken list (e.g. after /clear) is pulled back into range instead
+// of naming a message that no longer exists.
+func TestScrollList_SelectionClampedOnShrink(t *testing.T) {
+	sl := NewScrollList(40, 20)
+	sl.SetItems(makeItems(10, 2))
+	sl.SetSelectedIndex(9)
+
+	sl.SetItems(makeItems(3, 2))
+	if got := sl.SelectedIndex(); got >= 3 {
+		t.Errorf("selected index = %d, want < 3 after shrink", got)
+	}
+
+	// Rendering must stay safe with the clamped selection.
+	if lines := len(strings.Split(sl.View(), "\n")); lines != 20 {
+		t.Errorf("View() produced %d lines, want 20", lines)
+	}
+
+	// Emptying the list entirely must not leave a positive index.
+	sl.SetItems(nil)
+	if got := sl.SelectedIndex(); got >= 0 {
+		t.Errorf("selected index = %d, want negative for an empty list", got)
+	}
+}
+
+// TestScrollList_EnsureVisible checks that navigating to an off-screen item
+// scrolls it into view from either direction.
+func TestScrollList_EnsureVisible(t *testing.T) {
+	sl := NewScrollList(40, 10)
+	sl.SetItems(makeItems(20, 3)) // 60 lines into a 10-line viewport
+
+	// Target above the viewport.
+	sl.EnsureVisible(0)
+	if sl.offsetIdx != 0 || sl.offsetLine != 0 {
+		t.Errorf("after EnsureVisible(0): offset = (%d,%d), want (0,0)", sl.offsetIdx, sl.offsetLine)
+	}
+
+	// Target below the viewport must become visible.
+	sl.EnsureVisible(15)
+	if !isItemVisible(sl, 15) {
+		t.Errorf("item 15 not visible after EnsureVisible; offset = (%d,%d)", sl.offsetIdx, sl.offsetLine)
+	}
+}
+
+// isItemVisible reports whether any part of item idx is inside the viewport.
+func isItemVisible(sl *ScrollList, idx int) bool {
+	if idx < sl.offsetIdx {
+		return false
+	}
+	y := -sl.offsetLine
+	for i := sl.offsetIdx; i < idx; i++ {
+		y += sl.itemHeight(i)
+	}
+	return y < sl.height
+}
+
+// --------------------------------------------------------------------------
+// Inspector content resolution
+// --------------------------------------------------------------------------
+
+// TestMessageInspectorContent_PrefersRawOverTruncatedRender is the core
+// guarantee of the feature: the inspector must show the full source text,
+// not the truncated rendering the scrollback displays.
+func TestMessageInspectorContent_PrefersRawOverTruncatedRender(t *testing.T) {
+	raw := strings.Repeat("full output line\n", 50)
+	item := NewStyledMessageItem("id", "tool", raw, "truncated ... (truncated)")
+
+	title, content, markdown := messageInspectorContent(item, 80)
+
+	if content != raw {
+		t.Errorf("content = %q, want the raw text", content)
+	}
+	if title != "Tool Result" {
+		t.Errorf("title = %q, want %q", title, "Tool Result")
+	}
+	if markdown {
+		t.Error("tool output must not be rendered as markdown (it would mangle diffs and logs)")
+	}
+}
+
+// TestMessageInspectorContent_FallsBackToRender verifies items with no raw
+// content still display something rather than an empty dialog.
+func TestMessageInspectorContent_FallsBackToRender(t *testing.T) {
+	item := NewStyledMessageItem("id", "assistant", "", "rendered body")
+
+	_, content, _ := messageInspectorContent(item, 80)
+	if content != "rendered body" {
+		t.Errorf("content = %q, want the rendered fallback", content)
+	}
+}
+
+// TestMessageInspectorContent_Titles covers the role→title/markdown mapping.
+func TestMessageInspectorContent_Titles(t *testing.T) {
+	tests := []struct {
+		role      string
+		wantTitle string
+		wantMD    bool
+	}{
+		{"user", "You", true},
+		{"assistant", "Assistant", true},
+		{"tool", "Tool Result", false},
+		{"error", "Error", false},
+		{"system", "System", false},
+		{"reasoning", "Reasoning", false},
+		{"custom", "Custom", false},
+	}
+
+	for _, tt := range tests {
+		item := NewStyledMessageItem("id", tt.role, "body", "styled")
+		title, _, md := messageInspectorContent(item, 80)
+		if title != tt.wantTitle {
+			t.Errorf("role %q: title = %q, want %q", tt.role, title, tt.wantTitle)
+		}
+		if md != tt.wantMD {
+			t.Errorf("role %q: markdown = %v, want %v", tt.role, md, tt.wantMD)
+		}
+	}
+}
+
+// TestToolRawContent_IncludesFullResult verifies tool raw content carries the
+// complete result plus the call metadata needed to interpret it.
+func TestToolRawContent_IncludesFullResult(t *testing.T) {
+	result := strings.Repeat("line\n", 100)
+	got := toolRawContent(appToolResult("read", `{"path":"main.go"}`, result, false))
+
+	if !strings.Contains(got, "read") {
+		t.Error("missing tool name")
+	}
+	if !strings.Contains(got, "main.go") {
+		t.Error("missing tool arguments")
+	}
+	if !strings.Contains(got, strings.TrimRight(result, "\n")) {
+		t.Error("missing full result body")
+	}
+}
+
+// TestToolRawContent_MarksErrors verifies error results are labelled.
+func TestToolRawContent_MarksErrors(t *testing.T) {
+	got := toolRawContent(appToolResult("bash", "{}", "boom", true))
+	if !strings.Contains(got, "(error)") {
+		t.Errorf("error result not marked: %q", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Overlay dialog geometry (the inspector's rendering surface)
+// --------------------------------------------------------------------------
+
+// TestOverlayDialog_TitleSeparatorFitsOnOneLine guards the dialog width math.
+// lipgloss's Width() includes the border, so treating it as border-exclusive
+// made the content area two columns narrower than innerWidth and wrapped the
+// title separator (and action bar) onto a stray extra line.
+func TestOverlayDialog_TitleSeparatorFitsOnOneLine(t *testing.T) {
+	o := newOverlayDialog("Tool Result", "body text", false, "", "", 0, 0, "center", nil, 100, 30)
+
+	var seen int
+	for _, line := range strings.Split(o.Render(), "\n") {
+		plain := strings.TrimSpace(xansi.Strip(line))
+		// Separator rows contain only box-drawing dashes between the frame.
+		inner := strings.Trim(plain, "│ ")
+		if inner != "" && strings.Trim(inner, "─") == "" {
+			seen++
+			if len(inner) < 10 {
+				t.Errorf("separator fragment %q wrapped onto its own line", inner)
+			}
+		}
+	}
+	if seen == 0 {
+		t.Fatal("no title separator rendered")
+	}
+}
+
+// TestOverlayDialog_ScrollsLongContent verifies the inspector can page
+// through content that exceeds the dialog height — the whole point of
+// opening a truncated message.
+func TestOverlayDialog_ScrollsLongContent(t *testing.T) {
+	body := make([]string, 200)
+	for i := range body {
+		body[i] = "line"
+	}
+	o := newOverlayDialog("Tool Result", strings.Join(body, "\n"), false, "", "", 0, 0, "center", nil, 100, 30)
+
+	first := o.Render()
+	if !strings.Contains(xansi.Strip(first), "of 200 lines") {
+		t.Error("expected a scroll indicator for content taller than the dialog")
+	}
+
+	// Scroll to the end; the offset must advance and stay clamped.
+	o.scrollOff = o.totalLines
+	o.Render()
+	if o.scrollOff == 0 {
+		t.Error("scroll offset did not advance")
+	}
+	if o.scrollOff >= o.totalLines {
+		t.Errorf("scroll offset %d not clamped below total %d", o.scrollOff, o.totalLines)
+	}
+}
+
+// TestOverlayDialog_DismissOnlyHint verifies the inspector advertises a
+// single close action, while extension overlays keep the dismiss/cancel
+// wording that matches the distinct results they report.
+func TestOverlayDialog_DismissOnlyHint(t *testing.T) {
+	ext := newOverlayDialog("T", "body", false, "", "", 0, 0, "center", nil, 100, 30)
+	if got := xansi.Strip(ext.Render()); !strings.Contains(got, "Enter dismiss") ||
+		!strings.Contains(got, "Esc cancel") {
+		t.Error("extension overlay should keep the dismiss/cancel hints")
+	}
+
+	insp := newOverlayDialog("T", "body", false, "", "", 0, 0, "center", nil, 100, 30)
+	insp.dismissOnly = true
+	got := xansi.Strip(insp.Render())
+	if !strings.Contains(got, "Enter/Esc close") {
+		t.Errorf("inspector should show a single close hint, got %q", got)
+	}
+	if strings.Contains(got, "Esc cancel") {
+		t.Error("inspector must not imply Esc cancels something")
+	}
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -3392,9 +3393,10 @@ func (m *AppModel) printToolResult(evt app.ToolResultEvent) {
 
 	// Keep the untruncated result as the item's raw content. The styled
 	// rendering caps output (10 lines for generic results, 20 for diffs and
-	// code), so without this the message inspector could only ever show the
-	// same elided text the scrollback already displays.
-	raw := toolRawContent(evt)
+	// code) and elides long arguments in the header, so without this the
+	// message inspector could only ever show the same elided text the
+	// scrollback already displays.
+	raw := toolRawContent(evt.ToolName, evt.ToolArgs, evt.Result, evt.IsError)
 
 	// Add to in-memory scrollList with styled content
 	msg := NewStyledMessageItem(generateMessageID(), "tool", raw, styledMsg.Content)
@@ -3407,33 +3409,77 @@ func (m *AppModel) printToolResult(evt app.ToolResultEvent) {
 // toolRawContent composes the full, untruncated record of a tool call for
 // the message inspector: the tool name, its arguments, and the complete
 // result body.
-func toolRawContent(evt app.ToolResultEvent) string {
+//
+// The scrollback header shows only a truncated one-line summary of the
+// arguments (formatToolParams), so the full argument set — e.g. a long bash
+// command — is only recoverable from here.
+func toolRawContent(toolName, toolArgs, result string, isError bool) string {
 	var b strings.Builder
 
-	b.WriteString(evt.ToolName)
-	if evt.IsError {
+	b.WriteString(toolName)
+	if isError {
 		b.WriteString(" (error)")
 	}
 	b.WriteString("\n")
 
-	if args := strings.TrimSpace(evt.ToolArgs); args != "" && args != "{}" {
-		// Pretty-print JSON arguments when possible so long tool calls are
-		// readable in the inspector; fall back to the raw string otherwise.
-		var parsed any
-		if err := json.Unmarshal([]byte(args), &parsed); err == nil {
-			if pretty, err := json.MarshalIndent(parsed, "", "  "); err == nil {
-				args = string(pretty)
-			}
-		}
+	if args := strings.TrimSpace(toolArgs); args != "" && args != "{}" {
 		b.WriteString("\n")
-		b.WriteString(args)
+		b.WriteString(formatToolArgsForInspector(args))
 		b.WriteString("\n")
 	}
 
 	b.WriteString("\n")
-	b.WriteString(evt.Result)
+	b.WriteString(result)
 
 	return strings.TrimRight(b.String(), "\n")
+}
+
+// formatToolArgsForInspector renders tool arguments for full display.
+//
+// Single string values (a bash command, a file path) are printed as bare
+// "key: value" lines so the value stays copy-pasteable: JSON encoding would
+// escape every quote and collapse newlines into \n, which is exactly what
+// makes a long shell command unreadable. Structured values fall back to
+// indented JSON.
+func formatToolArgsForInspector(args string) string {
+	var params map[string]any
+	if err := json.Unmarshal([]byte(args), &params); err != nil {
+		// Not an object — show the argument text as-is.
+		return args
+	}
+	if len(params) == 0 {
+		return ""
+	}
+
+	keys := make([]string, 0, len(params))
+	for k := range params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var b strings.Builder
+	for _, k := range keys {
+		if b.Len() > 0 {
+			b.WriteString("\n")
+		}
+		switch v := params[k].(type) {
+		case string:
+			if strings.Contains(v, "\n") {
+				// Multi-line values start on their own line so the key
+				// doesn't visually bind to only the first line.
+				b.WriteString(k + ":\n" + v)
+			} else {
+				b.WriteString(k + ": " + v)
+			}
+		default:
+			if enc, err := json.MarshalIndent(v, "", "  "); err == nil {
+				b.WriteString(k + ": " + string(enc))
+			} else {
+				b.WriteString(fmt.Sprintf("%s: %v", k, v))
+			}
+		}
+	}
+	return b.String()
 }
 
 // printErrorResponse renders an error message into the ScrollList.
@@ -5483,7 +5529,10 @@ func (m *AppModel) renderSessionHistory() {
 					toolArgs = info.Args
 				}
 				styledMsg := m.renderer.RenderToolMessage(toolName, toolArgs, tr.Content, tr.IsError)
-				item := NewStyledMessageItem(generateMessageID(), "tool", styledMsg.Content, styledMsg.Content)
+				// Retain the full call record so a resumed session's tool
+				// messages stay inspectable, exactly as live ones are.
+				raw := toolRawContent(toolName, toolArgs, tr.Content, tr.IsError)
+				item := NewStyledMessageItem(generateMessageID(), "tool", raw, styledMsg.Content)
 				m.messages = append(m.messages, item)
 			}
 		}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -2673,29 +2673,10 @@ func (m *AppModel) View() tea.View {
 		return v
 	}
 
-	// Tree selector overlay replaces the normal layout.
-	if m.state == stateTreeSelector && m.treeSelector != nil {
-		return m.treeSelector.View()
-	}
-
-	// Model selector is rendered as a centered overlay later (see below).
-
-	// Session selector overlay replaces the normal layout.
-	if m.state == stateSessionSelector && m.sessionSelector != nil {
-		return m.sessionSelector.View()
-	}
-
-	// Overlay dialog replaces the normal layout.
-	if m.state == stateOverlay && m.overlay != nil {
-		v := tea.NewView(m.overlay.Render())
-		v.AltScreen = true
-		v.MouseMode = tea.MouseModeCellMotion
-		v.ReportFocus = true
-		v.KeyboardEnhancements = tea.KeyboardEnhancements{
-			ReportEventTypes: true,
-		}
-		return v
-	}
+	// Tree selector, session selector and the overlay dialog are composited
+	// over the normal layout further down, alongside the slash popup and the
+	// model selector, so every modal in the app shows the conversation
+	// behind it instead of blanking the screen.
 
 	// Recompute layout heights if any Update() changed state that affects
 	// sizing. Deferring this to View() guarantees exactly one call per frame
@@ -2832,19 +2813,37 @@ func (m *AppModel) View() tea.View {
 
 	content := lipgloss.JoinVertical(lipgloss.Left, parts...)
 
-	// Render slash command popup as centered overlay if active
+	// Composite every modal surface over the layout at the cell level, so
+	// the conversation stays visible around each one. Ordering is z-order:
+	// later draws sit on top.
 	finalContent := content
+
+	// Slash / @ autocomplete popup.
 	if ic, ok := m.input.(*InputComponent); ok {
-		if popupContent := ic.RenderPopupCentered(m.width, m.height); popupContent != "" {
-			// Overlay popup content on top of main content
-			finalContent = overlayContent(content, popupContent, m.width, m.height)
+		if box := ic.RenderPopupBox(m.width, m.height); box != "" {
+			finalContent = compositeCentered(finalContent, box, m.width, m.height)
 		}
 	}
 
-	// Render model selector as centered overlay if active
+	// Model selector.
 	if m.state == stateModelSelector && m.modelSelector != nil {
-		popupContent := m.modelSelector.RenderOverlay(m.width, m.height)
-		finalContent = overlayContent(finalContent, popupContent, m.width, m.height)
+		finalContent = compositeCentered(finalContent, m.modelSelector.RenderOverlay(), m.width, m.height)
+	}
+
+	// Tree selector (/tree).
+	if m.state == stateTreeSelector && m.treeSelector != nil {
+		finalContent = compositeCentered(finalContent, m.treeSelector.RenderOverlay(), m.width, m.height)
+	}
+
+	// Session selector (/resume).
+	if m.state == stateSessionSelector && m.sessionSelector != nil {
+		finalContent = compositeCentered(finalContent, m.sessionSelector.RenderOverlay(), m.width, m.height)
+	}
+
+	// Modal dialog — extension overlays and the message inspector. Honours
+	// the caller's vertical anchor.
+	if m.state == stateOverlay && m.overlay != nil {
+		finalContent = compositeAnchored(finalContent, m.overlay.Render(), m.overlay.Anchor(), m.width, m.height)
 	}
 
 	v := tea.NewView(finalContent)
@@ -2860,35 +2859,6 @@ func (m *AppModel) View() tea.View {
 // --------------------------------------------------------------------------
 // Rendering helpers
 // --------------------------------------------------------------------------
-
-// overlayContent overlays popup content on top of base content line-by-line.
-// Both content strings should be full-screen (width x height).
-func overlayContent(base, overlay string, width, height int) string {
-	baseLines := strings.Split(base, "\n")
-	overlayLines := strings.Split(overlay, "\n")
-
-	// Ensure we have exactly height lines
-	for len(baseLines) < height {
-		baseLines = append(baseLines, strings.Repeat(" ", width))
-	}
-	for len(overlayLines) < height {
-		overlayLines = append(overlayLines, strings.Repeat(" ", width))
-	}
-
-	// Merge lines - overlay takes precedence where non-empty
-	result := make([]string, height)
-	for i := range height {
-		if i < len(overlayLines) && strings.TrimSpace(overlayLines[i]) != "" {
-			result[i] = overlayLines[i]
-		} else if i < len(baseLines) {
-			result[i] = baseLines[i]
-		} else {
-			result[i] = strings.Repeat(" ", width)
-		}
-	}
-
-	return strings.Join(result, "\n")
-}
 
 // refreshContent updates the ScrollList with current messages.
 // Called whenever messages change (new message, streaming update, etc.)

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -3462,20 +3462,23 @@ func formatToolArgsForInspector(args string) string {
 		if b.Len() > 0 {
 			b.WriteString("\n")
 		}
+		b.WriteString(k)
 		switch v := params[k].(type) {
 		case string:
 			if strings.Contains(v, "\n") {
 				// Multi-line values start on their own line so the key
 				// doesn't visually bind to only the first line.
-				b.WriteString(k + ":\n" + v)
+				b.WriteString(":\n")
 			} else {
-				b.WriteString(k + ": " + v)
+				b.WriteString(": ")
 			}
+			b.WriteString(v)
 		default:
+			b.WriteString(": ")
 			if enc, err := json.MarshalIndent(v, "", "  "); err == nil {
-				b.WriteString(k + ": " + string(enc))
+				b.Write(enc)
 			} else {
-				b.WriteString(fmt.Sprintf("%s: %v", k, v))
+				fmt.Fprintf(&b, "%v", v)
 			}
 		}
 	}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1380,7 +1380,18 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// A width change re-wraps every message, so the selected one can end
 		// up outside the viewport. Pull it back into view rather than leaving
 		// the user navigating a selection they cannot see.
+		//
+		// The layout pass has to run first: SetWidth/SetHeight land in
+		// distributeHeight, which View() defers until the next frame. Choosing
+		// an offset before that would measure the selected item at the old
+		// width (and against a stale viewport height), so a message that grew
+		// taller under the new wrapping could still end up clipped.
+		//
+		// layoutDirty is deliberately left set so View() still runs its own
+		// pass and repopulates the chrome cache it invalidates each frame.
+		// The repeat is cheap — SetWidth is a no-op at an unchanged width.
 		if m.state == stateMessageNav && m.scrollList != nil {
+			m.distributeHeight()
 			m.scrollList.EnsureVisible(m.scrollList.SelectedIndex())
 		}
 
@@ -1485,9 +1496,12 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Check extension-registered global keyboard shortcuts. These fire
 		// in all app states except modal prompts/overlays (which return early
-		// above). Matched shortcuts are consumed — the key does not propagate
+		// above) and message navigation, which rebinds plain keys like j/k
+		// and enter for itself — an extension shortcut on one of those would
+		// otherwise consume it first and silently break navigation.
+		// Matched shortcuts are consumed — the key does not propagate
 		// to child components.
-		if m.getGlobalShortcuts != nil {
+		if m.getGlobalShortcuts != nil && m.state != stateMessageNav {
 			if shortcuts := m.getGlobalShortcuts(); shortcuts != nil {
 				if handler, ok := shortcuts[msg.String()]; ok {
 					// Run in goroutine so blocking extension calls

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -60,6 +60,12 @@ const (
 
 	// stateSessionSelector means the /resume session picker is active.
 	stateSessionSelector
+
+	// stateMessageNav means scrollback message navigation is active. The
+	// user moves a selection between messages with up/down (or j/k) and
+	// opens the selected message in a scrollable inspector with Enter.
+	// The composer keeps its text but does not receive keys.
+	stateMessageNav
 )
 
 // AppController is the interface the parent TUI model uses to interact with the
@@ -1370,6 +1376,12 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.stream, _ = updated.(streamComponentIface)
 			cmds = append(cmds, cmd)
 		}
+		// A width change re-wraps every message, so the selected one can end
+		// up outside the viewport. Pull it back into view rather than leaving
+		// the user navigating a selection they cannot see.
+		if m.state == stateMessageNav && m.scrollList != nil {
+			m.scrollList.EnsureVisible(m.scrollList.SelectedIndex())
+		}
 
 	// ── Mouse wheel scrolling ────────────────────────────────────────────────
 	case tea.MouseWheelMsg:
@@ -1546,6 +1558,38 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Batch(cmds...)
 		}
 
+		// Message navigation consumes every key it understands so the
+		// composer never sees j/k as text while the user is browsing.
+		if m.state == stateMessageNav {
+			switch msg.String() {
+			case "up", "k":
+				m.moveMessageSelection(-1)
+				return m, tea.Batch(cmds...)
+			case "down", "j":
+				m.moveMessageSelection(1)
+				return m, tea.Batch(cmds...)
+			case "home", "g":
+				if idx := m.firstSelectableIndex(); idx >= 0 {
+					m.selectMessage(idx)
+				}
+				return m, tea.Batch(cmds...)
+			case "end", "G":
+				if idx := m.lastSelectableIndex(); idx >= 0 {
+					m.selectMessage(idx)
+				}
+				return m, tea.Batch(cmds...)
+			case "enter":
+				m.inspectSelectedMessage()
+				return m, tea.Batch(cmds...)
+			case "esc", "q":
+				m.exitMessageNav()
+				return m, tea.Batch(cmds...)
+			}
+			// Swallow everything else: an unhandled key must not leak into
+			// the composer while navigation owns the keyboard.
+			return m, tea.Batch(cmds...)
+		}
+
 		// ── Leader key chord handling (Ctrl+X prefix) ──────────────
 		// If the leader key was previously pressed, the current key
 		// completes the chord. We consume it regardless of match so
@@ -1623,6 +1667,9 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						m.stream.SetThinkingVisible(m.thinkingVisible)
 					}
 				}
+			case "m":
+				// Ctrl+X m → Move: navigate messages in the scrollback.
+				m.enterMessageNav()
 			case "e":
 				// Ctrl+X e → open $EDITOR to compose/edit the prompt.
 				editorApp := os.Getenv("VISUAL")
@@ -2881,8 +2928,16 @@ func (m *AppModel) renderStatusBar() string {
 	veryMuted := lipgloss.NewStyle().Foreground(theme.VeryMuted)
 
 	// Left: working directory, plus the git branch when one is known.
+	// While message navigation owns the keyboard its key hints take that
+	// slot instead: the rebound keys are transient and need discovering,
+	// whereas the path is ambient and always recoverable by pressing Esc.
 	var leftSide string
-	if m.cwd != "" {
+	if m.state == stateMessageNav {
+		leftSide = " " + lipgloss.NewStyle().
+			Foreground(theme.Accent).
+			Render("MESSAGE NAV") +
+			veryMuted.Render("  ↑/↓ move · enter open · esc exit")
+	} else if m.cwd != "" {
 		left := tildeHome(m.cwd)
 		if m.gitBranch != "" {
 			left += " (" + m.gitBranch + ")"
@@ -3335,12 +3390,50 @@ func (m *AppModel) printToolResult(evt app.ToolResultEvent) {
 	// Render styled tool message using MessageRenderer
 	styledMsg := m.renderer.RenderToolMessage(evt.ToolName, evt.ToolArgs, evt.Result, evt.IsError)
 
+	// Keep the untruncated result as the item's raw content. The styled
+	// rendering caps output (10 lines for generic results, 20 for diffs and
+	// code), so without this the message inspector could only ever show the
+	// same elided text the scrollback already displays.
+	raw := toolRawContent(evt)
+
 	// Add to in-memory scrollList with styled content
-	msg := NewStyledMessageItem(generateMessageID(), "tool", styledMsg.Content, styledMsg.Content)
+	msg := NewStyledMessageItem(generateMessageID(), "tool", raw, styledMsg.Content)
 	m.messages = append(m.messages, msg)
 
 	// Refresh ScrollList content
 	m.refreshContent()
+}
+
+// toolRawContent composes the full, untruncated record of a tool call for
+// the message inspector: the tool name, its arguments, and the complete
+// result body.
+func toolRawContent(evt app.ToolResultEvent) string {
+	var b strings.Builder
+
+	b.WriteString(evt.ToolName)
+	if evt.IsError {
+		b.WriteString(" (error)")
+	}
+	b.WriteString("\n")
+
+	if args := strings.TrimSpace(evt.ToolArgs); args != "" && args != "{}" {
+		// Pretty-print JSON arguments when possible so long tool calls are
+		// readable in the inspector; fall back to the raw string otherwise.
+		var parsed any
+		if err := json.Unmarshal([]byte(args), &parsed); err == nil {
+			if pretty, err := json.MarshalIndent(parsed, "", "  "); err == nil {
+				args = string(pretty)
+			}
+		}
+		b.WriteString("\n")
+		b.WriteString(args)
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n")
+	b.WriteString(evt.Result)
+
+	return strings.TrimRight(b.String(), "\n")
 }
 
 // printErrorResponse renders an error message into the ScrollList.
@@ -3350,7 +3443,7 @@ func (m *AppModel) printErrorResponse(evt app.StepErrorEvent) {
 		styledMsg := m.renderer.RenderErrorMessage(evt.Err.Error(), time.Now())
 
 		// Add to in-memory scrollList with styled content
-		msg := NewStyledMessageItem(generateMessageID(), "error", styledMsg.Content, styledMsg.Content)
+		msg := NewStyledMessageItem(generateMessageID(), "error", evt.Err.Error(), styledMsg.Content)
 		m.messages = append(m.messages, msg)
 
 		// Refresh ScrollList content
@@ -3443,7 +3536,7 @@ func (m *AppModel) printSystemMessage(text string) {
 	styledMsg := m.renderer.RenderSystemMessage(text, time.Now())
 
 	// Add to in-memory scrollList with styled content
-	msg := NewStyledMessageItem(generateMessageID(), "system", styledMsg.Content, styledMsg.Content)
+	msg := NewStyledMessageItem(generateMessageID(), "system", text, styledMsg.Content)
 	m.messages = append(m.messages, msg)
 
 	// Refresh ScrollList content
@@ -3454,7 +3547,7 @@ func (m *AppModel) printSystemMessage(text string) {
 func (m *AppModel) printCustomMessage(text, label string) {
 	styledMsg := m.renderer.RenderCustomMessage(text, label, time.Now())
 
-	msg := NewStyledMessageItem(generateMessageID(), "system", styledMsg.Content, styledMsg.Content)
+	msg := NewStyledMessageItem(generateMessageID(), "system", text, styledMsg.Content)
 	m.messages = append(m.messages, msg)
 
 	m.refreshContent()
@@ -5853,8 +5946,25 @@ func (m *AppModel) handleShellCommandResult(msg uicore.ShellCommandResultMsg) te
 		WithMarginBottom(1),
 	)
 
-	// Add shell command output to ScrollList.
-	msg2 := NewStyledMessageItem(generateMessageID(), "system", rendered, rendered)
+	// Add shell command output to ScrollList. The rendered form is capped at
+	// maxShellDisplayLines, so the full output is kept alongside it as the
+	// item's raw content for the message inspector.
+	var raw strings.Builder
+	raw.WriteString(header)
+	if msg.Err != nil {
+		fmt.Fprintf(&raw, "\n\nError: %v", msg.Err)
+	}
+	if msg.Output != "" {
+		raw.WriteString("\n\n")
+		raw.WriteString(msg.Output)
+	} else if msg.Err == nil {
+		raw.WriteString("\n\n(no output)")
+	}
+	if msg.ExitCode != 0 {
+		fmt.Fprintf(&raw, "\n\nExit code: %d", msg.ExitCode)
+	}
+
+	msg2 := NewStyledMessageItem(generateMessageID(), "shell", raw.String(), rendered)
 	m.messages = append(m.messages, msg2)
 	m.refreshContent()
 

--- a/internal/ui/model_selector.go
+++ b/internal/ui/model_selector.go
@@ -162,10 +162,10 @@ func (ms *ModelSelectorComponent) View() tea.View {
 	return v
 }
 
-// RenderOverlay returns the popup as a centered overlay string, ready to be
-// composited on top of the main content via overlayContent().
-func (ms *ModelSelectorComponent) RenderOverlay(termWidth, termHeight int) string {
-	return ms.popup.RenderCentered(termWidth, termHeight)
+// RenderOverlay returns the popup as a bare box, ready to be composited on
+// top of the main content so the conversation stays visible behind it.
+func (ms *ModelSelectorComponent) RenderOverlay() string {
+	return ms.popup.Render()
 }
 
 // IsActive returns whether the selector is still accepting input.

--- a/internal/ui/overlay.go
+++ b/internal/ui/overlay.go
@@ -43,6 +43,16 @@ type overlayDialog struct {
 	dialogWidth int // configured dialog width (0 = auto)
 	maxHeight   int // configured max height (0 = auto)
 	anchor      string
+
+	// dismissOnly marks an overlay that has no consumer for its result —
+	// the message inspector, which the UI opens for reading only. Enter and
+	// Esc then close the dialog with no observable difference, so the key
+	// hint advertises a single "close" action instead of implying that
+	// dismiss and cancel lead to different outcomes.
+	//
+	// Extension overlays leave this false: ShowOverlay reports Enter as
+	// completed and Esc as cancelled, and extensions may branch on it.
+	dismissOnly bool
 }
 
 // newOverlayDialog creates an overlay dialog from an OverlayRequestEvent's
@@ -154,6 +164,9 @@ func (o *overlayDialog) Render() string {
 	mh = clamp(mh, min(6, termH), termH)
 
 	// Inner width accounts for border (2) + horizontal padding (2 left + 1 right).
+	// lipgloss's Width() sets the total rendered width including the border,
+	// so the dialog style below is given the full dw and the content area is
+	// what remains after the frame and padding.
 	innerWidth := max(dw-5, 6)
 
 	// Render body text (potentially as markdown).
@@ -249,11 +262,14 @@ func (o *overlayDialog) Render() string {
 		borderClr = lipgloss.Color(o.borderColor)
 	}
 
-	// Build the dialog box style.
+	// Build the dialog box style. Width() is the total rendered width
+	// including the border, so dw is passed through unmodified — subtracting
+	// the border here would shrink the content area below innerWidth and
+	// wrap the title separator and action bar onto extra lines.
 	dialogStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(borderClr).
-		Width(dw-2). // -2 for border chars
+		Width(dw).
 		Padding(1, 1, 1, 2).
 		Foreground(theme.Text)
 
@@ -269,20 +285,28 @@ func (o *overlayDialog) Render() string {
 		if scrollable {
 			hints = append(hints, "↑/↓ scroll")
 		}
-		if len(o.actions) > 0 {
+		switch {
+		case len(o.actions) > 0:
 			hints = append(hints, "←/→ switch")
 			hints = append(hints, "Enter select")
-		} else {
+			hints = append(hints, "Esc cancel")
+		case o.dismissOnly:
+			hints = append(hints, "Enter/Esc close")
+		default:
 			hints = append(hints, "Enter dismiss")
+			hints = append(hints, "Esc cancel")
 		}
-		hints = append(hints, "Esc cancel")
 	} else {
-		if len(o.actions) > 0 {
+		switch {
+		case len(o.actions) > 0:
 			hints = append(hints, "↵ select")
-		} else {
+			hints = append(hints, "esc")
+		case o.dismissOnly:
+			hints = append(hints, "↵/esc close")
+		default:
 			hints = append(hints, "↵ ok")
+			hints = append(hints, "esc")
 		}
-		hints = append(hints, "esc")
 	}
 	hintText := lipgloss.NewStyle().
 		Foreground(theme.Muted).

--- a/internal/ui/overlay.go
+++ b/internal/ui/overlay.go
@@ -180,8 +180,11 @@ func (o *overlayDialog) Render() string {
 	o.totalLines = len(bodyLines)
 
 	// Calculate available height for the scrollable body.
-	// Chrome: border(2) + padTop(1) + padBottom(1) + hintLine(1) = 5
-	chromeLines := 5
+	// Chrome: border(2) + padTop(1) + padBottom(1) + blank(1) + footer(1) = 6.
+	// The footer row carries the scroll indicator and the key hints; both
+	// live inside the border so no part of the dialog is a bare strip of
+	// padding that would erase the view behind it.
+	chromeLines := 6
 	if o.title != "" {
 		chromeLines += 2 // title line + separator line
 	}
@@ -222,19 +225,6 @@ func (o *overlayDialog) Render() string {
 	parts = append(parts, "")
 	parts = append(parts, strings.Join(bodyLines, "\n"))
 
-	// Scroll indicator.
-	if scrollable {
-		indicator := fmt.Sprintf("(%d–%d of %d lines)",
-			o.scrollOff+1,
-			min(o.scrollOff+maxBodyLines, o.totalLines),
-			o.totalLines)
-		parts = append(parts, lipgloss.NewStyle().
-			Foreground(theme.VeryMuted).
-			Render(indicator))
-	} else {
-		parts = append(parts, "")
-	}
-
 	// Action bar.
 	if len(o.actions) > 0 {
 		parts = append(parts, lipgloss.NewStyle().
@@ -253,6 +243,9 @@ func (o *overlayDialog) Render() string {
 		}
 		parts = append(parts, strings.Join(actionParts, "    "))
 	}
+
+	// Footer: scroll position on the left, key hints on the right.
+	parts = append(parts, o.renderFooter(scrollable, maxBodyLines, innerWidth, theme))
 
 	innerContent := strings.Join(parts, "\n")
 
@@ -279,66 +272,100 @@ func (o *overlayDialog) Render() string {
 
 	dialog := dialogStyle.Render(innerContent)
 
-	// Key hints below the dialog, adapted to width.
+	// The box is returned unpositioned; the caller composites it over the
+	// main view at the anchor point (see compositeAnchored). Positioning
+	// here by padding with spaces and newlines would produce an opaque
+	// full-screen block that erases whatever is behind it.
+	return dialog
+}
+
+// renderFooter builds the dialog's bottom row: the scroll position on the
+// left and the key hints on the right, padded to exactly innerWidth.
+//
+// The row lives inside the border. Rendering hints below the box would leave
+// a bare band of padding that the compositor draws as opaque cells, cutting a
+// blank strip through the content behind the dialog.
+//
+// Both halves compete for one row, so the content degrades by priority rather
+// than being dropped outright: the verbose "(1–12 of 200 lines)" collapses to
+// "12/200", and the "↑/↓ scroll" hint goes before any dismiss hint because a
+// visible position indicator already implies the dialog scrolls. The keys
+// that close the dialog are the last thing surrendered.
+func (o *overlayDialog) renderFooter(scrollable bool, maxBodyLines, innerWidth int, theme style.Theme) string {
+	mutedStyle := lipgloss.NewStyle().Foreground(theme.Muted)
+	veryMutedStyle := lipgloss.NewStyle().Foreground(theme.VeryMuted)
+
+	var indicators []string
+	if scrollable {
+		last := min(o.scrollOff+maxBodyLines, o.totalLines)
+		indicators = append(indicators,
+			fmt.Sprintf("(%d–%d of %d lines)", o.scrollOff+1, last, o.totalLines),
+			fmt.Sprintf("%d/%d", last, o.totalLines),
+		)
+	}
+	indicators = append(indicators, "")
+
+	// Hint sets, widest first.
+	hintSets := [][]string{o.hintLabels(scrollable, true), o.hintLabels(scrollable, false)}
+
+	for _, hints := range hintSets {
+		hintText := strings.Join(hints, "  ")
+		hintW := lipgloss.Width(hintText)
+
+		for _, indicator := range indicators {
+			if indicator == "" {
+				continue
+			}
+			if gap := innerWidth - lipgloss.Width(indicator) - hintW; gap >= 2 {
+				return veryMutedStyle.Render(indicator) +
+					strings.Repeat(" ", gap) +
+					mutedStyle.Render(hintText)
+			}
+		}
+
+		// Hints alone, right-aligned.
+		if pad := innerWidth - hintW; pad >= 0 {
+			return strings.Repeat(" ", pad) + mutedStyle.Render(hintText)
+		}
+	}
+
+	// Narrower than even the terse hints — show them and let the box clip.
+	return mutedStyle.Render(strings.Join(o.hintLabels(scrollable, false), "  "))
+}
+
+// hintLabels returns the key hints for the dialog's current configuration.
+// verbose selects the full wording over the terse forms used when the row is
+// too narrow to spell the keys out.
+func (o *overlayDialog) hintLabels(scrollable, verbose bool) []string {
 	var hints []string
-	if termW >= 50 {
+
+	if verbose {
 		if scrollable {
 			hints = append(hints, "↑/↓ scroll")
 		}
 		switch {
 		case len(o.actions) > 0:
-			hints = append(hints, "←/→ switch")
-			hints = append(hints, "Enter select")
-			hints = append(hints, "Esc cancel")
+			hints = append(hints, "←/→ switch", "Enter select", "Esc cancel")
 		case o.dismissOnly:
 			hints = append(hints, "Enter/Esc close")
 		default:
-			hints = append(hints, "Enter dismiss")
-			hints = append(hints, "Esc cancel")
+			hints = append(hints, "Enter dismiss", "Esc cancel")
 		}
-	} else {
-		switch {
-		case len(o.actions) > 0:
-			hints = append(hints, "↵ select")
-			hints = append(hints, "esc")
-		case o.dismissOnly:
-			hints = append(hints, "↵/esc close")
-		default:
-			hints = append(hints, "↵ ok")
-			hints = append(hints, "esc")
-		}
-	}
-	hintText := lipgloss.NewStyle().
-		Foreground(theme.Muted).
-		Render("  " + strings.Join(hints, "  "))
-
-	full := lipgloss.JoinVertical(lipgloss.Left, dialog, hintText)
-
-	// Center horizontally within the terminal width.
-	centered := lipgloss.PlaceHorizontal(o.width, lipgloss.Center, full)
-
-	// Apply vertical positioning based on anchor.
-	// Calculate how many lines we have and how many we need.
-	contentHeight := lipgloss.Height(centered)
-	if contentHeight < o.height {
-		switch o.anchor {
-		case "top-center":
-			// Add one blank line at top for breathing room.
-			centered = "\n" + centered
-		case "bottom-center":
-			// Pad from the top so the dialog sits near the bottom.
-			topPad := o.height - contentHeight - 1
-			if topPad > 0 {
-				centered = strings.Repeat("\n", topPad) + centered
-			}
-		default: // "center"
-			// Vertically center within available height.
-			topPad := (o.height - contentHeight) / 2
-			if topPad > 0 {
-				centered = strings.Repeat("\n", topPad) + centered
-			}
-		}
+		return hints
 	}
 
-	return centered
+	switch {
+	case len(o.actions) > 0:
+		hints = append(hints, "↵ select", "esc")
+	case o.dismissOnly:
+		hints = append(hints, "↵/esc close")
+	default:
+		hints = append(hints, "↵ ok", "esc")
+	}
+	return hints
+}
+
+// Anchor returns the configured vertical anchor for this dialog.
+func (o *overlayDialog) Anchor() string {
+	return o.anchor
 }

--- a/internal/ui/overlay.go
+++ b/internal/ui/overlay.go
@@ -6,6 +6,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	xansi "github.com/charmbracelet/x/ansi"
 
 	"github.com/mark3labs/kit/internal/ui/style"
 )
@@ -54,6 +55,14 @@ type overlayDialog struct {
 	// completed and Esc as cancelled, and extensions may branch on it.
 	dismissOnly bool
 }
+
+// Dialog layout constants.
+const (
+	// dialogTabWidth is the number of spaces a tab expands to inside the
+	// dialog body. It must match the box style's tab handling so wrapping
+	// measurements agree with what is rendered.
+	dialogTabWidth = 4
+)
 
 // newOverlayDialog creates an overlay dialog from an OverlayRequestEvent's
 // parameters.
@@ -175,6 +184,27 @@ func (o *overlayDialog) Render() string {
 		bodyText = style.ToMarkdown(bodyText, innerWidth)
 	}
 	bodyText = strings.TrimRight(bodyText, "\n")
+
+	// Expand tabs before measuring. Wrapping counts a tab as one cell but
+	// the box style renders it as several, so a line wrapped to exactly the
+	// content width would overflow and be wrapped a second time by the
+	// style — silently doubling the height of tab-indented output such as
+	// grep matches. Expanding first makes the two agree.
+	bodyText = strings.ReplaceAll(bodyText, "\t", strings.Repeat(" ", dialogTabWidth))
+
+	// Wrap to the content width *before* measuring.
+	//
+	// The box style would otherwise wrap over-long lines itself, at which
+	// point one source line occupies several rows and every downstream
+	// number is wrong: totalLines under-counts, the maxBodyLines slice lets
+	// through more rows than budgeted (a grep result with long paths grew a
+	// 30-row terminal's dialog to 48 rows), and scrolling moves by source
+	// line rather than by the row the reader actually sees.
+	//
+	// Wrapping here makes one element of bodyLines equal exactly one
+	// rendered row, so the height budget, the scroll offset and the "of N
+	// lines" counter all agree with the display.
+	bodyText = xansi.Wrap(bodyText, innerWidth, "")
 
 	bodyLines := strings.Split(bodyText, "\n")
 	o.totalLines = len(bodyLines)

--- a/internal/ui/popup_list.go
+++ b/internal/ui/popup_list.go
@@ -310,9 +310,10 @@ func (p *PopupList) Render() string {
 		Width(popupW)
 	if popupH > 0 {
 		popupStyle = popupStyle.Height(popupH)
-	} else {
-		popupStyle = popupStyle.MarginBottom(1)
 	}
+	// No bottom margin: the popup is composited over the view, so a margin
+	// row would be an unstyled band of spaces below the border that erases
+	// the content behind it. Spacing is the caller's business.
 
 	var b strings.Builder
 
@@ -487,7 +488,8 @@ func (p *PopupList) Render() string {
 }
 
 // RenderCentered returns the popup placed at the center of a termWidth×termHeight
-// canvas, ready to be composed with overlayContent().
+// canvas. Prefer Render() plus the compositor for modals — this full-screen
+// form is opaque and erases whatever sits behind it.
 func (p *PopupList) RenderCentered(termWidth, termHeight int) string {
 	popupContent := p.Render()
 	return lipgloss.Place(

--- a/internal/ui/scrolllist.go
+++ b/internal/ui/scrolllist.go
@@ -7,6 +7,7 @@ import (
 	xansi "github.com/charmbracelet/x/ansi"
 
 	"github.com/mark3labs/kit/internal/ui/selection"
+	"github.com/mark3labs/kit/internal/ui/style"
 )
 
 // MessageItem is the interface all scrollback messages must implement.
@@ -41,6 +42,12 @@ type ScrollList struct {
 	// View() when an item is actually rendered.
 	heightCache map[string]int
 
+	// selectedIdx is the index of the message currently framed by the
+	// selection border, or -1 when message navigation is inactive. The
+	// selected item renders two lines taller than normal, so changing this
+	// must invalidate the affected height-cache entries (SetSelectedIndex).
+	selectedIdx int
+
 	// Character-level text selection (crush-style).
 	sel selection.State
 }
@@ -55,6 +62,7 @@ func NewScrollList(width, height int) *ScrollList {
 		height:      height,
 		autoScroll:  true,
 		heightCache: make(map[string]int, 64),
+		selectedIdx: -1,
 		sel:         selection.NewState(),
 	}
 }
@@ -67,6 +75,12 @@ func NewScrollList(width, height int) *ScrollList {
 func (s *ScrollList) SetItems(items []MessageItem) {
 	s.items = items
 	s.pruneHeightCache()
+	// A shrinking list (e.g. /clear or a session switch) can strand the
+	// selection past the end, which would leave a selected index that no
+	// longer names a message.
+	if s.selectedIdx >= len(s.items) {
+		s.selectedIdx = len(s.items) - 1
+	}
 	if s.autoScroll && !s.sel.MouseDown {
 		s.GotoBottom()
 	}
@@ -97,6 +111,42 @@ func (s *ScrollList) pruneHeightCache() {
 // an item's content (e.g. AppendChunk on a streaming message).
 func (s *ScrollList) InvalidateItemHeight(id string) {
 	delete(s.heightCache, id)
+}
+
+// SetSelectedIndex sets the message framed by the selection border, or -1 to
+// clear the selection. The border adds two lines to the item's rendered
+// height, so the cached heights of both the previously and newly selected
+// items are invalidated to keep scroll math and mouse hit-testing accurate.
+func (s *ScrollList) SetSelectedIndex(idx int) {
+	if idx == s.selectedIdx {
+		return
+	}
+	if s.selectedIdx >= 0 && s.selectedIdx < len(s.items) {
+		delete(s.heightCache, s.items[s.selectedIdx].ID())
+	}
+	if idx >= 0 && idx < len(s.items) {
+		delete(s.heightCache, s.items[idx].ID())
+	}
+	s.selectedIdx = idx
+	s.clampOffset()
+}
+
+// SelectedIndex returns the index of the selected message, or -1 if none.
+func (s *ScrollList) SelectedIndex() int {
+	return s.selectedIdx
+}
+
+// Len returns the number of items in the list.
+func (s *ScrollList) Len() int {
+	return len(s.items)
+}
+
+// ItemAt returns the item at idx, or nil when idx is out of range.
+func (s *ScrollList) ItemAt(idx int) MessageItem {
+	if idx < 0 || idx >= len(s.items) {
+		return nil
+	}
+	return s.items[idx]
 }
 
 // SetHeight updates the viewport height. Called when the terminal is resized.
@@ -254,8 +304,7 @@ func (s *ScrollList) ExtractSelectedText() string {
 	var sb strings.Builder
 
 	for itemIdx := r.StartItemIdx; itemIdx <= r.EndItemIdx && itemIdx < len(s.items); itemIdx++ {
-		item := s.items[itemIdx]
-		content := item.Render(s.width)
+		content := s.renderItem(itemIdx)
 		contentLines := strings.Split(content, "\n")
 
 		for lineIdx, line := range contentLines {
@@ -284,8 +333,7 @@ func (s *ScrollList) selectWord(itemIdx, lineIdx, x int) {
 		return
 	}
 
-	item := s.items[itemIdx]
-	content := item.Render(s.width)
+	content := s.renderItem(itemIdx)
 	lines := strings.Split(content, "\n")
 	if lineIdx < 0 || lineIdx >= len(lines) {
 		return
@@ -323,8 +371,7 @@ func (s *ScrollList) selectLine(itemIdx, lineIdx int) {
 		return
 	}
 
-	item := s.items[itemIdx]
-	content := item.Render(s.width)
+	content := s.renderItem(itemIdx)
 	lines := strings.Split(content, "\n")
 	if lineIdx < 0 || lineIdx >= len(lines) {
 		return
@@ -355,9 +402,8 @@ func (s *ScrollList) getItemAndLineAtY(y int) (itemIdx, lineIdx int) {
 
 	currentY := 0
 	for idx := s.offsetIdx; idx < len(s.items); idx++ {
-		item := s.items[idx]
 		// Compute height the same way View() does: render, then count lines.
-		itemHeight := s.renderedHeight(item)
+		itemHeight := s.renderedHeight(idx)
 
 		// Account for partial visibility of the first item.
 		startLine := 0
@@ -398,7 +444,7 @@ func (s *ScrollList) ScrollBy(lines int) {
 			if s.offsetIdx >= len(s.items) {
 				break
 			}
-			ih := s.itemHeight(s.items[s.offsetIdx])
+			ih := s.itemHeight(s.offsetIdx)
 			remainingLines := ih - s.offsetLine
 
 			if lines >= remainingLines {
@@ -446,7 +492,7 @@ func (s *ScrollList) ScrollBy(lines int) {
 				// Move to previous item
 				s.offsetIdx--
 				if s.offsetIdx < len(s.items) {
-					ih := s.itemHeight(s.items[s.offsetIdx])
+					ih := s.itemHeight(s.offsetIdx)
 
 					if lines >= ih {
 						lines -= ih
@@ -481,7 +527,7 @@ func (s *ScrollList) bottomOffset() (offsetIdx, offsetLine int) {
 
 	budget := s.height
 	for idx := len(s.items) - 1; idx >= 0; idx-- {
-		ih := s.itemHeight(s.items[idx])
+		ih := s.itemHeight(idx)
 
 		// Account for gap *above* this item (gap between idx-1 and idx).
 		gap := 0
@@ -508,6 +554,51 @@ func (s *ScrollList) GotoTop() {
 	s.offsetLine = 0
 }
 
+// EnsureVisible scrolls the minimum amount needed to bring the item at idx
+// fully into the viewport.
+//
+// If the item sits above the viewport it is aligned to the top; if it
+// extends past the bottom it is scrolled up just far enough to fit. An item
+// taller than the viewport is aligned to its first line so navigation always
+// lands on the start of a long message rather than its middle.
+func (s *ScrollList) EnsureVisible(idx int) {
+	if idx < 0 || idx >= len(s.items) {
+		return
+	}
+
+	// Above the viewport (or partially scrolled off the top) — align to top.
+	if idx < s.offsetIdx || (idx == s.offsetIdx && s.offsetLine > 0) {
+		s.offsetIdx = idx
+		s.offsetLine = 0
+		s.clampOffset()
+		return
+	}
+
+	// Measure from the top of the viewport to the end of the target item.
+	distance := -s.offsetLine
+	for i := s.offsetIdx; i <= idx; i++ {
+		distance += s.itemHeight(i)
+		if s.itemGap > 0 && i < idx {
+			distance += s.itemGap
+		}
+	}
+
+	// Already fully visible.
+	if distance <= s.height {
+		return
+	}
+
+	// Taller than the viewport — show it from its first line.
+	if s.itemHeight(idx) >= s.height {
+		s.offsetIdx = idx
+		s.offsetLine = 0
+		s.clampOffset()
+		return
+	}
+
+	s.ScrollBy(distance - s.height)
+}
+
 // AtBottom returns true if the viewport is at the bottom of the list.
 func (s *ScrollList) AtBottom() bool {
 	if len(s.items) == 0 {
@@ -516,7 +607,7 @@ func (s *ScrollList) AtBottom() bool {
 
 	visibleHeight := 0
 	for idx := s.offsetIdx; idx < len(s.items); idx++ {
-		ih := s.itemHeight(s.items[idx])
+		ih := s.itemHeight(idx)
 
 		if idx == s.offsetIdx {
 			visibleHeight += ih - s.offsetLine
@@ -566,7 +657,7 @@ func (s *ScrollList) View() string {
 	if len(s.items) > 0 {
 		for idx := s.offsetIdx; idx < len(s.items) && remainingHeight > 0; idx++ {
 			item := s.items[idx]
-			content := item.Render(s.width)
+			content := s.renderItem(idx)
 
 			// Items that render to an empty string contribute zero height to
 			// the viewport. This MUST match renderedHeight()'s semantics —
@@ -634,8 +725,8 @@ func (s *ScrollList) ScrollPercent() float64 {
 	}
 
 	totalHeight := 0
-	for _, item := range s.items {
-		totalHeight += s.itemHeight(item)
+	for idx := range s.items {
+		totalHeight += s.itemHeight(idx)
 	}
 
 	if totalHeight <= s.height {
@@ -644,7 +735,7 @@ func (s *ScrollList) ScrollPercent() float64 {
 
 	linesAbove := 0
 	for i := 0; i < s.offsetIdx && i < len(s.items); i++ {
-		linesAbove += s.itemHeight(s.items[i])
+		linesAbove += s.itemHeight(i)
 	}
 	linesAbove += s.offsetLine
 
@@ -688,7 +779,7 @@ func (s *ScrollList) clampOffset() {
 
 	// Clamp offsetLine within current item.
 	if s.offsetIdx < len(s.items) {
-		ih := s.itemHeight(s.items[s.offsetIdx])
+		ih := s.itemHeight(s.offsetIdx)
 		if s.offsetLine >= ih {
 			s.offsetLine = max(0, ih-1)
 		}
@@ -707,36 +798,68 @@ func (s *ScrollList) clampOffset() {
 	}
 }
 
-// itemHeight returns the cached rendered height for an item, computing and
-// caching it on first access. This avoids calling Render() purely to
-// count lines — the most common source of redundant work in the scroll
-// list (GotoBottom, clampOffset, AtBottom, ScrollBy all need heights but
-// never use the rendered content).
+// itemHeight returns the cached rendered height for the item at idx,
+// computing and caching it on first access. This avoids calling Render()
+// purely to count lines — the most common source of redundant work in the
+// scroll list (GotoBottom, clampOffset, AtBottom, ScrollBy all need heights
+// but never use the rendered content).
 //
-// The cache is invalidated wholesale on width changes (SetWidth) and
-// individual entries are refreshed in View() after an item is actually
-// rendered, so stale entries are self-correcting within one frame.
-func (s *ScrollList) itemHeight(item MessageItem) int {
-	id := item.ID()
+// The cache is invalidated wholesale on width changes (SetWidth), per-item
+// when the selection moves (SetSelectedIndex), and individual entries are
+// refreshed in View() after an item is actually rendered, so stale entries
+// are self-correcting within one frame.
+func (s *ScrollList) itemHeight(idx int) int {
+	if idx < 0 || idx >= len(s.items) {
+		return 0
+	}
+	id := s.items[idx].ID()
 	if h, ok := s.heightCache[id]; ok {
 		return h
 	}
 	// Cache miss — render to measure.
-	h := s.renderedHeight(item)
+	h := s.renderedHeight(idx)
 	s.heightCache[id] = h
 	return h
 }
 
-// renderedHeight returns the height of a message item in lines by actually
+// renderedHeight returns the height of the item at idx in lines by actually
 // rendering it. This is the single source of truth for item height — it
 // matches exactly what View() produces, unlike item.Height() which may
-// return stale/zero values for uncached items (e.g. reasoning blocks).
-func (s *ScrollList) renderedHeight(item MessageItem) int {
-	rendered := item.Render(s.width)
+// return stale/zero values for uncached items (e.g. reasoning blocks) and
+// which is unaware of the selection border.
+func (s *ScrollList) renderedHeight(idx int) int {
+	rendered := s.renderItem(idx)
 	if rendered == "" {
 		return 0
 	}
 	return strings.Count(rendered, "\n") + 1
+}
+
+// renderItem renders the item at idx exactly as View() paints it, including
+// the selection border when idx is the selected message.
+//
+// Every consumer of item geometry (View, height measurement, mouse
+// hit-testing, text extraction) funnels through this method so they can
+// never disagree about how many lines an item occupies or which line is
+// which — a mismatch would offset mouse selection and corrupt the layout.
+func (s *ScrollList) renderItem(idx int) string {
+	if idx < 0 || idx >= len(s.items) {
+		return ""
+	}
+
+	if idx != s.selectedIdx {
+		return s.items[idx].Render(s.width)
+	}
+
+	// The border consumes one column on each side, so the content is asked
+	// to render narrower and the framed result still spans exactly s.width.
+	content := s.items[idx].Render(max(s.width-2, 1))
+	if content == "" {
+		// Nothing to frame — an empty item stays empty (and zero-height) so
+		// the selection can't conjure a box out of blank space.
+		return ""
+	}
+	return applySelectionBorder(content, s.width, style.GetTheme().Border)
 }
 
 // abs returns the absolute value of x.

--- a/internal/ui/scrolllist.go
+++ b/internal/ui/scrolllist.go
@@ -80,6 +80,13 @@ func (s *ScrollList) SetItems(items []MessageItem) {
 	// longer names a message.
 	if s.selectedIdx >= len(s.items) {
 		s.selectedIdx = len(s.items) - 1
+		// The item now under the selection may have a cached height measured
+		// without the selection border, which would throw the scroll maths
+		// off by selectionBorderOverhead until it is next rendered. Drop it
+		// so the next measurement includes the frame, as SetSelectedIndex does.
+		if s.selectedIdx >= 0 {
+			delete(s.heightCache, s.items[s.selectedIdx].ID())
+		}
 	}
 	if s.autoScroll && !s.sel.MouseDown {
 		s.GotoBottom()

--- a/internal/ui/session_selector.go
+++ b/internal/ui/session_selector.go
@@ -227,6 +227,14 @@ func (ss *SessionSelectorComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 // View implements tea.Model.
 func (ss *SessionSelectorComponent) View() tea.View {
+	v := tea.NewView(ss.RenderOverlay())
+	v.AltScreen = true
+	return v
+}
+
+// RenderOverlay returns the selector as a bare box, ready to be composited
+// over the main view so the conversation stays visible behind it.
+func (ss *SessionSelectorComponent) RenderOverlay() string {
 	// Compose dynamic footer extras: scope + filter + (delete confirm).
 	extra := fmt.Sprintf("scope: %s · filter: %s", ss.scope, ss.filter)
 	if ss.confirmDelete >= 0 && ss.confirmDelete < len(ss.filtered) {
@@ -236,10 +244,7 @@ func (ss *SessionSelectorComponent) View() tea.View {
 	ss.popup.Title = fmt.Sprintf("Resume Session (%s)", ss.scope)
 	ss.popup.ExtraFooter = extra
 
-	rendered := ss.popup.RenderCentered(ss.width, ss.height)
-	v := tea.NewView(rendered)
-	v.AltScreen = true
-	return v
+	return ss.popup.Render()
 }
 
 // IsActive returns whether the selector is still accepting input.

--- a/internal/ui/tree_selector.go
+++ b/internal/ui/tree_selector.go
@@ -211,12 +211,17 @@ func (ts *TreeSelectorComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 // View implements tea.Model.
 func (ts *TreeSelectorComponent) View() tea.View {
-	// Update extra footer with current filter mode.
-	ts.popup.ExtraFooter = fmt.Sprintf("[%s]", ts.filter)
-	rendered := ts.popup.RenderCentered(ts.width, ts.height)
-	v := tea.NewView(rendered)
+	v := tea.NewView(ts.RenderOverlay())
 	v.AltScreen = true
 	return v
+}
+
+// RenderOverlay returns the selector as a bare box, ready to be composited
+// over the main view so the conversation stays visible behind it.
+func (ts *TreeSelectorComponent) RenderOverlay() string {
+	// Update extra footer with current filter mode.
+	ts.popup.ExtraFooter = fmt.Sprintf("[%s]", ts.filter)
+	return ts.popup.Render()
 }
 
 // IsActive returns whether the tree selector is still accepting input.


### PR DESCRIPTION
## Description

Adds a message navigation mode to the transcript so long or truncated messages can actually be read, and fixes the overlay rendering inconsistencies that surfaced while reusing the modal dialog for it.

**Message navigation.** `Ctrl+X m` enters navigation mode (a new suffix on the existing `Ctrl+X` leader chord, alongside `s`/`t`/`e`). `↑`/`↓` or `j`/`k` move a selection between messages, `g`/`G` jump to the ends, `Enter` opens the selected message in the scrollable dialog, and `Esc` leaves. The selected message is framed by a thin border, and navigation swallows unhandled keys so `j`/`k` never leak into the composer.

The feature only works if the full text still exists, and it mostly didn't. Scrollback items stored the *already-truncated styled rendering* as their content for tool results, errors, system messages and shell output, so the inspector could only have shown the same elided text it was opened to escape. Each now retains its untruncated source alongside the display rendering. Concretely, a `!seq 1 300` result went from 26 inspectable lines to 302, and a `grep`'s full command — previously visible only as `... "Show the exact...` in the header — is now shown in full and stays copy-pasteable (arguments are laid out as `key: value` rather than JSON-encoded, which would escape every quote and collapse newlines).

**Overlay compositing.** Modals behaved three different ways: the tree selector, session selector and overlay dialog returned their own full-screen `tea.View` (the conversation vanished entirely), while the slash popup and model selector went through a line-merging helper that blanked the full width of every row the box occupied. Every modal now renders as a bare box and is composited by the parent at the cell level through an ultraviolet `ScreenBuffer` — the same approach the selection highlighter already uses — so content survives above, below, **and beside** each one, with ANSI styling intact on both sides of the splice.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional change)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`go test -race ./...`)
- [x] `go vet ./...`, `gofmt` and `golangci-lint run internal/ui/...` are clean (0 issues)
- [ ] I have made corresponding changes to the documentation

## Additional Information

### Pre-existing bugs fixed along the way

Compositing made latent bugs visible, because padding that was invisible on a blank canvas is now drawn as opaque cells:

- **`PopupList` bottom margin** — an unstyled row of spaces that cut a blank band under every popup.
- **Dialog key hints** — rendered *below* the border, so the hint row's padding erased a strip of the view. Hints moved inside the box and now share one footer row with the scroll indicator. The height budget already reserved a line for them, so this also corrects pre-existing chrome math.
- **Dialog width off-by-two** — `lipgloss.Width()` includes the border; treating it as border-exclusive made the content area two columns narrower than assumed and wrapped the title separator onto a stray line. Affected all extension overlays.
- **Session resume** — tool messages rebuilt from a session stored the truncated rendering, so they weren't inspectable after a reload the way live ones were.

### Measurement correctness

Two bugs made long `grep`/`ls` results unreadable, both fixed:

- The dialog body was measured *before* the box style wrapped it, so one source line became several rendered rows. 60 grep matches produced a **48-row dialog in a 30-row terminal** and the tail was unreachable. The body is now wrapped before measuring, so one measured line equals one rendered row and the budget, scroll offset and `of N lines` counter agree.
- **Tabs** broke the same accounting a second way: wrapping counts a tab as one cell while the renderer expands it to several, silently doubling the height of tab-indented output (most of what `grep` returns). Tabs are expanded before measuring in both the dialog body and the selection border, the latter using real tab stops.

### Files added

- `internal/ui/composite.go` — cell-level overlay compositor (`compositeOverlay` / `compositeCentered` / `compositeAnchored`)
- `internal/ui/message_nav.go` — navigation state, selection border, inspector content resolution
- `internal/ui/composite_test.go`, `internal/ui/message_nav_test.go` — 39 new tests

### Files modified

- `internal/ui/model.go` — `stateMessageNav`, `Ctrl+X m` chord, key routing, raw-content retention, single compositing path in `View()`
- `internal/ui/scrolllist.go` — selection-aware rendering; item geometry moved to index-based `renderItem`/`itemHeight` so `View()`, height measurement, mouse hit-testing and text extraction can never disagree
- `internal/ui/overlay.go` — returns an unpositioned box; footer inside the border; body wrapped before measuring
- `internal/ui/message_items.go` — `RawContent()` / `Role()` accessors
- `internal/ui/popup_list.go`, `input.go`, `model_selector.go`, `tree_selector.go`, `session_selector.go` — render bare boxes for compositing

### Backward compatibility

No changes to `internal/extensions/` or `pkg/` — the extension API surface is untouched. Extension overlays keep their existing semantics (`Enter` → completed, `Esc` → cancelled) and wording; the new `dismissOnly` flag defaults to `false` and is set only by the read-only inspector, where both keys are genuinely equivalent. `InputComponent.RenderPopupCentered` was renamed to `RenderPopupBox` and the `overlayContent` helper removed, both confined to `internal/ui` with no callers elsewhere.

### Notes for reviewers

- The tools themselves still cap output at source (`grep` 100 matches, `ls` 500 entries, both 50KB). That bound is deliberate and left alone — it's what the model sees too, so raising it for display would show text the LLM never received.
- The selection border is drawn manually rather than via a lipgloss border style: scrollback content is already styled and padded to the viewport width, so handing it to lipgloss would re-wrap every line and change item height unpredictably.
- Background dimming behind modals was deliberately **not** added — it aids contrast but works against seeing what's behind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added message navigation to browse, select, and inspect scrollback messages.
  * Added full-content inspection for messages, tool results (including arguments), and shell output.
  * Updated popups/selectors/dialogs to render as overlays on top of the conversation without clearing it.
* **Bug Fixes**
  * Improved overlay compositing for accurate cell placement, centering/anchoring, and terminal boundary clamping.
  * Fixed handling of padded trailing rows, overlay wrapping/height budgeting, and dialog footer/scroll indicator layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->