### PR TITLE
fix(ui): stop the diff overflowing narrow terminals, unify tool body geometry

### DIFF
--- a/internal/ui/block_contract_test.go
+++ b/internal/ui/block_contract_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"charm.land/lipgloss/v2"
+
 	"github.com/mark3labs/kit/internal/ui/style"
 )
 
@@ -385,6 +387,49 @@ func TestBlockTrailingGap(t *testing.T) {
 			}
 			if gap := trailingBlankLines(got); gap != style.BlockGap {
 				t.Errorf("block ends with %d blank lines, want %d", gap, style.BlockGap)
+			}
+		})
+	}
+}
+
+// TestBlockHasNoTrailingGutterRows verifies a block does not draw its gutter
+// beside empty rows at the end.
+//
+// Command output almost always ends with a newline, so a block built from it
+// carried a final row that was nothing but a gutter glyph — which reads as an
+// unfinished block rather than as space. Separation between blocks is the
+// margin's job.
+func TestBlockHasNoTrailingGutterRows(t *testing.T) {
+	const w = 60
+
+	for _, tc := range []struct {
+		name    string
+		content string
+	}{
+		{"trailing newline", "line one\nline two\n"},
+		{"several trailing newlines", "line one\n\n\n"},
+		{"no trailing newline", "line one\nline two"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := renderContentBlock(tc.content, w,
+				WithAlign(lipgloss.Left),
+				WithBorderColor(style.GetTheme().Accent),
+				WithMarginBottom(style.BlockGap),
+			)
+
+			lines := strings.Split(stripBlockAnsi(got), "\n")
+			// Walk back over the margin, then require the last drawn row to
+			// carry text rather than a lone gutter glyph.
+			i := len(lines) - 1
+			for i >= 0 && strings.TrimSpace(lines[i]) == "" {
+				i--
+			}
+			if i < 0 {
+				t.Fatalf("block rendered nothing:\n%q", got)
+			}
+			if strings.TrimSpace(lines[i]) == style.GutterGlyph {
+				t.Errorf("block ends with a bare gutter row:\n%s",
+					strings.Join(lines, "\n"))
 			}
 		})
 	}

--- a/internal/ui/block_contract_test.go
+++ b/internal/ui/block_contract_test.go
@@ -215,6 +215,29 @@ func blockCases() []blockCase {
 			},
 		},
 		{
+			// The diff renderer was the one tool body this table originally
+			// missed, and it overflowed the terminal below ~50 columns.
+			name:   "tool/edit",
+			marker: true,
+			render: func(r *MessageRenderer, w int) string {
+				args := `{"path":"a.go","edits":[{"old_text":"a somewhat longer original line here",` +
+					`"new_text":"a somewhat longer replacement line here"}]}`
+				return r.RenderToolMessage("edit", args, "edited", false).Content
+			},
+		},
+		{
+			name:   "tool/edit-multiline",
+			marker: true,
+			render: func(r *MessageRenderer, w int) string {
+				old := strings.Repeat("an original line of some length\n", 12)
+				new := strings.Repeat("a replacement line of some length\n", 12)
+				args := `{"path":"a.go","edits":[{"old_text":"` +
+					strings.ReplaceAll(old, "\n", "\\n") + `","new_text":"` +
+					strings.ReplaceAll(new, "\n", "\\n") + `"}]}`
+				return r.RenderToolMessage("edit", args, "edited", false).Content
+			},
+		},
+		{
 			name:   "tool/error",
 			marker: true,
 			render: func(r *MessageRenderer, w int) string {

--- a/internal/ui/block_renderer.go
+++ b/internal/ui/block_renderer.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"image/color"
+	"strings"
 
 	"charm.land/lipgloss/v2"
 
@@ -102,6 +103,13 @@ func renderContentBlock(content string, containerWidth int, options ...rendering
 	for _, option := range options {
 		option(renderer)
 	}
+
+	// Trailing blank lines inside the block would be drawn with the gutter
+	// glyph beside them, which reads as an unfinished block rather than as
+	// space. Command output usually ends with a newline, so this is the
+	// common case, not the exceptional one. Vertical separation is the
+	// margin's job.
+	content = strings.TrimRight(content, "\n")
 
 	// Resolve border configuration.
 	hasBorder := !renderer.noBorder

--- a/internal/ui/tool_body_test.go
+++ b/internal/ui/tool_body_test.go
@@ -350,8 +350,9 @@ func TestPadRightHandlesDegenerateWidths(t *testing.T) {
 		}
 	}
 
-	// Multi-byte input must pad by display cells, not bytes: "···" is nine
-	// bytes but three cells, so a width of 10 leaves seven spaces.
+	// Multi-byte input must pad by display cells, not bytes: "···" is six
+	// bytes (three 2-byte U+00B7 code points) but three cells, so a width of
+	// 10 leaves seven spaces.
 	if got, want := padRight("···", 10), "···"+strings.Repeat(" ", 7); got != want {
 		t.Errorf("padRight(%q, 10) = %q, want %q", "···", got, want)
 	}

--- a/internal/ui/tool_body_test.go
+++ b/internal/ui/tool_body_test.go
@@ -2,8 +2,11 @@ package ui
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
+
+	"charm.land/lipgloss/v2"
 
 	"github.com/mark3labs/kit/internal/ui/style"
 )
@@ -271,4 +274,88 @@ func TestDiffFallsBackToUnified(t *testing.T) {
 			t.Errorf("expected side-by-side at 100 columns, got:\n%s", got)
 		}
 	})
+}
+
+// multiHunkDiffArgs builds an edit spanning two changes far enough apart that
+// the differ emits separate hunks, with unchanged context between them.
+func multiHunkDiffArgs(t *testing.T) string {
+	t.Helper()
+	before := make([]string, 40)
+	after := make([]string, 40)
+	for i := range before {
+		line := fmt.Sprintf("unchanged context line %d", i)
+		before[i], after[i] = line, line
+	}
+	before[2], after[2] = "FIRST original", "FIRST changed"
+	before[35], after[35] = "SECOND original", "SECOND changed"
+	return diffArgs(t, strings.Join(before, "\n"), strings.Join(after, "\n"))
+}
+
+// TestMultiHunkDiff covers the hunk-separator row, which only appears when a
+// diff has more than one hunk — a case every other test here misses, because
+// a single replacement produces exactly one.
+//
+// The separator is built from U+00B7, so it is also the one row whose padding
+// depends on width being measured in cells rather than bytes.
+func TestMultiHunkDiff(t *testing.T) {
+	args := multiHunkDiffArgs(t)
+
+	t.Run("separator appears and both hunks survive", func(t *testing.T) {
+		for _, w := range []int{40, 80, 120} {
+			got := stripBlockAnsi(renderToolBody("edit", args, "edited", bodyWidthFor(w)))
+			if !strings.Contains(got, "···") {
+				t.Errorf("w=%d: expected a hunk separator:\n%s", w, got)
+			}
+			for _, want := range []string{"FIRST", "SECOND"} {
+				if !strings.Contains(got, want) {
+					t.Errorf("w=%d: hunk %q was dropped:\n%s", w, want, got)
+				}
+			}
+		}
+	})
+
+	t.Run("stays within budget", func(t *testing.T) {
+		for _, w := range []int{40, 80, 120} {
+			budget := bodyWidthFor(w)
+			if widest := widestColumn(renderToolBody("edit", args, "edited", budget)); widest > budget {
+				t.Errorf("w=%d: multi-hunk diff overflows: %d > %d", w, widest, budget)
+			}
+		}
+	})
+
+	t.Run("survives degenerate widths", func(t *testing.T) {
+		// The separator row pads to the available width. If that arithmetic
+		// were byte-based or unguarded against negatives it would misalign or
+		// panic here rather than at a normal size.
+		for _, w := range []int{-10, -1, 0, 1, 5, 10} {
+			if got := renderToolBody("edit", args, "edited", w); got == "" {
+				t.Errorf("w=%d: rendered nothing", w)
+			}
+		}
+	})
+}
+
+// TestPadRightHandlesDegenerateWidths pins the padding helper's behaviour at
+// the edges the diff renderers can reach.
+//
+// padRight measures with xansi.StringWidth, so a multi-byte glyph costs its
+// display cells rather than its bytes, and a non-positive width returns empty
+// via truncation rather than reaching strings.Repeat with a negative count.
+// Both properties are load-bearing for the hunk separator and easy to lose in
+// a refactor, so they are asserted rather than assumed.
+func TestPadRightHandlesDegenerateWidths(t *testing.T) {
+	for _, w := range []int{-100, -1, 0} {
+		if got := padRight("···", w); got != "" {
+			t.Errorf("padRight(%q, %d) = %q, want empty", "···", w, got)
+		}
+	}
+
+	// Multi-byte input must pad by display cells, not bytes: "···" is nine
+	// bytes but three cells, so a width of 10 leaves seven spaces.
+	if got, want := padRight("···", 10), "···"+strings.Repeat(" ", 7); got != want {
+		t.Errorf("padRight(%q, 10) = %q, want %q", "···", got, want)
+	}
+	if got := lipgloss.Width(padRight("···", 10)); got != 10 {
+		t.Errorf("padded width = %d cells, want 10", got)
+	}
 }

--- a/internal/ui/tool_body_test.go
+++ b/internal/ui/tool_body_test.go
@@ -1,0 +1,274 @@
+package ui
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/kit/internal/ui/style"
+)
+
+// Tool bodies are nested content: they sit beneath a tool header whose marker
+// occupies column 0. The block contract (block_contract_test.go) pins where
+// the header starts and that nothing overflows; these tests pin the interior,
+// which the contract test cannot see because every body type satisfies it in
+// its own way.
+
+// bodyWidthFor is the width a body renderer receives for a given terminal
+// width, matching what RenderToolMessage passes.
+func bodyWidthFor(termWidth int) int { return termWidth - 8 }
+
+// bodyIndentColumn returns the number of literal spaces a rendered body line
+// carries before its styling begins.
+//
+// This deliberately measures the un-stripped string. A tool body's panel is
+// indented with plain spaces and then painted, so the panel's left edge is the
+// last plain space before the first escape sequence. Measuring the stripped
+// text instead would report the panel's interior padding (and, for the read
+// and write bodies, their line-number gutters) as though it were indentation.
+func bodyIndentColumn(rendered string) int {
+	for line := range strings.SplitSeq(rendered, "\n") {
+		if strings.TrimSpace(stripBlockAnsi(line)) == "" {
+			continue
+		}
+		return len(line) - len(strings.TrimLeft(line, " "))
+	}
+	return -1
+}
+
+// toolBodyCases covers every renderer reachable from renderToolBody, with
+// input shaped the way the real tools emit it.
+var toolBodyCases = []struct {
+	name   string
+	tool   string
+	args   string
+	result string
+}{
+	{
+		name: "bash", tool: "bash", args: `{"command":"ls -la"}`,
+		result: "total 24\n-rw-r--r--  1 user staff 1024 main.go\nSTDERR:\nls: nope: No such file\nExit code: 1",
+	},
+	{
+		name: "bash/truncating", tool: "bash", args: `{"command":"yes"}`,
+		result: strings.Repeat("a line of output\n", 40),
+	},
+	{
+		name: "ls", tool: "ls", args: `{"path":"/tmp"}`,
+		result: strings.Repeat("some/path/to/file.go\n", 30),
+	},
+	{
+		name: "grep", tool: "grep", args: `{"pattern":"func"}`,
+		result: strings.Repeat("main.go:12: func main() {}\n", 5),
+	},
+	{
+		name: "find", tool: "find", args: `{"pattern":"*.go"}`,
+		result: strings.Repeat("internal/ui/model.go\n", 5),
+	},
+	{
+		name: "read", tool: "read", args: `{"path":"main.go"}`,
+		result: "1: package main\n2: \n3: func main() {}\n",
+	},
+	{
+		name: "write", tool: "write",
+		args:   `{"path":"a.go","content":"package main\n\nfunc main() {}\n"}`,
+		result: "written",
+	},
+	{
+		name: "subagent", tool: "subagent", args: `{"agent":"explore"}`,
+		result: "Subagent completed successfully in 12s\n\nResult:\nFound three call sites\n",
+	},
+	{
+		name: "subagent/failed", tool: "subagent", args: `{"agent":"explore"}`,
+		result: "Subagent failed\n\nError:\ncontext deadline exceeded\n",
+	},
+	{
+		name: "edit", tool: "edit",
+		args:   `{"path":"a.go","edits":[{"old_text":"one","new_text":"two"}]}`,
+		result: "edited",
+	},
+}
+
+// TestToolBodyStartsAtContentColumn pins every tool body to the same left
+// edge. Each renderer used to apply its own two-space literal, which meant a
+// change to one of them silently produced a body that no longer lined up with
+// the rest.
+func TestToolBodyStartsAtContentColumn(t *testing.T) {
+	for _, w := range []int{40, 80, 120} {
+		for _, tc := range toolBodyCases {
+			t.Run(tc.name+"/w"+itoa(w), func(t *testing.T) {
+				got := renderToolBody(tc.tool, tc.args, tc.result, bodyWidthFor(w))
+				if got == "" {
+					t.Skip("renderer declined this input")
+				}
+				if col := bodyIndentColumn(got); col != style.ContentOffset {
+					t.Errorf("body panel starts at column %d, want %d\nfirst line: %q",
+						col, style.ContentOffset, strings.SplitN(stripBlockAnsi(got), "\n", 2)[0])
+				}
+			})
+		}
+	}
+}
+
+// TestToolBodyFitsWidth guards the interior directly. RenderToolMessage's
+// output is already covered by the block contract, but a body that overflows
+// its own budget while the surrounding block stays inside the terminal would
+// pass that test and still look wrong.
+func TestToolBodyFitsWidth(t *testing.T) {
+	for _, w := range []int{40, 80, 120} {
+		budget := bodyWidthFor(w)
+		for _, tc := range toolBodyCases {
+			t.Run(tc.name+"/w"+itoa(w), func(t *testing.T) {
+				got := renderToolBody(tc.tool, tc.args, tc.result, budget)
+				if got == "" {
+					t.Skip("renderer declined this input")
+				}
+				if widest := widestColumn(got); widest > budget {
+					t.Errorf("body overflows its budget: widest %d > %d\n%s",
+						widest, budget, firstOverflowingLine(got, budget))
+				}
+			})
+		}
+	}
+}
+
+// TestToolPanelsShareGeometry verifies the renderers that draw a filled panel
+// produce panels of identical width. They are stacked in a single transcript,
+// so a one-column difference between them is visible as a ragged right edge
+// even though each is individually within budget.
+func TestToolPanelsShareGeometry(t *testing.T) {
+	const w = 80
+	budget := bodyWidthFor(w)
+
+	panels := map[string]string{
+		"bash":     renderToolBody("bash", `{"command":"ls"}`, strings.Repeat("x", 200), budget),
+		"ls":       renderToolBody("ls", `{"path":"/tmp"}`, strings.Repeat("x", 200), budget),
+		"grep":     renderToolBody("grep", `{"pattern":"x"}`, strings.Repeat("x", 200), budget),
+		"subagent": renderToolBody("subagent", `{"agent":"a"}`, strings.Repeat("x", 200), budget),
+	}
+
+	widths := map[string]int{}
+	for name, rendered := range panels {
+		if rendered == "" {
+			t.Fatalf("%s produced no body", name)
+		}
+		widths[name] = widestColumn(rendered)
+	}
+
+	var first string
+	for name, got := range widths {
+		if first == "" {
+			first = name
+			continue
+		}
+		if got != widths[first] {
+			t.Errorf("panel widths differ: %s=%d, %s=%d", first, widths[first], name, got)
+		}
+	}
+}
+
+// TestBashStripsOutputTags verifies the tagged stdout/stderr form is unwrapped
+// rather than shown as literal markup.
+//
+// Kit's builtin bash tool emits the STDERR:/Exit code: form, not this one, so
+// nothing in-tree produces it — but the error path already stripped these tags
+// via parseBashOutput, which meant a third-party MCP tool named "bash" would
+// have its markup hidden when it failed and shown raw when it succeeded.
+func TestBashStripsOutputTags(t *testing.T) {
+	got := stripBlockAnsi(renderToolBody("bash", `{"command":"x"}`,
+		"<stdout>\nhello\n</stdout>\n<stderr>\nbad\n</stderr>", 70))
+
+	for _, tag := range []string{"<stdout>", "</stdout>", "<stderr>", "</stderr>"} {
+		if strings.Contains(got, tag) {
+			t.Errorf("rendered body still contains %s:\n%s", tag, got)
+		}
+	}
+	if !strings.Contains(got, "hello") {
+		t.Errorf("stdout content was dropped:\n%s", got)
+	}
+}
+
+// TestBashReportsExitCodeInCaption verifies the exit-code line is lifted out
+// of the output and into the caption rather than rendered as a body line.
+func TestBashReportsExitCodeInCaption(t *testing.T) {
+	got := stripBlockAnsi(renderToolBody("bash", `{"command":"false"}`,
+		"some output\nExit code: 3", 70))
+
+	if strings.Contains(got, "Exit code: 3") {
+		t.Errorf("raw exit-code line leaked into the body:\n%s", got)
+	}
+	if !strings.Contains(got, "exit code 3") {
+		t.Errorf("caption is missing the exit code:\n%s", got)
+	}
+}
+
+// TestToolBodySurvivesNarrowWidth guards the clamp. renderBashBody used to
+// compute a clamped width and then render with the unclamped one, which goes
+// negative below the indent and makes lipgloss emit nothing at all.
+func TestToolBodySurvivesNarrowWidth(t *testing.T) {
+	for _, w := range []int{0, 1, 2, 5, 10} {
+		for _, tc := range toolBodyCases {
+			t.Run(tc.name+"/w"+itoa(w), func(t *testing.T) {
+				// Must not panic, and must not silently render nothing when
+				// there was content to show.
+				got := renderToolBody(tc.tool, tc.args, tc.result, w)
+				if strings.TrimSpace(stripBlockAnsi(got)) == "" && got != "" {
+					t.Errorf("rendered only whitespace at width %d", w)
+				}
+			})
+		}
+	}
+}
+
+// diffArgs builds edit-tool arguments for a single before/after replacement.
+// The payload is marshalled rather than concatenated: the text under test
+// contains tabs and quotes, which are not legal raw inside a JSON string, and
+// hand-escaping them silently produced arguments the renderer rejected.
+func diffArgs(t *testing.T, before, after string) string {
+	t.Helper()
+	payload := map[string]any{
+		"path": "a.go",
+		"edits": []map[string]string{
+			{"old_text": before, "new_text": after},
+		},
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshalling edit args: %v", err)
+	}
+	return string(encoded)
+}
+
+// TestDiffFallsBackToUnified verifies the side-by-side layout gives way to a
+// single column when there is not room for two.
+//
+// The panels have minimum widths, so forcing them into a narrow terminal
+// produced rows wider than the screen — 43 columns inside a 40-column
+// terminal. That wraps in the emulator rather than in lipgloss, which is
+// exactly the class of bug the block contract exists to prevent.
+func TestDiffFallsBackToUnified(t *testing.T) {
+	args := diffArgs(t,
+		"func hello() string {\n\treturn \"old value\"\n}",
+		"func hello() string {\n\treturn \"new value\"\n}",
+	)
+
+	t.Run("narrow renders one column", func(t *testing.T) {
+		got := stripBlockAnsi(renderToolBody("edit", args, "edited", bodyWidthFor(40)))
+		if got == "" {
+			t.Fatal("diff produced no body")
+		}
+		if strings.Contains(got, "│") {
+			t.Errorf("expected a unified diff at 40 columns, got side-by-side:\n%s", got)
+		}
+		// Both sides of the change must still be present.
+		if !strings.Contains(got, "old value") || !strings.Contains(got, "new value") {
+			t.Errorf("unified diff dropped one side of the change:\n%s", got)
+		}
+	})
+
+	t.Run("wide keeps side by side", func(t *testing.T) {
+		got := stripBlockAnsi(renderToolBody("edit", args, "edited", bodyWidthFor(100)))
+		if !strings.Contains(got, "│") {
+			t.Errorf("expected side-by-side at 100 columns, got:\n%s", got)
+		}
+	})
+}

--- a/internal/ui/tool_renderers.go
+++ b/internal/ui/tool_renderers.go
@@ -28,11 +28,95 @@ const (
 	maxLsLines    = 20 // lines for Ls directory listings
 )
 
+// minDiffContent is the narrowest code column a diff panel is worth drawing.
+// Below it the text is too clipped to compare against anything, so the layout
+// switches to a unified diff rather than shrinking further.
+const minDiffContent = 12
+
 // isShellTool reports if the tool name matches a shell-like tool (bash or
 // tools with "shell"/"command" in the name). Used by renderToolBody.
 func isShellTool(toolName string) bool {
 	return toolName == "bash" ||
 		strings.Contains(toolName, "shell") || strings.Contains(toolName, "command")
+}
+
+// ---------------------------------------------------------------------------
+// Shared tool body geometry
+// ---------------------------------------------------------------------------
+
+// toolIndent is the left indent applied to every tool body, placing it at the
+// shared content column beneath the tool header's marker.
+func toolIndent() string {
+	return strings.Repeat(" ", style.ContentOffset)
+}
+
+// panelPadding is the interior left padding of a tool body panel. The panel's
+// background begins at the content column and its text is inset by this much,
+// so the fill reads as a surface rather than as text with a colored margin.
+const panelPadding = 1
+
+// toolPanel renders lines inside the background-filled panel shared by the
+// bash, ls, find, grep and subagent bodies.
+//
+// Each of those renderers used to compute the same three quantities by hand —
+// panel width, per-line truncation budget, indent — and they disagreed: some
+// clamped the width and some did not, and renderBashBody clamped the value it
+// computed but then rendered with the unclamped one, which goes negative on a
+// very narrow terminal and makes lipgloss emit nothing at all. Deriving them
+// once keeps the panels identical and keeps the arithmetic in one place.
+type toolPanel struct {
+	// width is the panel's total width, including its interior padding.
+	width int
+	// textWidth is what remains for text after the interior padding.
+	textWidth int
+
+	text lipgloss.Style
+	err  lipgloss.Style
+}
+
+// newToolPanel builds a panel sized for a tool body rendered at the given
+// body width (the width handed to the body renderer, already inside the
+// tool block).
+func newToolPanel(bodyWidth int) toolPanel {
+	theme := GetTheme()
+	width := max(bodyWidth-style.ContentOffset, style.MinContentWidth)
+	return toolPanel{
+		width:     width,
+		textWidth: max(width-panelPadding, 1),
+		text:      lipgloss.NewStyle().Background(theme.CodeBg).PaddingLeft(panelPadding).Width(width),
+		err: lipgloss.NewStyle().Foreground(theme.Error).Background(theme.CodeBg).
+			PaddingLeft(panelPadding).Width(width),
+	}
+}
+
+// line renders one panel row, truncated to fit. The row is not indented:
+// callers indent the finished block (content plus any caption) as a unit, so
+// the caption lands in the same column as the panel above it.
+//
+// Truncation happens before styling because cutting a string that already
+// holds ANSI escapes truncates the escapes with it.
+func (p toolPanel) line(s string, isErr bool) string {
+	s = truncateLine(s, p.textWidth)
+	if isErr {
+		return p.err.Render(s)
+	}
+	return p.text.Render(s)
+}
+
+// blank renders an empty panel row, used to separate sections without
+// breaking the background fill.
+func (p toolPanel) blank() string {
+	return p.text.Render("")
+}
+
+// captionTypography returns a herald instance that places a muted caption
+// beneath a figure. Every tool body that captions its output built this
+// inline; they are identical.
+func captionTypography() *herald.Typography {
+	return herald.New(herald.WithTheme(herald.Theme{
+		FigureCaption:         lipgloss.NewStyle().Foreground(GetTheme().Muted),
+		FigureCaptionPosition: herald.CaptionBottom,
+	}))
 }
 
 // renderToolBody dispatches to tool-specific body renderers based on tool name.
@@ -243,9 +327,7 @@ func renderDiffBlock(before, after string, startLine int, width int) string {
 	}
 
 	// Layout calculations
-	const indent = "  "
-	availableWidth := width - len(indent)
-	panelWidth := max((availableWidth-3)/2, 20) // " │ " divider
+	availableWidth := width - style.ContentOffset
 
 	// Gutter width from max line number
 	maxLineNum := 1
@@ -258,7 +340,22 @@ func renderDiffBlock(before, after string, startLine int, width int) string {
 		}
 	}
 	gutterWidth := max(len(fmt.Sprintf("%d", maxLineNum)), 3)
-	contentWidth := max(panelWidth-gutterWidth-4, 10) // gutter + " - " or " + "
+
+	// A side-by-side diff needs room for two gutters, two markers, two
+	// columns of code and the divider between them. Below that it cannot be
+	// drawn at all: the panels have minimum widths, and forcing them into a
+	// narrow terminal produced rows wider than the screen, which wrap in the
+	// emulator and throw off the scroll list's height accounting. A unified
+	// diff says the same thing in one column, so narrow terminals get that
+	// instead of a broken two-column layout.
+	panelOverhead := gutterWidth + 4 // gutter, its leading space, and " - "
+	minSideBySide := 2*(panelOverhead+minDiffContent) + 3
+	if availableWidth < minSideBySide {
+		return renderUnifiedDiff(lines, diffHiddenCount, availableWidth, gutterWidth)
+	}
+
+	panelWidth := (availableWidth - 3) / 2 // " │ " divider
+	contentWidth := max(panelWidth-panelOverhead, minDiffContent)
 
 	theme := GetTheme()
 
@@ -279,7 +376,7 @@ func renderDiffBlock(before, after string, startLine int, width int) string {
 	for _, sl := range lines {
 		// Hunk separator
 		if sl.beforeKind == -1 {
-			sep := indent +
+			sep := toolIndent() +
 				dividerStyle.Render(padRight("···", panelWidth)) + " " +
 				dividerStyle.Render("│") + " " +
 				dividerStyle.Render(padRight("···", panelWidth))
@@ -322,7 +419,7 @@ func renderDiffBlock(before, after string, startLine int, width int) string {
 				contentMissing.Render(padRight("", contentWidth+3))
 		}
 
-		row := indent + left + " " + dividerStyle.Render("│") + " " + right
+		row := toolIndent() + left + " " + dividerStyle.Render("│") + " " + right
 		result = append(result, row)
 	}
 
@@ -334,8 +431,67 @@ func renderDiffBlock(before, after string, startLine int, width int) string {
 			Background(theme.DiffEqualBg).
 			Italic(true)
 		fullWidth := panelWidth*2 + 3 // both panels + divider
-		hintRow := indent + hintStyle.Width(fullWidth).Render(hint)
+		hintRow := toolIndent() + hintStyle.Width(fullWidth).Render(hint)
 		result = append(result, hintRow)
+	}
+
+	return strings.Join(result, "\n")
+}
+
+// renderUnifiedDiff renders a diff as a single column of changed lines, used
+// when the terminal is too narrow for the side-by-side layout.
+//
+// Deleted and inserted lines are shown on their own rows, marked and tinted
+// the same way as their side-by-side counterparts, so the vocabulary is the
+// same in both layouts and only the arrangement changes.
+func renderUnifiedDiff(lines []splitLine, hiddenCount, availableWidth, gutterWidth int) string {
+	theme := GetTheme()
+
+	gutterDelete := lipgloss.NewStyle().Foreground(theme.Muted).Background(theme.DiffDeleteBg)
+	gutterInsert := lipgloss.NewStyle().Foreground(theme.Muted).Background(theme.DiffInsertBg)
+	gutterEqual := lipgloss.NewStyle().Foreground(theme.VeryMuted).Background(theme.DiffEqualBg)
+	contentDelete := lipgloss.NewStyle().Background(theme.DiffDeleteBg)
+	contentInsert := lipgloss.NewStyle().Background(theme.DiffInsertBg)
+	contentEqual := lipgloss.NewStyle().Foreground(theme.Muted).Background(theme.DiffEqualBg)
+	dividerStyle := lipgloss.NewStyle().Foreground(theme.MutedBorder)
+
+	// gutter (with its leading space) + " - " marker + code
+	contentWidth := max(availableWidth-gutterWidth-4, 1)
+
+	row := func(num int, marker string, text string, g, c lipgloss.Style) string {
+		gutter := fmt.Sprintf(" %*d", gutterWidth, num)
+		code := padRight(truncateLine(strings.TrimRight(text, "\n"), contentWidth), contentWidth)
+		return toolIndent() + g.Render(gutter) + c.Render(marker+code)
+	}
+
+	var result []string
+	for _, sl := range lines {
+		if sl.beforeKind == -1 {
+			result = append(result, toolIndent()+dividerStyle.Render(padRight("···", availableWidth)))
+			continue
+		}
+
+		// An equal line appears once; a changed line contributes its deletion
+		// and its insertion as consecutive rows.
+		if sl.beforeNum > 0 && sl.beforeKind == udiff.Equal {
+			result = append(result, row(sl.beforeNum, "   ", sl.beforeText, gutterEqual, contentEqual))
+			continue
+		}
+		if sl.beforeNum > 0 && sl.beforeKind == udiff.Delete {
+			result = append(result, row(sl.beforeNum, " - ", sl.beforeText, gutterDelete, contentDelete))
+		}
+		if sl.afterNum > 0 && sl.afterKind == udiff.Insert {
+			result = append(result, row(sl.afterNum, " + ", sl.afterText, gutterInsert, contentInsert))
+		}
+	}
+
+	if hiddenCount > 0 {
+		hint := fmt.Sprintf("...(%d more lines)", hiddenCount)
+		hintStyle := lipgloss.NewStyle().
+			Foreground(theme.Muted).
+			Background(theme.DiffEqualBg).
+			Italic(true)
+		result = append(result, toolIndent()+hintStyle.Width(availableWidth).Render(hint))
 	}
 
 	return strings.Join(result, "\n")
@@ -365,36 +521,22 @@ func renderPlainListBody(toolResult string, width int, caption func(total, hidde
 		lines = lines[:maxLsLines]
 	}
 
-	const lineIndent = "  "
-	codeWidth := max(width-len(lineIndent), 20)
-
-	theme := GetTheme()
-	codeStyle := lipgloss.NewStyle().Background(theme.CodeBg).PaddingLeft(1)
+	panel := newToolPanel(width)
 
 	var rendered []string
 	for _, line := range lines {
-		// Truncate before styling to prevent wrapping.
-		line = truncateLine(line, codeWidth-1) // account for PaddingLeft(1)
-		styled := codeStyle.Width(codeWidth).Render(line)
-		rendered = append(rendered, styled)
+		rendered = append(rendered, panel.line(line, false))
 	}
 
 	content = strings.Join(rendered, "\n")
 
-	const blockIndent = "  "
 	if hiddenCount > 0 {
-		ty := herald.New(herald.WithTheme(herald.Theme{
-			FigureCaption:         lipgloss.NewStyle().Foreground(theme.Muted),
-			FigureCaptionPosition: herald.CaptionBottom,
-		}))
-		result := ty.Figure(content, caption(total, hiddenCount))
-
-		// Indent entire block (content + caption) to match other tools
-		return indentBlock(result, blockIndent)
+		result := captionTypography().Figure(content, caption(total, hiddenCount))
+		// Indent content and caption together so both sit at the content column.
+		return indentBlock(result, toolIndent())
 	}
 
-	// No caption - just return indented content
-	return indentBlock(content, blockIndent)
+	return indentBlock(content, toolIndent())
 }
 
 // renderFindBody renders find output as a plain list with code background.
@@ -625,9 +767,8 @@ func renderWriteBlock(content, fileName string, width int) string {
 	highlightedLines := strings.Split(highlighted, "\n")
 
 	// Layout
-	const codeIndent = "  "
 	gutterWidth := numDigits + 2
-	codeWidth := max(width-gutterWidth-len(codeIndent), 20)
+	codeWidth := max(width-gutterWidth-style.ContentOffset, style.MinContentWidth)
 
 	theme := GetTheme()
 	gutterStyle := lipgloss.NewStyle().Foreground(theme.Muted).Background(theme.GutterBg).PaddingRight(1)
@@ -649,7 +790,7 @@ func renderWriteBlock(content, fileName string, width int) string {
 		codePart = truncateLine(codePart, codeWidth-1) // account for PaddingLeft(1)
 		styledCode := writeStyle.Width(codeWidth).Render(codePart)
 
-		result = append(result, codeIndent+lipgloss.JoinHorizontal(lipgloss.Top, gutter, styledCode))
+		result = append(result, toolIndent()+lipgloss.JoinHorizontal(lipgloss.Top, gutter, styledCode))
 	}
 
 	// Footer
@@ -665,7 +806,7 @@ func renderWriteBlock(content, fileName string, width int) string {
 		Foreground(theme.Muted).
 		Italic(true).
 		Render(footer)
-	result = append(result, codeIndent+lipgloss.JoinHorizontal(lipgloss.Top, emptyGutter, footerContent))
+	result = append(result, toolIndent()+lipgloss.JoinHorizontal(lipgloss.Top, emptyGutter, footerContent))
 
 	return strings.Join(result, "\n")
 }
@@ -682,11 +823,16 @@ func renderBashBody(toolArgs, toolResult string, width int) string {
 	}
 
 	theme := GetTheme()
-	outputStyle := lipgloss.NewStyle().Background(theme.CodeBg).PaddingLeft(1)
-	stderrStyle := lipgloss.NewStyle().Foreground(theme.Error).Background(theme.CodeBg).PaddingLeft(1)
 
-	// Parse stdout/stderr sections (if tagged) or STDERR: label
+	// Strip <stdout>/<stderr> tags if present. Kit's builtin bash tool emits
+	// the STDERR:/Exit code: form handled below, but a third-party MCP tool
+	// named "bash" may emit the tagged form, which the error path already
+	// strips via parseBashOutput. Handling it here keeps the two paths
+	// agreeing instead of showing raw markup on the success path only.
 	result := toolResult
+	if strings.Contains(result, "<stdout>") || strings.Contains(result, "<stderr>") {
+		result = parseBashOutput(result, theme)
+	}
 
 	// Truncate to maxBashLines for display
 	lines := strings.Split(result, "\n")
@@ -696,17 +842,12 @@ func renderBashBody(toolArgs, toolResult string, width int) string {
 		lines = lines[:maxBashLines]
 	}
 
-	const lineIndent = "  "
-	// Truncate individual lines to the available width so they never wrap.
-	lineWidth := max(width-len(lineIndent), 20)
-	// Account for PaddingLeft(1) on the output/stderr styles
-	maxLineChars := lineWidth - 1
+	panel := newToolPanel(width)
 
 	var rendered []string
 	exitCode := -1 // -1 means not found
 	inStderr := false
 	for _, line := range lines {
-		line = truncateLine(line, maxLineChars)
 		// Detect the STDERR: label that Kit's bash tool emits
 		if strings.TrimSpace(line) == "STDERR:" {
 			inStderr = true
@@ -718,13 +859,7 @@ func renderBashBody(toolArgs, toolResult string, width int) string {
 			continue // Don't render exit code inline, it goes in caption
 		}
 
-		if inStderr {
-			styled := stderrStyle.Width(width - len(lineIndent)).Render(line)
-			rendered = append(rendered, styled)
-		} else {
-			styled := outputStyle.Width(width - len(lineIndent)).Render(line)
-			rendered = append(rendered, styled)
-		}
+		rendered = append(rendered, panel.line(line, inStderr))
 	}
 
 	// Build caption with status info
@@ -738,19 +873,15 @@ func renderBashBody(toolArgs, toolResult string, width int) string {
 
 	content := strings.Join(rendered, "\n")
 	if len(captionParts) > 0 {
-		ty := herald.New(herald.WithTheme(herald.Theme{
-			FigureCaption:         lipgloss.NewStyle().Foreground(theme.Muted),
-			FigureCaptionPosition: herald.CaptionBottom,
-		}))
 		caption := strings.Join(captionParts, " · ")
-		result := ty.Figure(content, caption)
+		result := captionTypography().Figure(content, caption)
 
 		// Indent entire block (content + caption) to match other tools
-		return indentBlock(result, "  ")
+		return indentBlock(result, toolIndent())
 	}
 
 	// No caption - just return indented content
-	return indentBlock(content, "  ")
+	return indentBlock(content, toolIndent())
 }
 
 // ---------------------------------------------------------------------------
@@ -865,7 +996,6 @@ func truncateLine(s string, maxWidth int) string {
 // renderSubagentBody renders a clean summary of subagent results with bash-style
 // background styling for consistency with other tools.
 func renderSubagentBody(toolResult string, width int) string {
-	theme := GetTheme()
 	result := strings.TrimSpace(toolResult)
 	if result == "" {
 		return ""
@@ -884,18 +1014,12 @@ func renderSubagentBody(toolResult string, width int) string {
 	statusLine := lines[0]
 
 	// Build content lines for display with bash-style background
-	outputStyle := lipgloss.NewStyle().Background(theme.CodeBg).PaddingLeft(1)
-	errorStyle := lipgloss.NewStyle().Foreground(theme.Error).Background(theme.CodeBg).PaddingLeft(1)
-
-	const lineIndent = "  "
-	lineWidth := max(width-len(lineIndent), 20)
-	maxLineChars := lineWidth - 1 // account for PaddingLeft(1)
+	panel := newToolPanel(width)
 
 	var contentLines []string
 
 	// Add status line
-	styledStatus := outputStyle.Width(lineWidth).Render(truncateLine(statusLine, maxLineChars))
-	contentLines = append(contentLines, lineIndent+styledStatus)
+	contentLines = append(contentLines, panel.line(statusLine, false))
 
 	// For successful results, extract a brief preview of the actual result
 	if strings.Contains(statusLine, "successfully") {
@@ -904,15 +1028,12 @@ func renderSubagentBody(toolResult string, width int) string {
 			resultContent = strings.TrimSpace(resultContent)
 			if resultContent != "" {
 				// Show first few meaningful lines as preview
-				previewLines := extractSubagentPreviewLines(resultContent, 5, maxLineChars)
+				previewLines := extractSubagentPreviewLines(resultContent, 5, panel.textWidth)
 				if len(previewLines) > 0 {
 					// Add blank separator line
-					blankLine := outputStyle.Width(lineWidth).Render("")
-					contentLines = append(contentLines, lineIndent+blankLine)
-
+					contentLines = append(contentLines, panel.blank())
 					for _, line := range previewLines {
-						styled := outputStyle.Width(lineWidth).Render(line)
-						contentLines = append(contentLines, lineIndent+styled)
+						contentLines = append(contentLines, panel.line(line, false))
 					}
 				}
 			}
@@ -922,21 +1043,18 @@ func renderSubagentBody(toolResult string, width int) string {
 		if _, errorContent, found := strings.Cut(result, "Error:\n"); found {
 			errorContent = strings.TrimSpace(errorContent)
 			if errorContent != "" {
-				previewLines := extractSubagentPreviewLines(errorContent, 3, maxLineChars)
+				previewLines := extractSubagentPreviewLines(errorContent, 3, panel.textWidth)
 				if len(previewLines) > 0 {
-					blankLine := outputStyle.Width(lineWidth).Render("")
-					contentLines = append(contentLines, lineIndent+blankLine)
-
+					contentLines = append(contentLines, panel.blank())
 					for _, line := range previewLines {
-						styled := errorStyle.Width(lineWidth).Render(line)
-						contentLines = append(contentLines, lineIndent+styled)
+						contentLines = append(contentLines, panel.line(line, true))
 					}
 				}
 			}
 		}
 	}
 
-	return strings.Join(contentLines, "\n")
+	return indentBlock(strings.Join(contentLines, "\n"), toolIndent())
 }
 
 // extractSubagentPreviewLines extracts the first N non-empty lines from content,


### PR DESCRIPTION
## Description

The side-by-side diff could not be drawn below about fifty columns. Each panel has a minimum width, and when the terminal could not accommodate two of them the layout did not adapt — it emitted rows wider than the screen. The emulator then wrapped what lipgloss had not, which is the same failure that corrupts the scroll list's height accounting elsewhere. At 38 columns the row measured 45 and was cut mid-word, with no ellipsis to mark the elision:

```
     3 - old value he… │    3 + new va      ← 45 columns in a 38-column terminal
```

Below the width needed for two panels the diff now renders unified: one column, deletions and insertions on consecutive rows, marked and tinted exactly as their side-by-side counterparts. The vocabulary is unchanged and only the arrangement differs, so a narrow terminal reads as a variation rather than as a different tool. Above that threshold the side-by-side layout is untouched.

```
     3 -     return "old valu…
     3 +     return "new valu…
```

The rest is the geometry the block contract could not see. Four renderers — bash, the shared ls/find/grep list, and subagent — each computed the same three quantities by hand (panel width, per-line truncation budget, indent) and disagreed: some clamped and some did not, and `renderBashBody` clamped the value it computed and then rendered with the unclamped one, which goes negative on a very narrow terminal and makes lipgloss emit nothing at all. A `toolPanel` type derives all three once and the four renderers share it. Every remaining hardcoded two-space indent now resolves from `style.ContentOffset`, so tool bodies move with the contract instead of having to be found and updated by hand.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the style guidelines of this project (`gofmt`, `go vet`, `golangci-lint`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes (`go test -race ./...`)
- [ ] I have made corresponding changes to the documentation (no user-facing docs cover tool body rendering)

## Additional Information

**New files**

- `internal/ui/tool_body_test.go` — pins the interior the block contract cannot reach: every body starts at the content column, each stays inside its *own* budget rather than merely inside the terminal, the filled panels share a width so stacking them does not produce a ragged right edge, and nothing renders blank or panics between zero and ten columns. The diff fallback is verified in both directions.

**Notable changes**

- `internal/ui/tool_renderers.go` — unified-diff fallback (`renderUnifiedDiff`); shared `toolPanel` type replacing four hand-rolled copies of the same arithmetic; `captionTypography` replacing four identical inline herald configurations; all six remaining `"  "` indent literals resolved from `style.ContentOffset`
- `internal/ui/block_renderer.go` — `renderContentBlock` trims trailing newlines before styling, so a block built from command output no longer draws its gutter glyph beside an empty final row
- `internal/ui/block_contract_test.go` — adds `tool/edit` and `tool/edit-multiline` cases, and `TestBlockHasNoTrailingGutterRows`

**Two notes for reviewers**

- `renderBashBody` now strips `<stdout>`/`<stderr>` tags. This is **not** a visible fix: Kit's builtin bash tool emits the `STDERR:`/`Exit code:` form and nothing in-tree produces the tagged form. But the error path already stripped those tags via `parseBashOutput`, so a third-party MCP tool named `bash` would have had its markup hidden when it failed and shown raw when it succeeded. The two paths agree now.
- The diff overflow survived the block-geometry contract (`block_contract_test.go`, added in `e88eab2d` on master) because `tool/edit` was the one body type that table did not cover. It is covered now, which is how the bug surfaced.

**Verification**

Both fixes were confirmed against the real TUI under tmux at 38, 46 and 100 columns, driving actual `edit` tool calls rather than synthetic renderer input — the trailing-gutter row in particular is invisible to a width assertion (it is not too wide) and to a trailing-gap assertion (it is not blank), so it needed an eye. Each fix was also verified by mutation: reverting it reproduces the failure in the new tests.

**Backward compatibility**

- No public SDK (`pkg/kit/`) changes.
- No extension-facing API changes.
- Rendering-only; the side-by-side diff is unchanged at widths that can accommodate it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved alignment and sizing across tool output panels, including list outputs, side-by-side diffs, unified diffs, write results, command output, and subagent previews.
  - Edit/diff rendering now reliably falls back to a unified layout on narrow terminals while preserving both old and new content.
  - Command output consistently removes optional wrapper tags and moves “Exit code” into the caption.
  - Prevented stray gutter markers on blank trailing rows and fixed blank-line rendering at block ends.
  - Enhanced truncation and padding behavior to remain stable in narrow/degenerate terminal widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->