### PR TITLE
feat(ui): render image previews with the Kitty graphics protocol

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mark3labs/kit/internal/ui"
 	"github.com/mark3labs/kit/internal/ui/commands"
 	"github.com/mark3labs/kit/internal/ui/progress"
+	"github.com/mark3labs/kit/internal/ui/termgfx"
 	"github.com/mark3labs/kit/internal/watcher"
 	kit "github.com/mark3labs/kit/pkg/kit"
 	"github.com/spf13/cobra"
@@ -1732,6 +1733,12 @@ func runInteractiveModeBubbleTea(_ context.Context, deps runModeDeps) error {
 		// TUI is running. Point it at the same file so no structured log
 		// output reaches the terminal.
 		charmlog.SetOutput(logFile)
+		// --debug turns on the structured debug output that diagnoses
+		// terminal-capability and layout decisions. Without this the default
+		// Info level silently drops it.
+		if debugMode {
+			charmlog.SetLevel(charmlog.DebugLevel)
+		}
 	}
 
 	// Determine terminal size; fall back gracefully.
@@ -1797,6 +1804,12 @@ func runInteractiveModeBubbleTea(_ context.Context, deps runModeDeps) error {
 	// it must happen here rather than lazily mid-render where it would race the
 	// event loop. No-op if a theme in config already resolved them.
 	ui.ResolveTerminalCapabilities()
+
+	// Detect the inline-graphics protocols the terminal honours, for the same
+	// reason and at the same point: the probe reads raw replies from stdin, so
+	// it must finish before the event loop owns that fd. Image previews fall
+	// back to half-block thumbnails when the probe finds no support.
+	termgfx.Resolve()
 
 	program := tea.NewProgram(appModel)
 

--- a/internal/ui/gfx_placement_test.go
+++ b/internal/ui/gfx_placement_test.go
@@ -1,0 +1,149 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	uicore "github.com/mark3labs/kit/internal/ui/core"
+)
+
+// A directly-placed image must land inside the composer, immediately above the
+// status bar, regardless of what the scrollback rendered.
+//
+// The placement is positioned by counting up from the bottom of the screen
+// precisely so a scrollback that draws fewer lines than it was allotted cannot
+// float the image away from the composer. This pins that: the scrollback part
+// is deliberately shorter than the space above the input.
+func TestComputeGfxPlacementAnchorsToComposer(t *testing.T) {
+	const (
+		screenH   = 40
+		imageRows = 12
+		imageCols = 20
+	)
+
+	m := &AppModel{height: screenH, width: 80}
+	ic := NewInputComponent(80, nil)
+	// One pending image whose thumbnail is already rendered, with a placement
+	// sequence, as the direct renderer produces.
+	ic.pendingImages = make([]uicore.ImageAttachment, 1)
+	ic.imageThumbs = []string{strings.TrimSuffix(strings.Repeat(strings.Repeat(" ", imageCols)+"\n", imageRows), "\n")}
+	ic.imageIDs = []uint32{7}
+	ic.imagePlace = []string{"\x1b_Ga=p,i=7\x1b\\"}
+	m.input = ic
+
+	// A layout whose scrollback is far shorter than the screen, which is the
+	// case that broke the original top-down arithmetic.
+	scrollback := strings.TrimSuffix(strings.Repeat("scrollback\n", 3), "\n")
+	inputView := ic.View().Content
+	statusBar := "status"
+	parts := []string{scrollback, inputView, statusBar}
+	const inputPartIndex = 1
+
+	got := m.computeGfxPlacement(parts, inputPartIndex)
+	if got == "" {
+		t.Fatal("computeGfxPlacement returned nothing, want a placement")
+	}
+
+	// The image's top row: the composer's last row is the one above the status
+	// bar, and the image sits at its own offset within the composer.
+	inputTop := screenH - lipgloss.Height(statusBar) - lipgloss.Height(inputView) + 1
+	offsets := ic.thumbRowOffsets()
+	if len(offsets) != 1 || offsets[0] < 0 {
+		t.Fatalf("thumbRowOffsets() = %v, want one non-negative offset", offsets)
+	}
+	wantRow := inputTop + offsets[0]
+
+	// The image must end on the row just above the status bar. If this fails
+	// the preview has drifted off the composer, which is the bug this guards.
+	if wantEnd := screenH - lipgloss.Height(statusBar); wantRow+imageRows-1 != wantEnd {
+		t.Errorf("image occupies rows %d-%d, want it to end at %d (just above the status bar)",
+			wantRow, wantRow+imageRows-1, wantEnd)
+	}
+
+	want := ansi.CursorPosition(thumbPaddingLeft+1, wantRow)
+	if !strings.Contains(got, want) {
+		t.Errorf("placement does not position at row %d\n got: %q\nwant substring: %q", wantRow, got, want)
+	}
+
+	// The renderer owns the cursor, so the sequence must put it back.
+	if !strings.HasPrefix(got, ansi.SaveCursor) || !strings.HasSuffix(got, ansi.RestoreCursor) {
+		t.Error("placement does not save and restore the cursor")
+	}
+}
+
+// With no pending images there is nothing to draw, and the placement must be
+// empty so the flush path stays quiet.
+func TestComputeGfxPlacementEmptyWithoutImages(t *testing.T) {
+	m := &AppModel{height: 40, width: 80}
+	m.input = NewInputComponent(80, nil)
+	if got := m.computeGfxPlacement([]string{"a", "b", "c"}, 1); got != "" {
+		t.Errorf("computeGfxPlacement() = %q, want empty", got)
+	}
+}
+
+// Half-block and placeholder thumbnails draw themselves as text and must not
+// produce a placement.
+func TestComputeGfxPlacementIgnoresTextThumbnails(t *testing.T) {
+	m := &AppModel{height: 40, width: 80}
+	ic := NewInputComponent(80, nil)
+	ic.pendingImages = make([]uicore.ImageAttachment, 1)
+	ic.imageThumbs = []string{"▀▀▀▀"}
+	ic.imageIDs = []uint32{0}
+	ic.imagePlace = []string{""} // text thumbnails carry no placement
+	m.input = ic
+
+	if got := m.computeGfxPlacement([]string{"scroll", ic.View().Content, "status"}, 1); got != "" {
+		t.Errorf("computeGfxPlacement() = %q, want empty for a text thumbnail", got)
+	}
+}
+
+// A directly-placed image must be drawn again after any repaint, even when the
+// row it belongs on has not changed.
+//
+// The renderer scrolls the screen to update it, and a terminal scrolls its
+// images along with the text, so an image drifts upward while its computed row
+// stays identical. Re-placing only on a changed row therefore leaves the image
+// stranded, which is the bug this guards.
+func TestFlushGfxPlacementRedrawsAfterRepaint(t *testing.T) {
+	m := &AppModel{height: 40, width: 80}
+	m.gfxPlacement = "\x1b_Ga=p,i=7\x1b\\"
+
+	// A repaint happened.
+	m.gfxDirty = true
+	if cmd := m.flushGfxPlacement(); cmd == nil {
+		t.Fatal("no placement written after a repaint")
+	}
+	if m.gfxDirty {
+		t.Error("gfxDirty still set after the placement was written")
+	}
+
+	// Nothing has changed since, so nothing more should be written. Without
+	// this the nudge would drive an endless render loop.
+	if cmd := m.flushGfxPlacement(); cmd != nil {
+		t.Error("placement rewritten when the screen had not changed")
+	}
+
+	// The next repaint must write it again, with the row unchanged.
+	m.gfxDirty = true
+	if cmd := m.flushGfxPlacement(); cmd == nil {
+		t.Error("no placement written after a second repaint")
+	}
+}
+
+// Once the images are gone there is nothing to draw, and the dirty flag must
+// still clear so the nudge loop stops.
+func TestFlushGfxPlacementStopsWhenImagesGo(t *testing.T) {
+	m := &AppModel{height: 40, width: 80}
+	m.gfxPlacement = ""
+	m.gfxDirty = true
+
+	if cmd := m.flushGfxPlacement(); cmd != nil {
+		t.Error("placement written when there are no images")
+	}
+	if m.gfxDirty {
+		t.Error("gfxDirty still set, which would spin the render loop")
+	}
+}

--- a/internal/ui/gfx_placement_test.go
+++ b/internal/ui/gfx_placement_test.go
@@ -1,6 +1,10 @@
 package ui
 
 import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
 	"strings"
 	"testing"
 
@@ -8,6 +12,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 
 	uicore "github.com/mark3labs/kit/internal/ui/core"
+	"github.com/mark3labs/kit/internal/ui/termgfx"
 )
 
 // A directly-placed image must land inside the composer, immediately above the
@@ -146,4 +151,98 @@ func TestFlushGfxPlacementStopsWhenImagesGo(t *testing.T) {
 	if m.gfxDirty {
 		t.Error("gfxDirty still set, which would spin the render loop")
 	}
+}
+
+// A transcript preview must never use a direct placement.
+//
+// The transcript lives in the scrollback, which scrolls and clips its items.
+// Placeholder cells are text and move with the message they belong to; a
+// directly placed image is painted at a fixed screen position and would sit
+// still while the transcript scrolled underneath it, and would outlive the
+// message scrolling away entirely. Terminals that need direct placement
+// therefore keep half blocks here, even though the composer uses graphics.
+func TestTranscriptPreviewNeverPlacesDirectly(t *testing.T) {
+	t.Cleanup(func() {
+		termgfx.Set(termgfx.Capabilities{})
+	})
+	t.Setenv("COLORTERM", "truecolor")
+	t.Setenv("ZELLIJ", "0") // the terminal that needs direct placement
+	termgfx.Set(termgfx.Capabilities{KittyGraphics: true, CellWidth: 10, CellHeight: 20})
+
+	if termgfx.PreviewMode() != termgfx.ModeDirect {
+		t.Fatalf("PreviewMode() = %v, want %v; the test premise no longer holds",
+			termgfx.PreviewMode(), termgfx.ModeDirect)
+	}
+
+	m := &AppModel{width: 100, height: 40}
+	cmd := m.transcriptPreviewCmd([]uicore.ImageAttachment{
+		{Data: testGradientPNG(t), MediaType: "image/png"},
+	}, "anchor-1")
+	if cmd == nil {
+		t.Fatal("transcriptPreviewCmd returned nil, want a preview")
+	}
+	msg, ok := cmd().(imagePreviewReadyMsg)
+	if !ok {
+		t.Fatalf("got %T, want imagePreviewReadyMsg", cmd())
+	}
+	if msg.transmit != "" {
+		t.Error("transcript preview transmitted an image in a direct-placement terminal")
+	}
+	if !strings.Contains(msg.block, "▀") {
+		t.Error("transcript preview is not half-block art")
+	}
+}
+
+// Where placeholders work the transcript must use them, so a submitted image
+// looks the same as it did in the composer.
+func TestTranscriptPreviewUsesPlaceholders(t *testing.T) {
+	t.Cleanup(func() {
+		termgfx.Set(termgfx.Capabilities{})
+	})
+	t.Setenv("COLORTERM", "truecolor")
+	t.Setenv("ZELLIJ", "")
+	t.Setenv("TMUX", "")
+	termgfx.Set(termgfx.Capabilities{KittyGraphics: true, CellWidth: 10, CellHeight: 20})
+
+	if termgfx.PreviewMode() != termgfx.ModePlaceholder {
+		t.Fatalf("PreviewMode() = %v, want %v; the test premise no longer holds",
+			termgfx.PreviewMode(), termgfx.ModePlaceholder)
+	}
+
+	m := &AppModel{width: 100, height: 40}
+	cmd := m.transcriptPreviewCmd([]uicore.ImageAttachment{
+		{Data: testGradientPNG(t), MediaType: "image/png"},
+	}, "anchor-1")
+	if cmd == nil {
+		t.Fatal("transcriptPreviewCmd returned nil, want a preview")
+	}
+	msg, ok := cmd().(imagePreviewReadyMsg)
+	if !ok {
+		t.Fatalf("got %T, want imagePreviewReadyMsg", cmd())
+	}
+	if msg.transmit == "" {
+		t.Error("transcript preview did not transmit the image")
+	}
+	if !strings.ContainsRune(msg.block, '\U0010EEEE') {
+		t.Error("transcript preview does not contain placeholder cells")
+	}
+	if strings.Contains(msg.block, "▀") {
+		t.Error("transcript preview fell back to half blocks")
+	}
+}
+
+// testGradientPNG returns a small encoded PNG.
+func testGradientPNG(t *testing.T) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 64, 32))
+	for y := range 32 {
+		for x := range 64 {
+			img.Set(x, y, color.RGBA{R: uint8(x * 4), G: uint8(y * 8), B: 200, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encode test png: %v", err)
+	}
+	return buf.Bytes()
 }

--- a/internal/ui/gfx_placement_test.go
+++ b/internal/ui/gfx_placement_test.go
@@ -165,9 +165,23 @@ func TestTranscriptPreviewNeverPlacesDirectly(t *testing.T) {
 	t.Cleanup(func() {
 		termgfx.Set(termgfx.Capabilities{})
 	})
-	t.Setenv("COLORTERM", "truecolor")
-	t.Setenv("ZELLIJ", "0") // the terminal that needs direct placement
-	termgfx.Set(termgfx.Capabilities{KittyGraphics: true, CellWidth: 10, CellHeight: 20})
+	// A terminal that draws graphics but strips the combining marks that
+	// placeholders are built from, so it needs a direct placement. Stated as
+	// capabilities rather than environment variables: the decision is a pure
+	// function of them, and an env-based setup passed only where TERM happened
+	// to be set.
+	termgfx.Set(termgfx.Capabilities{
+		KittyGraphics:       true,
+		CellWidth:           10,
+		CellHeight:          20,
+		TrueColor:           true,
+		UnicodePlaceholders: false,
+	})
+	// The half-block renderer reads the colour profile from the environment
+	// and draws nothing below 256 colours, which is what a bare CI environment
+	// reports. Give it a terminal so the fallback actually produces art to
+	// assert on.
+	t.Setenv("TERM", "xterm-256color")
 
 	if termgfx.PreviewMode() != termgfx.ModeDirect {
 		t.Fatalf("PreviewMode() = %v, want %v; the test premise no longer holds",
@@ -199,10 +213,13 @@ func TestTranscriptPreviewUsesPlaceholders(t *testing.T) {
 	t.Cleanup(func() {
 		termgfx.Set(termgfx.Capabilities{})
 	})
-	t.Setenv("COLORTERM", "truecolor")
-	t.Setenv("ZELLIJ", "")
-	t.Setenv("TMUX", "")
-	termgfx.Set(termgfx.Capabilities{KittyGraphics: true, CellWidth: 10, CellHeight: 20})
+	termgfx.Set(termgfx.Capabilities{
+		KittyGraphics:       true,
+		CellWidth:           10,
+		CellHeight:          20,
+		TrueColor:           true,
+		UnicodePlaceholders: true,
+	})
 
 	if termgfx.PreviewMode() != termgfx.ModePlaceholder {
 		t.Fatalf("PreviewMode() = %v, want %v; the test premise no longer holds",

--- a/internal/ui/gfx_placement_test.go
+++ b/internal/ui/gfx_placement_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
 
@@ -262,4 +263,58 @@ func testGradientPNG(t *testing.T) []byte {
 		t.Fatalf("encode test png: %v", err)
 	}
 	return buf.Bytes()
+}
+
+// ClearPendingImages must hand back the cleanup command.
+//
+// A terminal holds transmitted image data until told to drop it, and the ids
+// are discarded when the pending set is cleared, so a caller that cannot run
+// the cleanup leaks every preview image for the rest of the session. The
+// function used to free the images internally and throw the command away,
+// which meant the delete sequence never reached the terminal.
+func TestClearPendingImagesReturnsCleanup(t *testing.T) {
+	ic := NewInputComponent(80, nil)
+	ic.pendingImages = make([]uicore.ImageAttachment, 1)
+	ic.imageThumbs = []string{"thumb"}
+	ic.imageIDs = []uint32{99} // a transmitted image the terminal is holding
+	ic.imagePlace = []string{"\x1b_Ga=p,i=99\x1b\\"}
+
+	images, cleanup := ic.ClearPendingImages()
+	if len(images) != 1 {
+		t.Fatalf("got %d attachments, want 1", len(images))
+	}
+	if cleanup == nil {
+		t.Fatal("no cleanup command returned; the transmitted image would leak")
+	}
+
+	raw, ok := cleanup().(tea.RawMsg)
+	if !ok {
+		t.Fatalf("cleanup produced %T, want tea.RawMsg", cleanup())
+	}
+	seq, _ := raw.Msg.(string)
+	if !strings.Contains(seq, "a=d") || !strings.Contains(seq, "i=99") {
+		t.Errorf("cleanup does not delete image 99: %q", seq)
+	}
+
+	if len(ic.pendingImages) != 0 || len(ic.imageIDs) != 0 {
+		t.Error("pending image state was not cleared")
+	}
+}
+
+// With nothing transmitted there is nothing to free, so callers get no command
+// to run rather than an empty escape sequence.
+func TestClearPendingImagesNoCleanupForTextThumbnails(t *testing.T) {
+	ic := NewInputComponent(80, nil)
+	ic.pendingImages = make([]uicore.ImageAttachment, 1)
+	ic.imageThumbs = []string{"▀▀▀▀"}
+	ic.imageIDs = []uint32{0} // half blocks own no terminal resource
+	ic.imagePlace = []string{""}
+
+	images, cleanup := ic.ClearPendingImages()
+	if len(images) != 1 {
+		t.Fatalf("got %d attachments, want 1", len(images))
+	}
+	if cleanup != nil {
+		t.Error("cleanup command returned when no image was transmitted")
+	}
 }

--- a/internal/ui/imagepreview/kitty.go
+++ b/internal/ui/imagepreview/kitty.go
@@ -1,0 +1,317 @@
+package imagepreview
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	"math/rand/v2"
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/charmbracelet/x/ansi/kitty"
+	xdraw "golang.org/x/image/draw"
+)
+
+// Thumbnail is a rendered image preview, split into the part that must be
+// written straight to the terminal and the part that belongs in the view.
+//
+// The half-block renderer produces Cells only. The Kitty renderers produce
+// both: Transmit carries the image data, and Cells reserves the screen area
+// the image occupies.
+type Thumbnail struct {
+	// Transmit is an escape sequence that must reach the terminal unmodified,
+	// outside the normal view text. It is empty for half-block thumbnails.
+	//
+	// Write it with tea.Raw, never by embedding it in a view: the frame
+	// renderer parses view text into cells and would mangle or drop an APC
+	// sequence hidden inside it.
+	Transmit string
+
+	// Cells is the text to place in the view. For a placeholder thumbnail this
+	// is the Unicode placeholder grid that displays the image; for a direct
+	// placement it is blank cells that reserve the area the image is drawn
+	// over; for a half-block thumbnail it is the coloured art itself. Either
+	// way it is ordinary text that occupies exactly the intended cells, so the
+	// frame renderer can measure, pad, and diff it like any other content.
+	Cells string
+
+	// ImageID identifies the transmitted image so it can be deleted later. It
+	// is zero when nothing was transmitted.
+	ImageID uint32
+
+	// Cols and Rows are the size of the preview in terminal cells.
+	Cols, Rows int
+
+	// NeedsPlacement reports that the image is drawn by a direct placement
+	// anchored at the cursor, rather than by placeholder cells that travel with
+	// the view text.
+	//
+	// A direct placement is not part of the view, so the caller must position
+	// the cursor and emit Place after every frame that shows the preview, and
+	// must emit DeleteImage when it goes away. See RenderKittyDirect.
+	NeedsPlacement bool
+}
+
+// cellPixelWidth and cellPixelHeight are the fallback pixel dimensions of one
+// terminal cell, used when the caller does not know the real ones.
+//
+// The exact cell size only decides how much detail is sent: the terminal
+// rescales the image to the requested cell box regardless. The 1:2 ratio
+// matches the assumption fitDimensions already makes, so the aspect ratio
+// stays correct even when the guess is wrong.
+const (
+	cellPixelWidth  = 10
+	cellPixelHeight = 20
+)
+
+// RenderKitty builds a Kitty graphics thumbnail: a virtual image placement
+// plus the Unicode placeholder grid that displays it.
+//
+// Unicode placeholders let the image travel as ordinary text: the terminal
+// draws it only where the placeholder cells appear, so it moves, scrolls, and
+// disappears with the surrounding view. That is what a redrawing TUI wants,
+// and it is the right choice wherever it works.
+//
+// It does not work everywhere. Zellij 0.45 forwards the graphics protocol but
+// discards the combining marks that tell each placeholder cell which part of
+// the image it holds, so nothing is drawn. Use RenderKittyDirect there.
+//
+// cellW and cellH are the pixel dimensions of a terminal cell, used to choose
+// the resampling resolution. Pass zero for either to use a default.
+//
+// maxCols and maxRows bound the preview in cells, as with Render.
+func RenderKitty(data []byte, maxCols, maxRows, cellW, cellH int) (Thumbnail, error) {
+	scaled, cols, rows, err := scaleForCells(data, maxCols, maxRows, cellW, cellH)
+	if err != nil || scaled == nil {
+		return Thumbnail{}, err
+	}
+
+	id := newImageID()
+
+	var buf bytes.Buffer
+	opts := &kitty.Options{
+		Action:       kitty.TransmitAndPut,
+		ID:           int(id),
+		Format:       kitty.PNG,
+		Transmission: kitty.Direct,
+		Columns:      cols,
+		Rows:         rows,
+		// A virtual placement transmits the image without drawing it; the
+		// placeholder cells decide where it lands.
+		VirtualPlacement: true,
+		// Suppress both OK and error replies. Without this the terminal
+		// answers every chunk, and those replies arrive on stdin where the
+		// event loop would read them as input.
+		Quiet: 2,
+		// Chunk so no single escape sequence grows unbounded; terminals are
+		// free to reject an overlong one.
+		Chunk: true,
+	}
+	if err := kitty.EncodeGraphics(&buf, scaled, opts); err != nil {
+		return Thumbnail{}, fmt.Errorf("encode kitty graphics: %w", err)
+	}
+
+	return Thumbnail{
+		Transmit: buf.String(),
+		Cells:    placeholderGrid(id, cols, rows),
+		ImageID:  id,
+		Cols:     cols,
+		Rows:     rows,
+	}, nil
+}
+
+// RenderKittyDirect builds a Kitty graphics thumbnail that is drawn by a
+// direct placement at the cursor rather than by placeholder cells.
+//
+// This exists for terminals that carry the graphics protocol but not the
+// Unicode placeholder encoding — zellij 0.45 strips the combining marks that
+// placeholders depend on, so RenderKitty draws nothing there while this works.
+//
+// The trade-off is that the image is not part of the view. It is painted over
+// the screen at whatever position the cursor held when Place was written, and
+// it stays there until deleted. The caller must therefore:
+//
+//   - reserve the area with Cells, which is blank text of exactly Cols x Rows,
+//     so the layout accounts for the space the image covers;
+//   - write Transmit once to load the image;
+//   - position the cursor and write Place on every frame that shows it;
+//   - write DeleteImage when the preview goes away, since overwriting the
+//     cells does not remove it.
+//
+// cellW and cellH are the pixel dimensions of a terminal cell, used to choose
+// the resampling resolution. Pass zero for either to use a default.
+func RenderKittyDirect(data []byte, maxCols, maxRows, cellW, cellH int) (Thumbnail, error) {
+	scaled, cols, rows, err := scaleForCells(data, maxCols, maxRows, cellW, cellH)
+	if err != nil || scaled == nil {
+		return Thumbnail{}, err
+	}
+
+	id := newImageID()
+
+	var buf bytes.Buffer
+	opts := &kitty.Options{
+		// Transmit only. The placement is emitted separately by Place, so the
+		// image can be redrawn on later frames without resending the data.
+		Action:       kitty.Transmit,
+		ID:           int(id),
+		Format:       kitty.PNG,
+		Transmission: kitty.Direct,
+		Quiet:        2,
+		Chunk:        true,
+	}
+	if err := kitty.EncodeGraphics(&buf, scaled, opts); err != nil {
+		return Thumbnail{}, fmt.Errorf("encode kitty graphics: %w", err)
+	}
+
+	// Blank cells reserve the area. The image is painted over them, so their
+	// only job is to make the layout leave room and to keep whatever was
+	// underneath from showing through.
+	blank := strings.Repeat(" ", cols)
+	rowsText := make([]string, rows)
+	for i := range rowsText {
+		rowsText[i] = blank
+	}
+
+	return Thumbnail{
+		Transmit:       buf.String(),
+		Cells:          strings.Join(rowsText, "\n"),
+		ImageID:        id,
+		Cols:           cols,
+		Rows:           rows,
+		NeedsPlacement: true,
+	}, nil
+}
+
+// Place returns the escape sequence that draws an already-transmitted image at
+// the current cursor position, scaled into a Cols x Rows cell box.
+//
+// It returns an empty string for thumbnails that do not need a placement, so
+// callers can emit it unconditionally.
+func (t Thumbnail) Place() string {
+	if !t.NeedsPlacement || t.ImageID == 0 || t.Cols < 1 || t.Rows < 1 {
+		return ""
+	}
+	// Drop any earlier placement of this image first. Each a=p adds another
+	// placement rather than moving the existing one, so a redraw at a new row
+	// would leave the previous copy stranded on screen — two thumbnails for one
+	// attachment.
+	//
+	// The lowercase d=i deletes placements only and keeps the transmitted data,
+	// so the redraw that follows needs no retransmit. Deleting does not depend
+	// on the cursor, so it is safe to emit before positioning.
+	drop := ansi.KittyGraphics(nil,
+		"a=d",
+		"d=i",
+		fmt.Sprintf("i=%d", t.ImageID),
+		"q=2",
+	)
+	// C=1 keeps the cursor where it was: without it the terminal moves the
+	// cursor past the image and the frame renderer loses its position.
+	put := ansi.KittyGraphics(nil,
+		"a=p",
+		fmt.Sprintf("i=%d", t.ImageID),
+		fmt.Sprintf("c=%d", t.Cols),
+		fmt.Sprintf("r=%d", t.Rows),
+		"C=1",
+		"q=2",
+	)
+	return drop + put
+}
+
+// scaleForCells decodes an image and resamples it to fill a cell box that fits
+// within maxCols x maxRows while preserving aspect ratio. It returns a nil
+// image when there is no room to draw anything.
+func scaleForCells(data []byte, maxCols, maxRows, cellW, cellH int) (*image.RGBA, int, int, error) {
+	if maxCols < 1 || maxRows < 1 {
+		return nil, 0, 0, nil
+	}
+	if cellW < 1 {
+		cellW = cellPixelWidth
+	}
+	if cellH < 1 {
+		cellH = cellPixelHeight
+	}
+
+	// Guard against decompression bombs before decoding, exactly as Render
+	// does: a small payload must not be able to expand into a huge buffer.
+	cfg, _, err := image.DecodeConfig(bytes.NewReader(data))
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("decode image config: %w", err)
+	}
+	if cfg.Width > maxImageDimension || cfg.Height > maxImageDimension {
+		return nil, 0, 0, fmt.Errorf("decode image: dimensions %dx%d exceed limit %d", cfg.Width, cfg.Height, maxImageDimension)
+	}
+
+	img, _, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("decode image: %w", err)
+	}
+
+	cols, rows := fitDimensions(img.Bounds().Dx(), img.Bounds().Dy(), maxCols, maxRows)
+	if cols < 1 || rows < 1 {
+		return nil, 0, 0, nil
+	}
+
+	// Resample before transmitting. The source may be a multi-megabyte
+	// screenshot, and every byte would otherwise be base64-encoded into the
+	// escape sequence for a thumbnail a few dozen cells wide.
+	scaled := image.NewRGBA(image.Rect(0, 0, cols*cellW, rows*cellH))
+	xdraw.CatmullRom.Scale(scaled, scaled.Bounds(), img, img.Bounds(), xdraw.Over, nil)
+	return scaled, cols, rows, nil
+}
+
+// placeholderGrid builds the cell grid that displays a virtually placed image.
+//
+// Each cell holds U+10EEEE followed by two combining marks that encode its row
+// and column, and the whole row carries a foreground colour whose 24 bits are
+// the image id. The terminal reads that triple to decide which image, and
+// which part of it, belongs in the cell.
+func placeholderGrid(id uint32, cols, rows int) string {
+	var b strings.Builder
+
+	// The id travels as a 24-bit RGB foreground colour. newImageID keeps ids
+	// inside 24 bits so no fourth byte (a third combining mark) is needed.
+	r := (id >> 16) & 0xff
+	g := (id >> 8) & 0xff
+	bl := id & 0xff
+
+	for row := range rows {
+		fmt.Fprintf(&b, "\x1b[38;2;%d;%d;%dm", r, g, bl)
+		rowMark := kitty.Diacritic(row)
+		for col := range cols {
+			b.WriteRune(kitty.Placeholder)
+			b.WriteRune(rowMark)
+			b.WriteRune(kitty.Diacritic(col))
+		}
+		b.WriteString(reset)
+		if row+1 < rows {
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+// DeleteImage returns the escape sequence that removes a transmitted image and
+// frees the memory the terminal holds for it.
+//
+// Every transmitted thumbnail must be deleted once its preview is gone.
+// Terminals keep image data until told otherwise, so a session that pastes
+// many images would otherwise accumulate all of them.
+func DeleteImage(id uint32) string {
+	if id == 0 {
+		return ""
+	}
+	// d=I (not d=i) deletes the image data as well as its placements.
+	return ansi.KittyGraphics(nil, "a=d", "d=I", fmt.Sprintf("i=%d", id), "q=2")
+}
+
+// newImageID returns a random image id in [0x010000, 0xFFFFFF].
+//
+// Ids are a terminal-wide namespace shared with every other program drawing to
+// the same window, so they are randomised rather than counted from zero to
+// avoid colliding with another program's images. Staying inside 24 bits lets
+// the id fit in the placeholder foreground colour; keeping the high byte
+// non-zero avoids ids that a terminal might read as a palette index.
+func newImageID() uint32 {
+	return uint32(rand.IntN(0xFFFFFF-0x010000+1) + 0x010000) //nolint:gosec // not security-sensitive
+}

--- a/internal/ui/imagepreview/kitty_test.go
+++ b/internal/ui/imagepreview/kitty_test.go
@@ -1,0 +1,402 @@
+package imagepreview
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+	"math/rand/v2"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/x/ansi/kitty"
+	"golang.org/x/term"
+)
+
+// TestKittyLive transmits a thumbnail to the real terminal and asserts that it
+// accepts the image.
+//
+// The test is skipped unless KIT_LIVE_KITTY=1 and stdin is a terminal, because
+// it needs a terminal that actually implements the graphics protocol. Run it
+// inside kitty with:
+//
+//	KIT_LIVE_KITTY=1 go test -run TestKittyLive ./internal/ui/imagepreview/
+//
+// Unlike the offline tests, this one asks the terminal to confirm: it drops the
+// quiet flag so the terminal reports whether the transmission was valid, which
+// catches format, chunking, and base64 mistakes that a byte-level assertion
+// cannot.
+func TestKittyLive(t *testing.T) {
+	if os.Getenv("KIT_LIVE_KITTY") != "1" {
+		t.Skip("set KIT_LIVE_KITTY=1 and run inside a graphics-capable terminal")
+	}
+	// Talk to the controlling terminal directly. Under `go test` stdout is
+	// usually a pipe or a file, and writing the transmission there would put
+	// the escape sequence in the log instead of the terminal.
+	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	if err != nil {
+		t.Skipf("no controlling terminal: %v", err)
+	}
+	defer func() { _ = tty.Close() }()
+
+	fd := int(tty.Fd())
+	if !term.IsTerminal(fd) {
+		t.Skip("/dev/tty is not a terminal")
+	}
+
+	thumb, err := RenderKitty(testPNG(t, 200, 100), 20, 5, 0, 0)
+	if err != nil {
+		t.Fatalf("RenderKitty: %v", err)
+	}
+
+	// Re-encode the transmission without the quiet flag so the terminal
+	// answers. RenderKitty sets q=2 for production use, where an unsolicited
+	// reply would land in the event loop's input stream.
+	loud := strings.ReplaceAll(thumb.Transmit, ",q=2", "")
+
+	state, err := term.MakeRaw(fd)
+	if err != nil {
+		t.Fatalf("raw mode: %v", err)
+	}
+	defer func() { _ = term.Restore(fd, state) }()
+
+	if _, err := tty.WriteString(loud); err != nil {
+		t.Fatalf("write transmission: %v", err)
+	}
+
+	reply := make(chan string, 1)
+	go func() {
+		buf := make([]byte, 1024)
+		n, _ := tty.Read(buf)
+		reply <- string(buf[:n])
+	}()
+
+	select {
+	case got := <-reply:
+		if !strings.Contains(got, ";OK") {
+			t.Errorf("terminal rejected the image: %q", got)
+		}
+		t.Logf("terminal accepted the image: %q", got)
+	case <-time.After(3 * time.Second):
+		t.Error("terminal did not answer the transmission")
+	}
+
+	// Leave the placeholders on screen so `kitty @ get-text` can inspect them.
+	_, _ = tty.WriteString("\r\n" + thumb.Cells + "\r\n")
+	if os.Getenv("KIT_LIVE_KEEP") == "" {
+		_, _ = tty.WriteString(DeleteImage(thumb.ImageID))
+	}
+}
+
+// testPNG returns an encoded PNG of the given size with a colour gradient, so
+// a rendered preview is visually distinguishable from a blank cell.
+func testPNG(t *testing.T, w, h int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := range h {
+		for x := range w {
+			img.Set(x, y, color.RGBA{
+				R: uint8(x * 255 / max(w-1, 1)),
+				G: uint8(y * 255 / max(h-1, 1)),
+				B: 128,
+				A: 255,
+			})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encode test png: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// testNoisePNG returns an encoded PNG of random pixels. Noise resists PNG
+// compression, so the payload is large enough to be split into chunks.
+func testNoisePNG(t *testing.T, w, h int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := range h {
+		for x := range w {
+			img.Set(x, y, color.RGBA{
+				R: uint8(rand.IntN(256)), //nolint:gosec // test data, not security-sensitive
+				G: uint8(rand.IntN(256)), //nolint:gosec
+				B: uint8(rand.IntN(256)), //nolint:gosec
+				A: 255,
+			})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encode noise png: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// TestPlaceholderGridStructure pins the placeholder encoding: one placeholder
+// rune per cell, each followed by the row and column combining marks, with the
+// image id carried as a 24-bit foreground colour.
+func TestPlaceholderGridStructure(t *testing.T) {
+	const id = 0x123456
+	got := placeholderGrid(id, 3, 2)
+
+	lines := strings.Split(got, "\n")
+	if len(lines) != 2 {
+		t.Fatalf("got %d rows, want 2", len(lines))
+	}
+
+	for row, line := range lines {
+		if !strings.HasPrefix(line, "\x1b[38;2;18;52;86m") {
+			t.Errorf("row %d does not carry the image id as a foreground colour: %q", row, line)
+		}
+		if !strings.HasSuffix(line, reset) {
+			t.Errorf("row %d does not reset its colour: %q", row, line)
+		}
+
+		runes := []rune(strings.TrimSuffix(strings.TrimPrefix(line, "\x1b[38;2;18;52;86m"), reset))
+		if len(runes) != 3*3 { // 3 cells x (placeholder + row mark + column mark)
+			t.Fatalf("row %d has %d runes, want 9", row, len(runes))
+		}
+		for col := range 3 {
+			base := runes[col*3]
+			rowMark := runes[col*3+1]
+			colMark := runes[col*3+2]
+			if base != kitty.Placeholder {
+				t.Errorf("row %d col %d: base rune = %U, want %U", row, col, base, kitty.Placeholder)
+			}
+			if want := kitty.Diacritic(row); rowMark != want {
+				t.Errorf("row %d col %d: row mark = %U, want %U", row, col, rowMark, want)
+			}
+			if want := kitty.Diacritic(col); colMark != want {
+				t.Errorf("row %d col %d: column mark = %U, want %U", row, col, colMark, want)
+			}
+		}
+	}
+}
+
+// The transmission must create a virtual placement sized to the placeholder
+// grid, and must not provoke replies that the event loop would read as input.
+func TestRenderKittyTransmission(t *testing.T) {
+	thumb, err := RenderKitty(testPNG(t, 200, 100), 20, 5, 0, 0)
+	if err != nil {
+		t.Fatalf("RenderKitty: %v", err)
+	}
+	if thumb.ImageID == 0 {
+		t.Fatal("ImageID = 0, want a real id")
+	}
+	if !strings.HasPrefix(thumb.Transmit, "\x1b_G") {
+		t.Errorf("transmission is not an APC graphics sequence: %.32q", thumb.Transmit)
+	}
+	// t=d is omitted deliberately: direct transmission is the protocol default,
+	// so the encoder leaves the key out.
+	for _, want := range []string{"a=T", "U=1", "q=2", "f=100"} {
+		if !strings.Contains(thumb.Transmit, want) {
+			t.Errorf("transmission missing %q", want)
+		}
+	}
+
+	// The declared cell box must match the placeholder grid exactly, or the
+	// terminal scales the image into the wrong number of cells.
+	rows := strings.Split(thumb.Cells, "\n")
+	cols := strings.Count(rows[0], string(kitty.Placeholder))
+	if !strings.Contains(thumb.Transmit, "c="+strconv.Itoa(cols)) {
+		t.Errorf("transmission does not declare c=%d", cols)
+	}
+	if !strings.Contains(thumb.Transmit, "r="+strconv.Itoa(len(rows))) {
+		t.Errorf("transmission does not declare r=%d", len(rows))
+	}
+}
+
+// A 200x100 image is wider than it is tall, so the preview must be too. This
+// guards the aspect-ratio handling shared with the half-block renderer.
+func TestRenderKittyPreservesAspect(t *testing.T) {
+	thumb, err := RenderKitty(testPNG(t, 200, 100), 20, 20, 0, 0)
+	if err != nil {
+		t.Fatalf("RenderKitty: %v", err)
+	}
+	rows := strings.Split(thumb.Cells, "\n")
+	cols := strings.Count(rows[0], string(kitty.Placeholder))
+	if cols <= len(rows) {
+		t.Errorf("preview is %dx%d cells, want it wider than tall", cols, len(rows))
+	}
+}
+
+// A large payload must be split across several escape sequences rather than
+// sent as one unbounded sequence a terminal may reject.
+func TestRenderKittyChunksLargePayload(t *testing.T) {
+	// Noise, not a gradient: a smooth image compresses into a single chunk and
+	// would not exercise the split at all.
+	thumb, err := RenderKitty(testNoisePNG(t, 400, 400), 30, 15, 0, 0)
+	if err != nil {
+		t.Fatalf("RenderKitty: %v", err)
+	}
+	if n := strings.Count(thumb.Transmit, "\x1b_G"); n < 2 {
+		t.Errorf("payload sent as %d sequence(s), want it split into several", n)
+	}
+}
+
+func TestDeleteImage(t *testing.T) {
+	got := DeleteImage(0x4242)
+	for _, want := range []string{"a=d", "d=I", "i=16962"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("DeleteImage() = %q, missing %q", got, want)
+		}
+	}
+	if DeleteImage(0) != "" {
+		t.Error("DeleteImage(0) should return no sequence")
+	}
+}
+
+func TestRenderKittyRejectsGarbage(t *testing.T) {
+	if _, err := RenderKitty([]byte("not an image"), 10, 5, 0, 0); err == nil {
+		t.Error("RenderKitty accepted non-image data")
+	}
+}
+
+func TestNewImageIDStaysIn24Bits(t *testing.T) {
+	for range 1000 {
+		id := newImageID()
+		if id < 0x010000 || id > 0xFFFFFF {
+			t.Fatalf("newImageID() = %#x, want it inside [0x010000, 0xFFFFFF]", id)
+		}
+	}
+}
+
+// A direct thumbnail transmits without placing, and reserves its area with
+// blank cells that the image is painted over.
+func TestRenderKittyDirect(t *testing.T) {
+	thumb, err := RenderKittyDirect(testPNG(t, 200, 100), 20, 10, 10, 20)
+	if err != nil {
+		t.Fatalf("RenderKittyDirect: %v", err)
+	}
+	if !thumb.NeedsPlacement {
+		t.Error("NeedsPlacement = false, want true")
+	}
+	if thumb.ImageID == 0 {
+		t.Fatal("ImageID = 0, want a real id")
+	}
+	// The transmission must not display anything by itself: a=T would draw the
+	// image at wherever the cursor happens to be, before the caller has
+	// positioned it. Transmit-only (a=t) is the protocol default, so the
+	// encoder omits the key entirely — its absence is what must hold.
+	if strings.Contains(thumb.Transmit, "a=T") {
+		t.Errorf("transmission draws immediately: %.48q", thumb.Transmit)
+	}
+	if strings.Contains(thumb.Transmit, "U=1") {
+		t.Error("transmission requests a virtual placement, which needs placeholders")
+	}
+	if strings.Contains(thumb.Cells, string(kitty.Placeholder)) {
+		t.Error("reserved cells contain placeholders; they should be blank")
+	}
+
+	// The reserved area must match the declared size exactly, or the layout
+	// will not leave the right amount of room for the image.
+	lines := strings.Split(thumb.Cells, "\n")
+	if len(lines) != thumb.Rows {
+		t.Errorf("reserved %d rows, want %d", len(lines), thumb.Rows)
+	}
+	for i, l := range lines {
+		if len([]rune(l)) != thumb.Cols {
+			t.Errorf("reserved row %d is %d cells, want %d", i, len([]rune(l)), thumb.Cols)
+		}
+		if strings.TrimSpace(l) != "" {
+			t.Errorf("reserved row %d is not blank: %q", i, l)
+		}
+	}
+}
+
+// The placement must draw the image into exactly the reserved box and must not
+// move the cursor, which the frame renderer owns.
+func TestThumbnailPlace(t *testing.T) {
+	thumb, err := RenderKittyDirect(testPNG(t, 200, 100), 20, 10, 10, 20)
+	if err != nil {
+		t.Fatalf("RenderKittyDirect: %v", err)
+	}
+	place := thumb.Place()
+	for _, want := range []string{
+		"a=p",
+		"i=" + strconv.Itoa(int(thumb.ImageID)),
+		"c=" + strconv.Itoa(thumb.Cols),
+		"r=" + strconv.Itoa(thumb.Rows),
+		"C=1", // do not move the cursor
+		"q=2", // no replies into the input stream
+	} {
+		if !strings.Contains(place, want) {
+			t.Errorf("Place() = %q, missing %q", place, want)
+		}
+	}
+}
+
+// Placeholder thumbnails draw themselves as text, so they must report no
+// placement; callers emit Place unconditionally.
+func TestPlaceholderThumbnailNeedsNoPlacement(t *testing.T) {
+	thumb, err := RenderKitty(testPNG(t, 200, 100), 20, 10, 10, 20)
+	if err != nil {
+		t.Fatalf("RenderKitty: %v", err)
+	}
+	if thumb.NeedsPlacement {
+		t.Error("NeedsPlacement = true for a placeholder thumbnail")
+	}
+	if got := thumb.Place(); got != "" {
+		t.Errorf("Place() = %q, want empty", got)
+	}
+}
+
+// Both renderers must agree on the cell box they report, since the layout uses
+// it to reserve space either way.
+func TestRenderersAgreeOnSize(t *testing.T) {
+	data := testPNG(t, 200, 100)
+	ph, err := RenderKitty(data, 20, 10, 10, 20)
+	if err != nil {
+		t.Fatalf("RenderKitty: %v", err)
+	}
+	dir, err := RenderKittyDirect(data, 20, 10, 10, 20)
+	if err != nil {
+		t.Fatalf("RenderKittyDirect: %v", err)
+	}
+	if ph.Cols != dir.Cols || ph.Rows != dir.Rows {
+		t.Errorf("placeholder %dx%d, direct %dx%d; want identical",
+			ph.Cols, ph.Rows, dir.Cols, dir.Rows)
+	}
+}
+
+// Re-placing an image must not stack copies on screen.
+//
+// Each a=p adds a placement rather than moving the existing one, so a redraw
+// at a new row leaves the previous copy behind — one attachment, two visible
+// thumbnails. Place must therefore drop the old placement first.
+func TestPlaceReplacesRatherThanStacks(t *testing.T) {
+	thumb, err := RenderKittyDirect(testPNG(t, 200, 100), 20, 10, 10, 20)
+	if err != nil {
+		t.Fatalf("RenderKittyDirect: %v", err)
+	}
+	place := thumb.Place()
+
+	id := "i=" + strconv.Itoa(int(thumb.ImageID))
+	drop := strings.Index(place, "a=d")
+	put := strings.Index(place, "a=p")
+	if drop < 0 {
+		t.Fatalf("Place() does not remove the previous placement: %q", place)
+	}
+	if put < 0 {
+		t.Fatalf("Place() does not draw the image: %q", place)
+	}
+	if drop > put {
+		t.Error("Place() draws before removing the previous placement, which stacks copies")
+	}
+
+	// Lowercase d=i drops placements but keeps the image data, so redrawing
+	// needs no retransmit. Uppercase d=I would discard the data and leave
+	// later redraws with nothing to place.
+	if !strings.Contains(place, "d=i") {
+		t.Errorf("Place() does not drop placements with d=i: %q", place)
+	}
+	if strings.Contains(place, "d=I") {
+		t.Error("Place() discards the image data, so redraws would have nothing to draw")
+	}
+	if strings.Count(place, id) != 2 {
+		t.Errorf("Place() should scope both the drop and the draw to %s: %q", id, place)
+	}
+}

--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -990,19 +990,19 @@ func readClipboardImageCmd() tea.Cmd {
 	}
 }
 
-// ClearPendingImages removes all pending image attachments and returns them.
-// Used by the parent model when consuming images for submission.
+// ClearPendingImages removes all pending image attachments and returns them,
+// along with a command that frees any images transmitted to the terminal.
 //
-// Any transmitted preview images are freed as a side effect. Because this
-// returns attachments rather than a command, the escape sequence cannot be
-// routed through the event loop, so it is dropped here; the ids are discarded
-// either way and the terminal reclaims the data when the session ends.
-func (s *InputComponent) ClearPendingImages() []core.ImageAttachment {
+// The cleanup command must be run. A terminal holds transmitted image data
+// until told to drop it, and these ids are discarded here, so a caller that
+// ignores the command leaks every preview image for the rest of the session.
+// It is nil when there is nothing to free.
+func (s *InputComponent) ClearPendingImages() ([]core.ImageAttachment, tea.Cmd) {
 	images := s.pendingImages
 	s.pendingImages = nil
-	s.releaseImages()
+	cleanup := s.releaseImages()
 	s.imageGen++
-	return images
+	return images, cleanup
 }
 
 // PendingImageCount returns the number of images currently attached.

--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -10,12 +10,14 @@ import (
 	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/log"
 
 	"github.com/mark3labs/kit/internal/clipboard"
 	"github.com/mark3labs/kit/internal/ui/commands"
 	"github.com/mark3labs/kit/internal/ui/core"
 	"github.com/mark3labs/kit/internal/ui/imagepreview"
 	"github.com/mark3labs/kit/internal/ui/style"
+	"github.com/mark3labs/kit/internal/ui/termgfx"
 )
 
 // InputComponent is the interactive text input field for the parent AppModel.
@@ -87,15 +89,34 @@ type InputComponent struct {
 	// Images are added via Ctrl+V and cleared on submit or Ctrl+U.
 	pendingImages []core.ImageAttachment
 
-	// imageThumbs caches the rendered half-block thumbnail for each entry in
+	// imageThumbs caches the rendered thumbnail for each entry in
 	// pendingImages (1:1 index correspondence). Thumbnails are rendered
 	// asynchronously off the Bubble Tea event loop (decode + resample is too
 	// slow to run inside Update), so an entry starts as the empty string
 	// placeholder and is filled in when the matching thumbnailReadyMsg
-	// arrives. An entry stays empty when the terminal cannot display a
-	// half-block preview, in which case the text pill is shown alone.
-	// See internal/ui/imagepreview.
+	// arrives. An entry stays empty when the terminal can display no preview
+	// at all, in which case the text pill is shown alone.
+	//
+	// The contents are either half-block art or a grid of Unicode placeholders
+	// that display a transmitted image; both are ordinary styled text as far as
+	// the view is concerned. See internal/ui/imagepreview.
 	imageThumbs []string
+
+	// imageIDs holds the terminal image id backing each entry in imageThumbs
+	// (1:1 index correspondence), or 0 when the thumbnail is half-block art and
+	// owns no terminal resource. Ids are kept so the images can be freed when
+	// the pending set is cleared; terminals hold transmitted image data until
+	// told to drop it.
+	imageIDs []uint32
+
+	// imagePlace holds the placement escape sequence for each entry in
+	// imageThumbs (1:1 index correspondence), or "" when the thumbnail draws
+	// itself as text and needs no placement.
+	//
+	// A directly-placed image is painted over the screen rather than being part
+	// of the view, so it must be redrawn at its absolute position after every
+	// frame. See DirectPlacements.
+	imagePlace []string
 
 	// imageGen is a monotonic generation counter incremented whenever the
 	// pending image set is cleared. Async thumbnail results carry the
@@ -156,6 +177,19 @@ type thumbnailReadyMsg struct {
 	gen   int
 	index int
 	thumb string
+
+	// transmit carries image data that must reach the terminal outside the
+	// view text, and is empty for half-block thumbnails. See
+	// imagepreview.Thumbnail.
+	transmit string
+
+	// imageID identifies the transmitted image so it can be freed later, and is
+	// zero for half-block thumbnails.
+	imageID uint32
+
+	// place is the escape sequence that draws the image at the cursor, for
+	// thumbnails that are painted over the screen instead of drawn as text.
+	place string
 }
 
 // NewInputComponent creates a new InputComponent with the given width and
@@ -272,6 +306,8 @@ func (s *InputComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Reserve a placeholder; the async render fills it in via
 			// thumbnailReadyMsg so Update never blocks on decode/resample.
 			s.imageThumbs = append(s.imageThumbs, "")
+			s.imageIDs = append(s.imageIDs, 0)
+			s.imagePlace = append(s.imagePlace, "")
 			cols := s.thumbCols()
 			if cols < 1 {
 				return s, nil
@@ -281,8 +317,36 @@ func (s *InputComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return s, nil
 
 	case thumbnailReadyMsg:
-		if msg.gen == s.imageGen && msg.index >= 0 && msg.index < len(s.imageThumbs) {
-			s.imageThumbs[msg.index] = msg.thumb
+		if msg.gen != s.imageGen || msg.index < 0 || msg.index >= len(s.imageThumbs) {
+			// The slot is gone (cleared, or re-attached under a new
+			// generation). Free the image rather than leaking it in the
+			// terminal, which has already been told to hold the data.
+			if seq := imagepreview.DeleteImage(msg.imageID); seq != "" {
+				return s, tea.Raw(seq)
+			}
+			return s, nil
+		}
+		s.imageThumbs[msg.index] = msg.thumb
+		if msg.index < len(s.imageIDs) {
+			s.imageIDs[msg.index] = msg.imageID
+		}
+		if msg.index < len(s.imagePlace) {
+			s.imagePlace[msg.index] = msg.place
+		}
+		if msg.transmit != "" {
+			// The image data must be written straight to the terminal; it
+			// cannot travel inside the view text. For placeholder thumbnails
+			// the cells are already in the view and the terminal fills them in
+			// as soon as the data lands.
+			cmds := []tea.Cmd{tea.Raw(msg.transmit)}
+			if msg.place != "" {
+				// A directly-placed image is drawn by AppModel, which can only
+				// work out where it goes once this frame has been laid out.
+				// Nothing else would arrive to trigger that write, so ask for
+				// one more Update after the coming View.
+				cmds = append(cmds, gfxNudgeCmd())
+			}
+			return s, tea.Batch(cmds...)
 		}
 		return s, nil
 
@@ -338,10 +402,10 @@ func (s *InputComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case "ctrl+u":
 				// Clear all pending image attachments.
 				if len(s.pendingImages) > 0 {
+					cleanup := s.releaseImages()
 					s.pendingImages = nil
-					s.imageThumbs = nil
 					s.imageGen++
-					return s, nil
+					return s, cleanup
 				}
 			}
 		}
@@ -584,12 +648,39 @@ func (s *InputComponent) handleSubmit(value string) tea.Cmd {
 	// prompts) hand off to the parent via submitMsg. Attach any pending
 	// images and clear them.
 	images := s.pendingImages
+	cleanup := s.releaseImages()
 	s.pendingImages = nil
-	s.imageThumbs = nil
 	s.imageGen++
-	return func() tea.Msg {
+	submit := func() tea.Msg {
 		return core.SubmitMsg{Text: trimmed, Images: images}
 	}
+	if cleanup == nil {
+		return submit
+	}
+	// Free the preview images before handing off. tea.Sequence keeps the order
+	// so the terminal drops them while their placeholder cells are still on
+	// screen, rather than after the composer has already been redrawn.
+	return tea.Sequence(cleanup, submit)
+}
+
+// releaseImages returns a command that frees every transmitted preview image
+// and resets the thumbnail caches, or nil when nothing was transmitted.
+//
+// A terminal keeps transmitted image data until it is told to drop it, so a
+// session that attaches and clears many images would otherwise leave all of
+// them resident.
+func (s *InputComponent) releaseImages() tea.Cmd {
+	var seq strings.Builder
+	for _, id := range s.imageIDs {
+		seq.WriteString(imagepreview.DeleteImage(id))
+	}
+	s.imageThumbs = nil
+	s.imageIDs = nil
+	s.imagePlace = nil
+	if seq.Len() == 0 {
+		return nil
+	}
+	return tea.Raw(seq.String())
 }
 
 // pushHistory adds a prompt to the history ring buffer. Empty strings and
@@ -641,19 +732,124 @@ func (s *InputComponent) thumbCols() int {
 	return cols
 }
 
-// renderThumbnailCmd returns a tea.Cmd that renders a half-block ANSI preview
-// off the Bubble Tea event loop. The decode + resample work runs in the Cmd
-// goroutine, and the result is delivered as a thumbnailReadyMsg tagged with
-// the generation and slot index it was enqueued for. An empty thumbnail
-// (terminal unsupported or render error) leaves the text pill in place.
+// renderThumbnailCmd returns a tea.Cmd that renders an image preview off the
+// Bubble Tea event loop. The decode + resample work runs in the Cmd goroutine,
+// and the result is delivered as a thumbnailReadyMsg tagged with the
+// generation and slot index it was enqueued for. An empty thumbnail (terminal
+// unsupported or render error) leaves the text pill in place.
+//
+// A terminal that answered the graphics probe gets a real image; anything else
+// gets half-block art. The Kitty path falls back to half-block on error rather
+// than showing nothing, so a malformed image degrades instead of vanishing.
 func renderThumbnailCmd(img core.ImageAttachment, cols, rows int, bg color.Color, gen, index int) tea.Cmd {
 	return func() tea.Msg {
-		thumb, err := imagepreview.Render(img.Data, img.MediaType, cols, rows, bg)
+		caps := termgfx.Current()
+		var (
+			kt  imagepreview.Thumbnail
+			err error
+		)
+		switch termgfx.PreviewMode() {
+		case termgfx.ModePlaceholder:
+			kt, err = imagepreview.RenderKitty(img.Data, cols, rows, caps.CellWidth, caps.CellHeight)
+		case termgfx.ModeDirect:
+			kt, err = imagepreview.RenderKittyDirect(img.Data, cols, rows, caps.CellWidth, caps.CellHeight)
+		}
+		if kt.Cells != "" && err == nil {
+			return thumbnailReadyMsg{
+				gen:      gen,
+				index:    index,
+				thumb:    kt.Cells,
+				transmit: kt.Transmit,
+				imageID:  kt.ImageID,
+				place:    kt.Place(),
+			}
+		}
 		if err != nil {
+			log.Debug("kitty thumbnail failed, using half blocks", "error", err)
+		}
+		thumb, rerr := imagepreview.Render(img.Data, img.MediaType, cols, rows, bg)
+		if rerr != nil {
 			thumb = ""
 		}
 		return thumbnailReadyMsg{gen: gen, index: index, thumb: thumb}
 	}
+}
+
+// gfxNudgeMsg asks for one more Update/View cycle. It carries no data and is
+// handled as a no-op: its only purpose is to give AppModel.Update a chance to
+// write a graphics placement that the View before it has just computed.
+type gfxNudgeMsg struct{}
+
+// gfxNudgeCmd delivers a gfxNudgeMsg immediately.
+func gfxNudgeCmd() tea.Cmd {
+	return func() tea.Msg { return gfxNudgeMsg{} }
+}
+
+// DirectPlacement locates one directly-placed preview image within the input
+// component's view.
+type DirectPlacement struct {
+	// RowOffset is the image's first row, counted from the top of the input
+	// component's own view.
+	RowOffset int
+
+	// Col is the image's first column, counted from the left edge.
+	Col int
+
+	// Sequence draws the image at the cursor.
+	Sequence string
+}
+
+// DirectPlacements returns the placement of every preview image that is
+// painted over the screen rather than drawn as view text, positioned relative
+// to the top-left of this component's view.
+//
+// It returns nil in the usual case, where previews are either half-block art
+// or Unicode placeholders and therefore need no separate placement.
+//
+// The offsets must match the layout built by View exactly; the two are kept
+// in step by thumbRowOffsets.
+func (s *InputComponent) DirectPlacements() []DirectPlacement {
+	var out []DirectPlacement
+	for i, off := range s.thumbRowOffsets() {
+		if i < len(s.imagePlace) && s.imagePlace[i] != "" {
+			out = append(out, DirectPlacement{
+				RowOffset: off,
+				Col:       thumbPaddingLeft,
+				Sequence:  s.imagePlace[i],
+			})
+		}
+	}
+	return out
+}
+
+// thumbPaddingLeft is the left padding applied to each thumbnail by View. It
+// is a constant so DirectPlacements and View cannot disagree about where a
+// thumbnail starts.
+const thumbPaddingLeft = 1
+
+// thumbRowOffsets returns, for each pending image, the row its thumbnail
+// starts on relative to the top of this component's view, or -1 when that
+// image has no thumbnail yet.
+//
+// This mirrors the stacking order in View: the composer bar, then the "N
+// image(s) attached" label, then one block per rendered thumbnail.
+func (s *InputComponent) thumbRowOffsets() []int {
+	if len(s.pendingImages) == 0 {
+		return nil
+	}
+	// The composer bar, followed by the attachment label.
+	row := lipgloss.Height(s.textarea.View()) + 1
+
+	offsets := make([]int, len(s.pendingImages))
+	for i := range s.pendingImages {
+		if i >= len(s.imageThumbs) || s.imageThumbs[i] == "" {
+			offsets[i] = -1
+			continue
+		}
+		offsets[i] = row
+		row += lipgloss.Height(s.imageThumbs[i])
+	}
+	return offsets
 }
 
 // View implements tea.Model. Renders the composer bar and any pending image
@@ -686,7 +882,7 @@ func (s *InputComponent) View() tea.View {
 		view.WriteString("\n")
 		view.WriteString(imgStyle.Render(label))
 
-		thumbStyle := lipgloss.NewStyle().PaddingLeft(1)
+		thumbStyle := lipgloss.NewStyle().PaddingLeft(thumbPaddingLeft)
 		for i := range s.pendingImages {
 			if i < len(s.imageThumbs) && s.imageThumbs[i] != "" {
 				view.WriteString("\n")
@@ -796,10 +992,15 @@ func readClipboardImageCmd() tea.Cmd {
 
 // ClearPendingImages removes all pending image attachments and returns them.
 // Used by the parent model when consuming images for submission.
+//
+// Any transmitted preview images are freed as a side effect. Because this
+// returns attachments rather than a command, the escape sequence cannot be
+// routed through the event loop, so it is dropped here; the ids are discarded
+// either way and the terminal reclaims the data when the session ends.
 func (s *InputComponent) ClearPendingImages() []core.ImageAttachment {
 	images := s.pendingImages
 	s.pendingImages = nil
-	s.imageThumbs = nil
+	s.releaseImages()
 	s.imageGen++
 	return images
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -33,6 +33,7 @@ import (
 	"github.com/mark3labs/kit/internal/ui/imagepreview"
 	"github.com/mark3labs/kit/internal/ui/prefs"
 	"github.com/mark3labs/kit/internal/ui/style"
+	"github.com/mark3labs/kit/internal/ui/termgfx"
 	kit "github.com/mark3labs/kit/pkg/kit"
 )
 
@@ -2381,6 +2382,16 @@ func (m *AppModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.insertMessageAfter(msg.anchorID, item)
 			m.refreshContent()
 			m.layoutDirty = true
+			if msg.transmit != "" {
+				// The image data cannot travel inside the view text. The
+				// placeholder cells just inserted into the transcript display
+				// it as soon as it lands.
+				//
+				// It is deliberately never deleted: the message stays in the
+				// scrollback for the rest of the session, and freeing the data
+				// would blank the preview the next time it scrolls into view.
+				cmds = append(cmds, tea.Raw(msg.transmit))
+			}
 		}
 
 	// ── Shell command (! / !!) ───────────────────────────────────────────────
@@ -3892,15 +3903,30 @@ func truncateMessageForBlock(msg string, maxLines, width int) string {
 type imagePreviewReadyMsg struct {
 	block    string
 	anchorID string
+
+	// transmit carries image data that must reach the terminal outside the
+	// view text, and is empty for half-block previews. See
+	// imagepreview.Thumbnail.
+	transmit string
 }
 
-// transcriptPreviewCmd returns a tea.Cmd that renders half-block thumbnail
-// previews for the given clipboard images off the Bubble Tea event loop
-// (decode + resample must not block Update). The rendered block is delivered
-// via imagePreviewReadyMsg, tagged with anchorID so the consumer can place it
+// transcriptPreviewCmd returns a tea.Cmd that renders thumbnail previews for
+// the given clipboard images off the Bubble Tea event loop (decode + resample
+// must not block Update). The rendered block is delivered via
+// imagePreviewReadyMsg, tagged with anchorID so the consumer can place it
 // directly after the originating user message. Returns nil when there is
 // nothing to render or no room for a preview; an empty result (terminal lacks
 // color support) yields a nil message that Bubble Tea ignores.
+//
+// Unicode placeholders are used when the terminal supports them, because a
+// transcript preview lives in the scrollback: the ScrollList scrolls and clips
+// its items, and placeholder cells are text, so the image scrolls and clips
+// with the message it belongs to.
+//
+// Direct placement deliberately is not used here even where the composer uses
+// it. A directly placed image is painted at a fixed screen position and would
+// neither scroll with the transcript nor vanish when its message scrolls away,
+// so those terminals keep half blocks for transcript previews.
 func (m *AppModel) transcriptPreviewCmd(images []uicore.ImageAttachment, anchorID string) tea.Cmd {
 	if len(images) == 0 {
 		return nil
@@ -3914,10 +3940,22 @@ func (m *AppModel) transcriptPreviewCmd(images []uicore.ImageAttachment, anchorI
 	}
 	bg := style.GetTheme().Background
 	imgs := images
+	usePlaceholders := termgfx.PreviewMode() == termgfx.ModePlaceholder
+	caps := termgfx.Current()
 	return func() tea.Msg {
 		pad := lipgloss.NewStyle().PaddingLeft(style.ContentOffset)
 		var blocks []string
+		var transmit strings.Builder
 		for _, img := range imgs {
+			if usePlaceholders {
+				kt, err := imagepreview.RenderKitty(img.Data, cols, thumbMaxRows, caps.CellWidth, caps.CellHeight)
+				if err == nil && kt.Cells != "" {
+					transmit.WriteString(kt.Transmit)
+					blocks = append(blocks, pad.Render(kt.Cells))
+					continue
+				}
+				log.Debug("kitty transcript preview failed, using half blocks", "error", err)
+			}
 			thumb, err := imagepreview.Render(img.Data, img.MediaType, cols, thumbMaxRows, bg)
 			if err != nil || thumb == "" {
 				continue
@@ -3927,7 +3965,11 @@ func (m *AppModel) transcriptPreviewCmd(images []uicore.ImageAttachment, anchorI
 		if len(blocks) == 0 {
 			return nil
 		}
-		return imagePreviewReadyMsg{block: strings.Join(blocks, "\n"), anchorID: anchorID}
+		return imagePreviewReadyMsg{
+			block:    strings.Join(blocks, "\n"),
+			anchorID: anchorID,
+			transmit: transmit.String(),
+		}
 	}
 }
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -2053,7 +2053,11 @@ func (m *AppModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						if ic, ok := m.input.(*InputComponent); ok {
 							ic.pushHistory(text)
 							ic.textarea.SetValue("")
-							images = ic.ClearPendingImages()
+							var cleanup tea.Cmd
+							images, cleanup = ic.ClearPendingImages()
+							if cleanup != nil {
+								cmds = append(cmds, cleanup)
+							}
 						}
 
 						// Preprocess @file references (text files are XML-inlined,
@@ -2209,7 +2213,11 @@ func (m *AppModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						if text == "" {
 							if ic, ok := m.input.(*InputComponent); ok {
 								text = strings.TrimSpace(ic.textarea.Value())
-								images = ic.ClearPendingImages()
+								var cleanup tea.Cmd
+								images, cleanup = ic.ClearPendingImages()
+								if cleanup != nil {
+									cmds = append(cmds, cleanup)
+								}
 								ic.textarea.SetValue("")
 								ic.textarea.CursorEnd()
 							}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,6 +17,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/log"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/charmbracelet/x/editor"
 	"github.com/spf13/viper"
 
@@ -996,6 +998,31 @@ type AppModel struct {
 	// View() calls distributeHeight() when this is true and then clears it.
 	layoutDirty bool
 
+	// gfxPlacement is the escape sequence that redraws directly-placed preview
+	// images at their current screen position, or "" when there are none.
+	//
+	// A direct placement is painted over the screen rather than being part of
+	// the view. View computes it, because only View knows the final row of
+	// every element, and Update writes it, because escape sequences cannot
+	// travel inside view text.
+	//
+	// Only terminals that need ModeDirect use this; see internal/ui/termgfx.
+	gfxPlacement string
+
+	// gfxDirty records that the screen has been repainted since the image was
+	// last placed, so it must be drawn again.
+	//
+	// Re-placing only when the computed row changes is not enough. The
+	// renderer scrolls the screen to update it, and a terminal scrolls its
+	// images along with the text, so an image drifts upward while the row it
+	// belongs on stays exactly the same. Redrawing whenever the frame content
+	// changes catches that; gfxContentHash is what detects the change.
+	gfxDirty bool
+
+	// gfxContentHash is a hash of the last rendered frame, used to notice that
+	// the screen was repainted.
+	gfxContentHash uint64
+
 	// pendingGotoBottom requests a GotoBottom() after the next layout
 	// recalculation. Set when loading a session so that scrolling to the
 	// bottom happens with the correct viewport height.
@@ -1482,10 +1509,50 @@ func tildeHome(path string) string {
 // already running or not wanted.
 func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	model, cmd := m.update(msg)
-	if wake := m.wakeFrameClock(); wake != nil {
-		return model, tea.Batch(cmd, wake)
+	cmds := []tea.Cmd{cmd}
+	if gfx := m.flushGfxPlacement(); gfx != nil {
+		cmds = append(cmds, gfx)
 	}
-	return model, cmd
+	if wake := m.wakeFrameClock(); wake != nil {
+		cmds = append(cmds, wake)
+	}
+	if len(cmds) == 1 {
+		return model, cmd
+	}
+	return model, tea.Batch(cmds...)
+}
+
+// flushGfxPlacement returns a command that redraws directly-placed preview
+// images, or nil when their position has not changed since the last write.
+//
+// The sequence itself is computed by View, which is the only place that knows
+// the final screen row of every element. It is written from here because
+// escape sequences cannot travel inside view text: the renderer parses the
+// view into cells and would mangle them.
+//
+// The one-frame lag this implies is not visible in practice. Update runs
+// before View for a given message, so the placement written here belongs to
+// the previous frame; a frame that moves the image is therefore followed by a
+// corrective placement on the next event. Anything that changes the layout —
+// a keystroke, a resize, an agent event, the frame clock — produces that
+// event, and the image is re-placed against a screen the renderer has already
+// finished drawing.
+func (m *AppModel) flushGfxPlacement() tea.Cmd {
+	if !m.gfxDirty {
+		return nil
+	}
+	m.gfxDirty = false
+	if m.gfxPlacement == "" {
+		// The images are gone. They are deleted by the input component, which
+		// owns their ids, so there is nothing to draw here.
+		return nil
+	}
+	// Draw the image, then ask for one more cycle. Update runs before View, so
+	// the sequence written here was computed for the previous frame; the extra
+	// cycle lets the frame after this one settle and, if it moved the image
+	// again, mark it dirty once more. It converges as soon as the screen stops
+	// changing, because an unchanged frame leaves gfxDirty false.
+	return tea.Batch(tea.Raw(m.gfxPlacement), gfxNudgeCmd())
 }
 
 // wantsFrames reports whether any animation currently needs the clock.
@@ -3155,6 +3222,7 @@ func (m *AppModel) View() tea.View {
 		parts = append(parts, activityView)
 	}
 
+	inputPartIndex := len(parts)
 	parts = append(parts, inputView)
 
 	// Render "below" widgets between input and status bar.
@@ -3180,6 +3248,11 @@ func (m *AppModel) View() tea.View {
 	}
 
 	content := lipgloss.JoinVertical(lipgloss.Left, parts...)
+
+	// Record where directly-placed images landed. This must happen with the
+	// assembled parts in hand: the absolute screen row of a preview is only
+	// knowable once everything above and below it has been measured.
+	m.gfxPlacement = m.computeGfxPlacement(parts, inputPartIndex)
 
 	// Composite every modal surface over the layout at the cell level, so
 	// the conversation stays visible around each one. Ordering is z-order:
@@ -3212,6 +3285,20 @@ func (m *AppModel) View() tea.View {
 	// the caller's vertical anchor.
 	if m.state == stateOverlay && m.overlay != nil {
 		finalContent = compositeAnchored(finalContent, m.overlay.Render(), m.overlay.Anchor(), m.width, m.height)
+	}
+
+	// Notice a repaint. The renderer scrolls the screen to update it, and a
+	// terminal scrolls its images along with the text, so any change to the
+	// frame can move an image that is not part of the frame. Hashing the
+	// content is how a directly-placed image learns it must be drawn again.
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(finalContent))
+	if sum := h.Sum64(); sum != m.gfxContentHash {
+		m.gfxContentHash = sum
+		// Only a frame that still shows an image needs one drawn. The hash is
+		// updated either way, so that a frame rendered while no image was
+		// attached cannot later be mistaken for an unchanged screen.
+		m.gfxDirty = m.gfxPlacement != ""
 	}
 
 	v := tea.NewView(finalContent)
@@ -6652,4 +6739,59 @@ func (m *AppModel) handleShellCommandResult(msg uicore.ShellCommandResultMsg) te
 	}
 
 	return nil
+}
+
+// computeGfxPlacement returns the escape sequence that redraws every
+// directly-placed preview image at its current position, or "" when there is
+// nothing to place.
+//
+// Direct placements are needed by terminals that carry the Kitty graphics
+// protocol but not its Unicode placeholder encoding, where an image is painted
+// over the screen at the cursor instead of travelling with the view text. That
+// makes the image's position a property of the finished layout, which is why
+// this runs from View with the assembled parts in hand.
+//
+// parts are the stacked layout sections and inputPartIndex is the position of
+// the input section within them.
+//
+// The rows are counted up from the bottom of the screen, not down from the
+// top. The composer sits at the bottom with only the status bar and an
+// optional footer beneath it, so counting upwards depends on a couple of
+// short, fixed sections. Counting downwards would instead depend on the
+// scrollback's rendered height, and any disagreement between what it was
+// allotted and what it drew would float the image away from the composer.
+func (m *AppModel) computeGfxPlacement(parts []string, inputPartIndex int) string {
+	ic, ok := m.input.(*InputComponent)
+	if !ok || inputPartIndex < 0 || inputPartIndex >= len(parts) {
+		return ""
+	}
+	placements := ic.DirectPlacements()
+	if len(placements) == 0 {
+		return ""
+	}
+
+	// Rows occupied by everything below the input section.
+	below := 0
+	for i := inputPartIndex + 1; i < len(parts); i++ {
+		below += lipgloss.Height(parts[i])
+	}
+	// Screen rows are 1-based, so the input's last row is m.height-below and
+	// its first row is that many rows further up.
+	inputTop := m.height - below - lipgloss.Height(parts[inputPartIndex]) + 1
+
+	var b strings.Builder
+	// Save the cursor, draw each image at its absolute row, then restore. The
+	// renderer owns the cursor; moving it without putting it back would leave
+	// the next frame drawing in the wrong place.
+	b.WriteString(ansi.SaveCursor)
+	for _, p := range placements {
+		row := inputTop + p.RowOffset
+		if row < 1 || row > m.height {
+			continue // scrolled out of the visible area
+		}
+		b.WriteString(ansi.CursorPosition(p.Col+1, row))
+		b.WriteString(p.Sequence)
+	}
+	b.WriteString(ansi.RestoreCursor)
+	return b.String()
 }

--- a/internal/ui/termgfx/termgfx.go
+++ b/internal/ui/termgfx/termgfx.go
@@ -73,9 +73,10 @@ type Capabilities struct {
 	//
 	// It is captured when capabilities are resolved rather than read at draw
 	// time, so that the preview mode is a pure function of this struct. It
-	// matters for graphics because placeholder cells carry the image id in
-	// their foreground colour: a 256-colour terminal would quantise that colour
-	// and corrupt the id.
+	// decides only between the two graphics modes: placeholder cells carry the
+	// image id as a 24-bit foreground colour, which a smaller palette would
+	// quantise into a different id, whereas a direct placement carries the id
+	// in the escape sequence and does not care.
 	TrueColor bool
 
 	// UnicodePlaceholders reports that placeholder cells reach the terminal
@@ -215,16 +216,14 @@ func (m Mode) String() string {
 
 // PreviewMode reports how image previews should be drawn in this terminal.
 //
-// Kitty graphics need protocol support, a reported cell size, and truecolor:
+// Kitty graphics need protocol support and a reported cell size. The cell size
+// matters because a multiplexer that merely forwards the graphics query to the
+// terminal behind it will answer yes without being able to draw; see
+// [Capabilities.CellWidth].
 //
-//   - Cell size, because a multiplexer that merely forwards the graphics query
-//     to the terminal behind it will answer yes without being able to draw.
-//     See [Capabilities.CellWidth].
-//   - Truecolor, because placeholder cells carry the image id in their
-//     foreground colour. See [Capabilities.TrueColor].
-//
-// The choice between the two graphics modes is about the placeholder encoding
-// rather than the protocol. See [Capabilities.UnicodePlaceholders].
+// The choice between the two graphics modes turns on whether placeholder cells
+// survive to the terminal and whether it has truecolor to carry the image id
+// in. See [Capabilities.UnicodePlaceholders] and [Capabilities.TrueColor].
 func PreviewMode() Mode {
 	return previewMode(Current())
 }
@@ -237,13 +236,19 @@ func PreviewMode() Mode {
 // here would make it unsafe to call while holding capsMu, which is how a
 // startup deadlock was introduced once already.
 func previewMode(c Capabilities) Mode {
-	if !c.KittyGraphics || c.CellWidth <= 0 || c.CellHeight <= 0 || !c.TrueColor {
+	if !c.KittyGraphics || c.CellWidth <= 0 || c.CellHeight <= 0 {
 		return ModeHalfBlock
 	}
-	if !c.UnicodePlaceholders {
-		return ModeDirect
+	// Truecolor gates the placeholder encoding rather than graphics as a whole.
+	// Placeholder cells carry the image id as a 24-bit foreground colour, which
+	// a smaller palette would quantise into a different id, leaving the
+	// terminal with nothing to draw. A direct placement carries the id in the
+	// escape sequence itself, so it is unaffected and remains the better
+	// fallback for a graphics-capable terminal that lacks truecolor.
+	if c.UnicodePlaceholders && c.TrueColor {
+		return ModePlaceholder
 	}
-	return ModePlaceholder
+	return ModeDirect
 }
 
 // UseKittyGraphics reports whether image previews use the Kitty graphics
@@ -257,14 +262,21 @@ func detect(in, out *os.File, timeout time.Duration) Capabilities {
 	switch strings.ToLower(strings.TrimSpace(os.Getenv(EnvOverride))) {
 	case "kitty":
 		// Forcing the protocol must also supply a cell size, because
-		// UseKittyGraphics treats a missing one as "not really capable". Use
-		// the terminal's real geometry when it offers one so the image is
-		// resampled at the right resolution, and fall back to a plausible
-		// default when it does not — the override means the user is asserting
-		// support the probe cannot confirm.
+		// PreviewMode treats a missing one as "not really capable". Use the
+		// terminal's real geometry when it offers one so the image is resampled
+		// at the right resolution, and fall back to a plausible default when it
+		// does not — the override means the user is asserting support the probe
+		// cannot confirm.
+		//
+		// Truecolor is still resolved honestly rather than assumed. The user is
+		// asserting graphics support, not a colour depth, and claiming truecolor
+		// that is not there would select placeholder cells whose image id gets
+		// quantised into a different id. Reporting it truthfully instead falls
+		// back to a direct placement, which carries the id in the escape
+		// sequence and draws correctly at any colour depth.
 		c := Capabilities{
 			KittyGraphics:       true,
-			TrueColor:           true,
+			TrueColor:           terminalTrueColor(),
 			UnicodePlaceholders: unicodePlaceholdersWork(),
 		}
 		c.CellWidth, c.CellHeight = detectCellSize(out)
@@ -370,9 +382,14 @@ func Probe(in, out *os.File, timeout time.Duration) (Capabilities, error) {
 	// Capture the remaining capabilities now, so that every later decision is
 	// a pure function of this struct rather than a fresh look at the
 	// environment. See [Capabilities.TrueColor].
-	c.TrueColor = colorprofile.Env(os.Environ()) >= colorprofile.TrueColor
+	c.TrueColor = terminalTrueColor()
 	c.UnicodePlaceholders = unicodePlaceholdersWork()
 	return c, nil
+}
+
+// terminalTrueColor reports whether the terminal accepts 24-bit colour.
+func terminalTrueColor() bool {
+	return colorprofile.Env(os.Environ()) >= colorprofile.TrueColor
 }
 
 // unicodePlaceholdersWork reports whether placeholder cells survive the trip to

--- a/internal/ui/termgfx/termgfx.go
+++ b/internal/ui/termgfx/termgfx.go
@@ -1,0 +1,495 @@
+// Package termgfx detects which inline-graphics protocols the attached
+// terminal will actually honour.
+//
+// Detection is empirical, not a lookup table: the probe writes a Kitty
+// graphics query and a primary device attributes (DA1) request, then reads the
+// replies. A terminal that understands the Kitty graphics protocol answers the
+// query; every terminal answers DA1, so the DA1 reply is the guaranteed
+// terminator that keeps the probe from waiting for a response that will never
+// arrive.
+//
+// Empirical detection matters because a terminal's name does not predict what
+// it can do. It matters most under a multiplexer, where the answer can be
+// borrowed: both tmux and zellij forward the graphics query to the terminal
+// behind them and let that terminal answer, which makes the multiplexer look
+// capable when it cannot place an image. The probe therefore also requires the
+// pty to report pixel geometry, which is what a forwarding multiplexer lacks.
+//
+// Measured on 2026-08-26 with kitty 0.48.2:
+//
+//   - kitty: answers the query and reports a cell size. Graphics used.
+//   - zellij 0.45.0: answers (via kitty) and reports no pixel geometry. It
+//     also strips the combining marks that Unicode placeholders depend on, so
+//     nothing would draw. Half blocks used.
+//   - tmux with allow-passthrough on: answers DA1 itself while forwarding the
+//     graphics query onward, so the terminal's reply arrives after the probe
+//     has stopped reading and leaks into the input stream as visible garbage.
+//     The query is therefore not sent under a multiplexer at all.
+//
+// See internal/ui/imagepreview for the two renderers this chooses between.
+package termgfx
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/charmbracelet/colorprofile"
+	"github.com/charmbracelet/log"
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/x/ansi"
+	"golang.org/x/term"
+)
+
+// Capabilities records the graphics protocols the terminal accepted during the
+// probe. A zero value means "no inline graphics", which is the safe default:
+// callers fall back to half-block rendering.
+type Capabilities struct {
+	// KittyGraphics reports that the terminal answered the Kitty graphics
+	// query, and therefore that graphics escape sequences reach it intact.
+	KittyGraphics bool
+
+	// Sixel reports that DA1 advertised attribute 4 (sixel graphics). It is a
+	// free by-product of the probe's terminator and is not used for
+	// thumbnails today.
+	Sixel bool
+
+	// CellWidth and CellHeight are the pixel dimensions of one terminal cell,
+	// or zero when the terminal reports no pixel geometry.
+	//
+	// They are part of the graphics decision, not just a detail for scaling. A
+	// multiplexer can forward the graphics query to the terminal behind it and
+	// let that terminal answer, which makes the multiplexer look capable when
+	// it cannot actually place an image. Pixel geometry is what such a
+	// multiplexer does not report, so requiring it turns a borrowed answer into
+	// a truthful one. See ptyPixelSize.
+	CellWidth  int
+	CellHeight int
+}
+
+// kittyProbeID is the image id used by the query. Kitty echoes the id back in
+// its reply, which lets the probe tell its own response apart from any
+// unrelated APC traffic. The value is arbitrary but must be non-zero.
+const kittyProbeID = 31
+
+// kittyQuery asks the terminal to validate a one-pixel RGB image without
+// displaying it: a=q (query action), s=1,v=1 (1x1), f=24 (24-bit RGB),
+// t=d (direct payload). "AAAA" is base64 for three zero bytes, i.e. one black
+// pixel. A terminal that implements the protocol replies with
+// "\x1b_Gi=31;OK\x1b\\"; one that does not replies with nothing.
+const kittyQuery = "\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\"
+
+// requestCellSize asks the terminal for the pixel size of one cell. The reply
+// is CSI 6 ; height ; width t.
+const requestCellSize = "\x1b[16t"
+
+// defaultTimeout bounds the probe. Terminals answer in single-digit
+// milliseconds; the budget exists only so a terminal that answers neither the
+// Kitty query nor DA1 cannot stall startup.
+const defaultTimeout = 500 * time.Millisecond
+
+// EnvOverride is the environment variable that bypasses detection.
+//
+//	KIT_IMAGE_PROTOCOL=kitty      force the Kitty graphics protocol
+//	KIT_IMAGE_PROTOCOL=halfblock  force half-block thumbnails
+//	KIT_IMAGE_PROTOCOL=auto       probe the terminal (default)
+const EnvOverride = "KIT_IMAGE_PROTOCOL"
+
+// caps holds the resolved capabilities. It is nil until Resolve or Set runs,
+// so the blocking, fd-touching probe is never an import-time side effect. This
+// mirrors the lazy-capability pattern in internal/ui/style.
+var (
+	capsMu sync.RWMutex
+	caps   *Capabilities
+)
+
+// Resolve probes the process terminal once and caches the result. Later calls
+// are no-ops.
+//
+// Call this during startup, before the TUI takes over stdin: the probe reads
+// raw bytes from stdin, so it must not run while the event loop owns the same
+// fd. Headless frontends should call Set instead, so no fd that does not
+// describe their client is ever probed.
+func Resolve() {
+	capsMu.Lock()
+	if caps != nil {
+		capsMu.Unlock()
+		return
+	}
+	resolved := detect(os.Stdin, os.Stdout, defaultTimeout)
+	caps = &resolved
+	capsMu.Unlock()
+
+	// Log after releasing the lock, and derive the decision from the resolved
+	// value rather than re-reading the cache. sync.RWMutex is not reentrant, so
+	// anything here that called Current would deadlock the whole program before
+	// the TUI starts.
+	log.Debug("terminal graphics probe",
+		"kitty", resolved.KittyGraphics,
+		"sixel", resolved.Sixel,
+		"cell", fmt.Sprintf("%dx%d", resolved.CellWidth, resolved.CellHeight),
+		"use_kitty", previewMode(resolved).String(),
+		"tmux", insideTmux(),
+		"zellij", insideZellij())
+}
+
+// Set overrides the detected capabilities. It exists for headless frontends,
+// which know their client's capabilities out of band, and for tests.
+func Set(c Capabilities) {
+	capsMu.Lock()
+	caps = &c
+	capsMu.Unlock()
+}
+
+// Current returns the resolved capabilities, or the zero value when nothing
+// has been resolved yet. It never probes: an unresolved value degrades to
+// half-block rendering rather than reading stdin at render time.
+func Current() Capabilities {
+	capsMu.RLock()
+	defer capsMu.RUnlock()
+	if caps == nil {
+		return Capabilities{}
+	}
+	return *caps
+}
+
+// SupportsKittyGraphics reports whether inline Kitty graphics reach the
+// terminal intact.
+func SupportsKittyGraphics() bool {
+	return Current().KittyGraphics
+}
+
+// Mode is how image previews should be drawn.
+type Mode int
+
+const (
+	// ModeHalfBlock draws previews as coloured half-block text. It works in
+	// any terminal with 256 colours and survives multiplexers untouched.
+	ModeHalfBlock Mode = iota
+
+	// ModePlaceholder draws previews with the Kitty graphics protocol using
+	// Unicode placeholder cells, so the image travels with the view text.
+	ModePlaceholder
+
+	// ModeDirect draws previews with the Kitty graphics protocol using a
+	// direct placement at the cursor. It is for terminals that carry the
+	// protocol but drop the combining marks placeholders depend on.
+	ModeDirect
+)
+
+// String implements fmt.Stringer.
+func (m Mode) String() string {
+	switch m {
+	case ModePlaceholder:
+		return "placeholder"
+	case ModeDirect:
+		return "direct"
+	default:
+		return "halfblock"
+	}
+}
+
+// PreviewMode reports how image previews should be drawn in this terminal.
+//
+// Kitty graphics need protocol support, a reported cell size, and truecolor:
+//
+//   - Cell size, because a multiplexer that merely forwards the graphics query
+//     to the terminal behind it will answer yes without being able to draw.
+//     See [Capabilities.CellWidth].
+//   - Truecolor, because placeholder cells carry the image id in their
+//     foreground colour. A 256-colour terminal would quantise that colour and
+//     corrupt the id. Direct placement does not depend on this, but a terminal
+//     that cannot do truecolor is not one to attempt graphics in.
+//
+// The choice between the two graphics modes is about the placeholder encoding,
+// not the protocol. Zellij forwards the protocol — verified drawing a real
+// image — but discards the combining marks that tell each placeholder cell
+// which part of the image it holds, so it needs a direct placement.
+func PreviewMode() Mode {
+	return previewMode(Current())
+}
+
+// previewMode is the lock-free core of PreviewMode. It takes the capabilities
+// as an argument so callers holding capsMu, or holding a freshly resolved
+// value, can reach the same decision without reading the cache. Reading the
+// cache here would make this unsafe to call under the lock, which is how a
+// startup deadlock was introduced once already.
+func previewMode(c Capabilities) Mode {
+	if !c.KittyGraphics || c.CellWidth <= 0 || c.CellHeight <= 0 {
+		return ModeHalfBlock
+	}
+	if colorprofile.Env(os.Environ()) < colorprofile.TrueColor {
+		return ModeHalfBlock
+	}
+	if insideZellij() {
+		return ModeDirect
+	}
+	return ModePlaceholder
+}
+
+// UseKittyGraphics reports whether image previews use the Kitty graphics
+// protocol rather than half-block text.
+func UseKittyGraphics() bool {
+	return PreviewMode() != ModeHalfBlock
+}
+
+// detect applies the environment override, then falls back to the live probe.
+func detect(in, out *os.File, timeout time.Duration) Capabilities {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(EnvOverride))) {
+	case "kitty":
+		// Forcing the protocol must also supply a cell size, because
+		// UseKittyGraphics treats a missing one as "not really capable". Use
+		// the terminal's real geometry when it offers one so the image is
+		// resampled at the right resolution, and fall back to a plausible
+		// default when it does not — the override means the user is asserting
+		// support the probe cannot confirm.
+		c := Capabilities{KittyGraphics: true}
+		c.CellWidth, c.CellHeight = detectCellSize(out)
+		if c.CellWidth <= 0 || c.CellHeight <= 0 {
+			c.CellWidth, c.CellHeight = fallbackCellWidth, fallbackCellHeight
+		}
+		return c
+	case "halfblock", "none", "off":
+		return Capabilities{}
+	}
+
+	c, err := Probe(in, out, timeout)
+	if err != nil {
+		// A failed probe is not an error condition for the caller: it means
+		// "assume no graphics" and use the half-block path.
+		return Capabilities{}
+	}
+	return c
+}
+
+// fallbackCellWidth and fallbackCellHeight stand in for a cell size the
+// terminal declines to report, and are used only when the user has forced the
+// protocol on. They only affect resampling resolution: the terminal scales the
+// image into the requested cell box either way.
+const (
+	fallbackCellWidth  = 10
+	fallbackCellHeight = 20
+)
+
+// detectCellSize returns the pixel size of one cell, or zeros when the terminal
+// reports no pixel geometry.
+func detectCellSize(out *os.File) (width, height int) {
+	if out == nil {
+		return 0, 0
+	}
+	fd := int(out.Fd())
+	pxW, pxH := ptyPixelSize(fd)
+	if pxW <= 0 || pxH <= 0 {
+		return 0, 0
+	}
+	cols, rows, err := terminalGrid(fd)
+	if err != nil || cols <= 0 || rows <= 0 {
+		return 0, 0
+	}
+	return pxW / cols, pxH / rows
+}
+
+// Probe queries the terminal directly, bypassing both the cache and the
+// environment override.
+//
+// in must be the terminal's input and out its output; both are put in raw mode
+// for the duration of the call. An error means the probe could not run (not a
+// terminal, raw mode refused, write failed), which callers should read as
+// "no graphics support".
+func Probe(in, out *os.File, timeout time.Duration) (Capabilities, error) {
+	if in == nil || out == nil {
+		return Capabilities{}, fmt.Errorf("probe: nil terminal file")
+	}
+	inFd, outFd := int(in.Fd()), int(out.Fd())
+	if !term.IsTerminal(inFd) || !term.IsTerminal(outFd) {
+		return Capabilities{}, fmt.Errorf("probe: input/output is not a terminal")
+	}
+	// TERM=dumb terminals do not parse escape sequences, so the query would be
+	// echoed as literal text over the user's screen.
+	if t := os.Getenv("TERM"); t == "" || t == "dumb" {
+		return Capabilities{}, fmt.Errorf("probe: terminal type %q cannot answer queries", t)
+	}
+
+	state, err := term.MakeRaw(inFd)
+	if err != nil {
+		return Capabilities{}, fmt.Errorf("probe: enter raw mode: %w", err)
+	}
+	defer func() { _ = term.Restore(inFd, state) }()
+
+	// Ask about graphics everywhere except tmux. tmux answers DA1 itself while
+	// forwarding the graphics query onward, so the terminal's reply arrives
+	// after the probe has stopped reading and is printed into the TUI as
+	// visible garbage. Zellij forwards both consistently and answers in order.
+	var query string
+	if !insideTmux() {
+		query = kittyQuery
+	}
+	// Ask for the cell size explicitly. This is a standard sequence, not a
+	// graphics one, so multiplexers either answer it themselves or forward it
+	// safely. It is the only cell-size source inside zellij, which reports no
+	// pty pixel geometry of its own.
+	query += requestCellSize
+	// DA1 goes last: every terminal answers it, so it bounds the read whether
+	// or not the other queries were understood.
+	query += ansi.RequestPrimaryDeviceAttributes
+
+	c, err := query_(in, out, timeout, query)
+	if err != nil {
+		return c, err
+	}
+
+	// Prefer the pty's own pixel geometry, which is the terminal describing
+	// itself, and fall back to whatever the cell-size query reported.
+	if w, h := detectCellSize(out); w > 0 && h > 0 {
+		c.CellWidth, c.CellHeight = w, h
+	}
+	return c, nil
+}
+
+// terminalGrid returns the terminal size in cells.
+func terminalGrid(fd int) (cols, rows int, err error) {
+	return term.GetSize(fd)
+}
+
+// cancelGrace is how long the probe waits for the read loop to unwind after
+// the timeout cancels it. A cancelled tty read returns at once; the grace
+// period only covers readers whose Cancel is a no-op, so the probe returns a
+// partial answer instead of blocking its caller forever.
+const cancelGrace = 100 * time.Millisecond
+
+// query_ writes the query and classifies the replies until DA1 arrives or the
+// timeout cancels the read. The read loop follows the same
+// cancel-reader + sequence-decoder shape lipgloss uses for its OSC background
+// query, so an escape sequence split across two reads is reassembled rather
+// than misparsed.
+//
+// The loop runs on its own goroutine so the timeout bounds this function even
+// when the underlying reader cannot be cancelled. Capabilities classified
+// before the cancellation are still reported.
+func query_(in io.Reader, out io.Writer, timeout time.Duration, query string) (Capabilities, error) {
+	rd, err := uv.NewCancelReader(in)
+	if err != nil {
+		return Capabilities{}, fmt.Errorf("probe: create cancel reader: %w", err)
+	}
+	defer func() { _ = rd.Close() }()
+
+	if _, err := io.WriteString(out, query); err != nil {
+		return Capabilities{}, fmt.Errorf("probe: write query: %w", err)
+	}
+
+	// partial is written by the read loop and read here after a timeout, so it
+	// carries its own lock.
+	var (
+		mu      sync.Mutex
+		partial Capabilities
+	)
+	done := make(chan Capabilities, 1)
+
+	go func() {
+		pa := ansi.GetParser()
+		defer ansi.PutParser(pa)
+
+		var c Capabilities
+		var acc []byte    // one decoded sequence, reassembled across reads
+		var buf [256]byte // replies are far shorter than this
+		var state byte
+		for {
+			n, err := rd.Read(buf[:])
+			if err != nil {
+				// Cancelled or closed before DA1 arrived.
+				done <- c
+				return
+			}
+
+			p := buf[:]
+			for n > 0 {
+				seq, _, read, newState := ansi.DecodeSequence(p[:n], state, pa)
+				acc = append(acc, seq...)
+
+				if newState == ansi.NormalState {
+					terminated := classify(acc, pa, &c)
+					mu.Lock()
+					partial = c
+					mu.Unlock()
+					if terminated {
+						done <- c
+						return
+					}
+					acc = acc[:0]
+				}
+
+				state = newState
+				n -= read
+				p = p[read:]
+			}
+		}
+	}()
+
+	select {
+	case c := <-done:
+		return c, nil
+	case <-time.After(timeout):
+	}
+
+	rd.Cancel()
+	select {
+	case c := <-done:
+		return c, nil
+	case <-time.After(cancelGrace):
+		mu.Lock()
+		defer mu.Unlock()
+		return partial, nil
+	}
+}
+
+// classify inspects one decoded sequence and updates c. It returns true when
+// the sequence is the DA1 reply, which terminates the probe.
+func classify(seq []byte, pa *ansi.Parser, c *Capabilities) bool {
+	switch {
+	case ansi.HasApcPrefix(seq):
+		// A Kitty graphics reply looks like "\x1b_Gi=31;OK\x1b\\". Requiring
+		// the echoed id keeps an unrelated APC message from being mistaken
+		// for support; requiring OK keeps an error reply (ENOTSUPP, EBADF)
+		// from counting as one.
+		data := string(pa.Data())
+		if strings.HasPrefix(data, "G") &&
+			strings.Contains(data, fmt.Sprintf("i=%d", kittyProbeID)) &&
+			strings.Contains(data, ";OK") {
+			c.KittyGraphics = true
+		}
+	case ansi.HasCsiPrefix(seq):
+		switch pa.Command() {
+		case 't': // window manipulation report
+			// CSI 6 ; height ; width t answers the cell-size request.
+			if kind, _ := pa.Param(0, 0); kind == 6 {
+				h, _ := pa.Param(1, 0)
+				w, _ := pa.Param(2, 0)
+				if w > 0 && h > 0 {
+					c.CellWidth, c.CellHeight = w, h
+				}
+			}
+		case ansi.Command('?', 0, 'c'): // DA1
+			// DA1 attribute 4 advertises sixel graphics.
+			for i := range pa.Params() {
+				if v, _ := pa.Param(i, 0); v == 4 {
+					c.Sixel = true
+				}
+			}
+			return true
+		}
+	}
+	return false
+}
+
+// insideTmux reports whether the process is running in a tmux pane.
+func insideTmux() bool {
+	return os.Getenv("TMUX") != "" || strings.HasPrefix(os.Getenv("TERM"), "tmux")
+}
+
+// insideZellij reports whether the process is running in a zellij pane.
+func insideZellij() bool {
+	return os.Getenv("ZELLIJ") != ""
+}

--- a/internal/ui/termgfx/termgfx.go
+++ b/internal/ui/termgfx/termgfx.go
@@ -68,6 +68,27 @@ type Capabilities struct {
 	// a truthful one. See ptyPixelSize.
 	CellWidth  int
 	CellHeight int
+
+	// TrueColor reports that the terminal accepts 24-bit colour.
+	//
+	// It is captured when capabilities are resolved rather than read at draw
+	// time, so that the preview mode is a pure function of this struct. It
+	// matters for graphics because placeholder cells carry the image id in
+	// their foreground colour: a 256-colour terminal would quantise that colour
+	// and corrupt the id.
+	TrueColor bool
+
+	// UnicodePlaceholders reports that placeholder cells reach the terminal
+	// intact, and therefore that an image can be drawn as view text.
+	//
+	// This is a separate capability from the protocol itself. Zellij 0.45
+	// forwards the graphics protocol and draws real images, but discards the
+	// combining marks that tell each placeholder cell which part of the image
+	// it holds, so placeholders render nothing there while direct placement
+	// works. Naming the capability rather than the terminal keeps the decision
+	// in one place: a future release that fixes the marks changes detection,
+	// not the renderer.
+	UnicodePlaceholders bool
 }
 
 // kittyProbeID is the image id used by the query. Kitty echoes the id back in
@@ -200,31 +221,26 @@ func (m Mode) String() string {
 //     to the terminal behind it will answer yes without being able to draw.
 //     See [Capabilities.CellWidth].
 //   - Truecolor, because placeholder cells carry the image id in their
-//     foreground colour. A 256-colour terminal would quantise that colour and
-//     corrupt the id. Direct placement does not depend on this, but a terminal
-//     that cannot do truecolor is not one to attempt graphics in.
+//     foreground colour. See [Capabilities.TrueColor].
 //
-// The choice between the two graphics modes is about the placeholder encoding,
-// not the protocol. Zellij forwards the protocol — verified drawing a real
-// image — but discards the combining marks that tell each placeholder cell
-// which part of the image it holds, so it needs a direct placement.
+// The choice between the two graphics modes is about the placeholder encoding
+// rather than the protocol. See [Capabilities.UnicodePlaceholders].
 func PreviewMode() Mode {
 	return previewMode(Current())
 }
 
-// previewMode is the lock-free core of PreviewMode. It takes the capabilities
-// as an argument so callers holding capsMu, or holding a freshly resolved
-// value, can reach the same decision without reading the cache. Reading the
-// cache here would make this unsafe to call under the lock, which is how a
+// previewMode is the pure core of PreviewMode. It decides only from the
+// resolved capabilities, and reads neither the environment nor the cache.
+//
+// Keeping it pure matters twice over. It is called for every thumbnail render,
+// so it must not re-sniff the environment each time; and reading the cache
+// here would make it unsafe to call while holding capsMu, which is how a
 // startup deadlock was introduced once already.
 func previewMode(c Capabilities) Mode {
-	if !c.KittyGraphics || c.CellWidth <= 0 || c.CellHeight <= 0 {
+	if !c.KittyGraphics || c.CellWidth <= 0 || c.CellHeight <= 0 || !c.TrueColor {
 		return ModeHalfBlock
 	}
-	if colorprofile.Env(os.Environ()) < colorprofile.TrueColor {
-		return ModeHalfBlock
-	}
-	if insideZellij() {
+	if !c.UnicodePlaceholders {
 		return ModeDirect
 	}
 	return ModePlaceholder
@@ -246,7 +262,11 @@ func detect(in, out *os.File, timeout time.Duration) Capabilities {
 		// resampled at the right resolution, and fall back to a plausible
 		// default when it does not — the override means the user is asserting
 		// support the probe cannot confirm.
-		c := Capabilities{KittyGraphics: true}
+		c := Capabilities{
+			KittyGraphics:       true,
+			TrueColor:           true,
+			UnicodePlaceholders: unicodePlaceholdersWork(),
+		}
 		c.CellWidth, c.CellHeight = detectCellSize(out)
 		if c.CellWidth <= 0 || c.CellHeight <= 0 {
 			c.CellWidth, c.CellHeight = fallbackCellWidth, fallbackCellHeight
@@ -346,7 +366,25 @@ func Probe(in, out *os.File, timeout time.Duration) (Capabilities, error) {
 	if w, h := detectCellSize(out); w > 0 && h > 0 {
 		c.CellWidth, c.CellHeight = w, h
 	}
+
+	// Capture the remaining capabilities now, so that every later decision is
+	// a pure function of this struct rather than a fresh look at the
+	// environment. See [Capabilities.TrueColor].
+	c.TrueColor = colorprofile.Env(os.Environ()) >= colorprofile.TrueColor
+	c.UnicodePlaceholders = unicodePlaceholdersWork()
 	return c, nil
+}
+
+// unicodePlaceholdersWork reports whether placeholder cells survive the trip to
+// the terminal.
+//
+// There is no query for this, so it is a known-bad list of one: zellij 0.45
+// forwards the graphics protocol and draws real images, but strips the
+// combining marks that placeholders are built from. Everything else is assumed
+// to pass text through unchanged, which is the safe assumption — a terminal
+// that mangles combining marks would garble ordinary text too.
+func unicodePlaceholdersWork() bool {
+	return !insideZellij()
 }
 
 // terminalGrid returns the terminal size in cells.

--- a/internal/ui/termgfx/termgfx_test.go
+++ b/internal/ui/termgfx/termgfx_test.go
@@ -1,0 +1,332 @@
+package termgfx
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeTerminal replays a canned reply stream, so the probe's read loop can be
+// exercised without a real tty.
+type fakeTerminal struct {
+	reply  *bytes.Reader
+	out    bytes.Buffer
+	chunks int // when >0, return at most this many bytes per Read
+}
+
+func (f *fakeTerminal) Read(p []byte) (int, error) {
+	if f.chunks > 0 && len(p) > f.chunks {
+		p = p[:f.chunks]
+	}
+	return f.reply.Read(p)
+}
+
+func (f *fakeTerminal) Write(p []byte) (int, error) { return f.out.Write(p) }
+
+const (
+	kittyOK  = "\x1b_Gi=31;OK\x1b\\"
+	da1Plain = "\x1b[?62;22c"
+	da1Sixel = "\x1b[?62;4;22c"
+)
+
+func TestQueryClassifiesReplies(t *testing.T) {
+	tests := []struct {
+		name      string
+		reply     string
+		wantKitty bool
+		wantSixel bool
+	}{
+		{"kitty then da1", kittyOK + da1Plain, true, false},
+		{"da1 only", da1Plain, false, false},
+		{"sixel only", da1Sixel, false, true},
+		{"kitty and sixel", kittyOK + da1Sixel, true, true},
+		{"kitty error reply", "\x1b_Gi=31;ENOTSUPPORTED\x1b\\" + da1Plain, false, false},
+		{"foreign apc ignored", "\x1b_Xhello\x1b\\" + da1Plain, false, false},
+		{"wrong image id ignored", "\x1b_Gi=99;OK\x1b\\" + da1Plain, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ft := &fakeTerminal{reply: bytes.NewReader([]byte(tt.reply))}
+			got, err := query_(ft, ft, time.Second, "query")
+			if err != nil {
+				t.Fatalf("query_: %v", err)
+			}
+			if got.KittyGraphics != tt.wantKitty {
+				t.Errorf("KittyGraphics = %v, want %v", got.KittyGraphics, tt.wantKitty)
+			}
+			if got.Sixel != tt.wantSixel {
+				t.Errorf("Sixel = %v, want %v", got.Sixel, tt.wantSixel)
+			}
+			if ft.out.String() != "query" {
+				t.Errorf("wrote %q, want %q", ft.out.String(), "query")
+			}
+		})
+	}
+}
+
+// A reply split across reads must still be decoded as one sequence.
+func TestQueryReassemblesSplitSequences(t *testing.T) {
+	ft := &fakeTerminal{
+		reply:  bytes.NewReader([]byte(kittyOK + da1Sixel)),
+		chunks: 3,
+	}
+	got, err := query_(ft, ft, time.Second, "q")
+	if err != nil {
+		t.Fatalf("query_: %v", err)
+	}
+	if !got.KittyGraphics || !got.Sixel {
+		t.Errorf("got %+v, want both capabilities", got)
+	}
+}
+
+// A terminal that answers nothing must not hang the caller: the timeout has to
+// cancel a read that would otherwise block forever.
+func TestQueryTimesOutWithoutReply(t *testing.T) {
+	pr, pw := io.Pipe() // never written to, so every Read blocks
+	t.Cleanup(func() { _ = pw.Close() })
+
+	start := time.Now()
+	got, err := query_(pr, io.Discard, 50*time.Millisecond, "q")
+	if err != nil {
+		t.Fatalf("query_: %v", err)
+	}
+	if got != (Capabilities{}) {
+		t.Errorf("got %+v, want zero capabilities", got)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("probe took %v, want it bounded by the timeout", elapsed)
+	}
+}
+
+// A stream that ends mid-probe must report what was classified so far rather
+// than an error.
+func TestQueryHandlesEarlyEOF(t *testing.T) {
+	ft := &fakeTerminal{reply: bytes.NewReader(nil)}
+	got, err := query_(ft, ft, time.Second, "q")
+	if err != nil {
+		t.Fatalf("query_: %v", err)
+	}
+	if got != (Capabilities{}) {
+		t.Errorf("got %+v, want zero capabilities", got)
+	}
+}
+
+// Zellij needs a direct placement: it forwards the graphics protocol but drops
+// the combining marks that Unicode placeholders depend on.
+func TestPreviewModeChoosesDirectInZellij(t *testing.T) {
+	t.Cleanup(func() {
+		capsMu.Lock()
+		caps = nil
+		capsMu.Unlock()
+	})
+	t.Setenv("COLORTERM", "truecolor")
+	capable := Capabilities{KittyGraphics: true, CellWidth: 10, CellHeight: 20}
+
+	t.Setenv("ZELLIJ", "0")
+	if got := previewMode(capable); got != ModeDirect {
+		t.Errorf("previewMode() in zellij = %v, want %v", got, ModeDirect)
+	}
+
+	t.Setenv("ZELLIJ", "")
+	if got := previewMode(capable); got != ModePlaceholder {
+		t.Errorf("previewMode() in a bare terminal = %v, want %v", got, ModePlaceholder)
+	}
+}
+
+// Graphics stay off inside a multiplexer even when the probe reports support,
+// because the reported support is borrowed from the terminal behind it.
+func TestUseKittyGraphicsRequiresCellSize(t *testing.T) {
+	t.Cleanup(func() {
+		capsMu.Lock()
+		caps = nil
+		capsMu.Unlock()
+	})
+	t.Setenv("COLORTERM", "truecolor")
+
+	Set(Capabilities{KittyGraphics: true, CellWidth: 0, CellHeight: 0})
+	if UseKittyGraphics() {
+		t.Error("UseKittyGraphics() = true without a reported cell size")
+	}
+	Set(Capabilities{KittyGraphics: true, CellWidth: 10, CellHeight: 20})
+	if !UseKittyGraphics() {
+		t.Error("UseKittyGraphics() = false with support and a cell size")
+	}
+	Set(Capabilities{KittyGraphics: false, CellWidth: 10, CellHeight: 20})
+	if UseKittyGraphics() {
+		t.Error("UseKittyGraphics() = true without protocol support")
+	}
+}
+
+func TestEnvOverride(t *testing.T) {
+	// Forcing the protocol on must produce capabilities that UseKittyGraphics
+	// actually accepts. Returning support without a cell size would make the
+	// override silently do nothing.
+	for _, v := range []string{"kitty", "KITTY"} {
+		t.Run(v, func(t *testing.T) {
+			t.Setenv(EnvOverride, v)
+			t.Setenv("COLORTERM", "truecolor")
+			got := detect(nil, nil, time.Second)
+			if !got.KittyGraphics {
+				t.Errorf("detect() = %+v, want graphics support", got)
+			}
+			if got.CellWidth <= 0 || got.CellHeight <= 0 {
+				t.Errorf("detect() = %+v, want a usable cell size", got)
+			}
+			Set(got)
+			t.Cleanup(func() {
+				capsMu.Lock()
+				caps = nil
+				capsMu.Unlock()
+			})
+			if !UseKittyGraphics() {
+				t.Error("UseKittyGraphics() = false after forcing the protocol on")
+			}
+		})
+	}
+
+	for _, v := range []string{"halfblock", "none", "off"} {
+		t.Run(v, func(t *testing.T) {
+			t.Setenv(EnvOverride, v)
+			// os.Stdin under `go test` is not a terminal, so any value that
+			// does not short-circuit would fall through to a failed probe.
+			if got := detect(nil, nil, time.Second); got != (Capabilities{}) {
+				t.Errorf("detect() = %+v, want no capabilities", got)
+			}
+		})
+	}
+}
+
+func TestProbeRejectsNonTerminal(t *testing.T) {
+	// go test replaces stdin with /dev/null, which is not a terminal.
+	if _, err := Probe(nil, nil, time.Second); err == nil {
+		t.Error("Probe(nil, nil) = nil error, want an error")
+	}
+}
+
+func TestSetAndCurrent(t *testing.T) {
+	t.Cleanup(func() {
+		capsMu.Lock()
+		caps = nil
+		capsMu.Unlock()
+	})
+
+	Set(Capabilities{KittyGraphics: true})
+	if !SupportsKittyGraphics() {
+		t.Error("SupportsKittyGraphics() = false after Set, want true")
+	}
+
+	// Resolve must not overwrite an explicitly supplied value.
+	Resolve()
+	if !SupportsKittyGraphics() {
+		t.Error("Resolve() overwrote the value supplied by Set")
+	}
+}
+
+func TestUnresolvedDefaultsToNoGraphics(t *testing.T) {
+	capsMu.Lock()
+	caps = nil
+	capsMu.Unlock()
+
+	if Current() != (Capabilities{}) {
+		t.Error("Current() on an unresolved cache reported graphics support")
+	}
+	if SupportsKittyGraphics() {
+		t.Error("SupportsKittyGraphics() = true before resolution, want false")
+	}
+}
+
+// The query the probe sends must carry the id the classifier looks for.
+func TestKittyQueryCarriesProbeID(t *testing.T) {
+	if !strings.Contains(kittyQuery, "i=31") || kittyProbeID != 31 {
+		t.Errorf("kittyQuery %q and kittyProbeID %d disagree", kittyQuery, kittyProbeID)
+	}
+	if !strings.HasPrefix(kittyQuery, "\x1b_G") || !strings.HasSuffix(kittyQuery, "\x1b\\") {
+		t.Errorf("kittyQuery %q is not a well-formed APC sequence", kittyQuery)
+	}
+}
+
+// TestProbeLive runs the probe against the real controlling terminal and
+// reports what it found. It is skipped unless KIT_LIVE_PROBE=1.
+//
+// Run it inside each terminal and multiplexer you care about:
+//
+//	KIT_LIVE_PROBE=1 go test -v -run TestProbeLive ./internal/ui/termgfx/
+func TestProbeLive(t *testing.T) {
+	if os.Getenv("KIT_LIVE_PROBE") != "1" {
+		t.Skip("set KIT_LIVE_PROBE=1 to probe the real terminal")
+	}
+	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	if err != nil {
+		t.Skipf("no controlling terminal: %v", err)
+	}
+	defer func() { _ = tty.Close() }()
+
+	c, err := Probe(tty, tty, 2*time.Second)
+	t.Logf("TERM=%q ZELLIJ=%q TMUX=%q", os.Getenv("TERM"), os.Getenv("ZELLIJ"), os.Getenv("TMUX"))
+	t.Logf("caps=%+v err=%v", c, err)
+	Set(c)
+	t.Logf("UseKittyGraphics=%v", UseKittyGraphics())
+}
+
+// Resolve must not deadlock. It holds capsMu while caching the result, and
+// sync.RWMutex is not reentrant, so any call it makes that reads the cache
+// (Current, UseKittyGraphics) hangs the process before the TUI ever starts.
+// That shipped once and made kit render nothing at all.
+func TestResolveDoesNotDeadlock(t *testing.T) {
+	t.Cleanup(func() {
+		capsMu.Lock()
+		caps = nil
+		capsMu.Unlock()
+	})
+	// Short-circuit the probe so this exercises the locking, not a terminal.
+	t.Setenv(EnvOverride, "halfblock")
+
+	capsMu.Lock()
+	caps = nil
+	capsMu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		Resolve()
+		// Reading the cache afterwards must work too: a Resolve that returned
+		// while still holding the lock would block every later reader.
+		_ = Current()
+		_ = UseKittyGraphics()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Resolve deadlocked")
+	}
+}
+
+// The second Resolve takes the early-return path, which must also release the
+// lock.
+func TestResolveIsIdempotent(t *testing.T) {
+	t.Cleanup(func() {
+		capsMu.Lock()
+		caps = nil
+		capsMu.Unlock()
+	})
+	t.Setenv(EnvOverride, "halfblock")
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		Resolve()
+		Resolve()
+		_ = Current()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("second Resolve deadlocked")
+	}
+}

--- a/internal/ui/termgfx/termgfx_test.go
+++ b/internal/ui/termgfx/termgfx_test.go
@@ -163,10 +163,20 @@ func TestPreviewMode(t *testing.T) {
 		},
 		{
 			// Placeholders carry the image id in their foreground colour, which
-			// a 256-colour terminal would quantise and corrupt.
+			// a smaller palette would quantise into a different id. A direct
+			// placement carries the id in the escape sequence, so it still
+			// draws correctly and is the better fallback than half blocks.
 			name: "no truecolor",
 			caps: withCaps(func(c *Capabilities) { c.TrueColor = false }),
-			want: ModeHalfBlock,
+			want: ModeDirect,
+		},
+		{
+			name: "neither placeholders nor truecolor",
+			caps: withCaps(func(c *Capabilities) {
+				c.TrueColor = false
+				c.UnicodePlaceholders = false
+			}),
+			want: ModeDirect,
 		},
 		{
 			name: "nothing detected",
@@ -250,10 +260,33 @@ func TestEnvOverride(t *testing.T) {
 	// Forcing the protocol on must produce capabilities that UseKittyGraphics
 	// actually accepts. Returning support without a cell size would make the
 	// override silently do nothing.
+	// Forcing the protocol on must not fabricate a colour depth. Claiming
+	// truecolor that is not there would select placeholder cells whose image id
+	// is carried in a 24-bit foreground colour, and a smaller palette would
+	// quantise it into a different id, so nothing would draw.
+	t.Run("does not fabricate truecolor", func(t *testing.T) {
+		t.Setenv(EnvOverride, "kitty")
+		t.Setenv("TERM", "xterm-256color")
+		t.Setenv("COLORTERM", "")
+		t.Setenv("ZELLIJ", "")
+
+		got := detect(nil, nil, time.Second)
+		if got.TrueColor {
+			t.Error("detect() claimed truecolor in a 256-colour terminal")
+		}
+		// The override must still deliver graphics, via the mode that works
+		// without truecolor.
+		if mode := previewMode(got); mode != ModeDirect {
+			t.Errorf("previewMode() = %v, want %v", mode, ModeDirect)
+		}
+	})
+
 	for _, v := range []string{"kitty", "KITTY"} {
 		t.Run(v, func(t *testing.T) {
 			t.Setenv(EnvOverride, v)
 			t.Setenv("ZELLIJ", "")
+			t.Setenv("TERM", "xterm-kitty")
+			t.Setenv("COLORTERM", "truecolor")
 			got := detect(nil, nil, time.Second)
 			if !got.KittyGraphics {
 				t.Errorf("detect() = %+v, want graphics support", got)

--- a/internal/ui/termgfx/termgfx_test.go
+++ b/internal/ui/termgfx/termgfx_test.go
@@ -115,25 +115,111 @@ func TestQueryHandlesEarlyEOF(t *testing.T) {
 	}
 }
 
-// Zellij needs a direct placement: it forwards the graphics protocol but drops
-// the combining marks that Unicode placeholders depend on.
-func TestPreviewModeChoosesDirectInZellij(t *testing.T) {
-	t.Cleanup(func() {
-		capsMu.Lock()
-		caps = nil
-		capsMu.Unlock()
-	})
-	t.Setenv("COLORTERM", "truecolor")
-	capable := Capabilities{KittyGraphics: true, CellWidth: 10, CellHeight: 20}
+// capableTerminal is a terminal that can draw graphics every way Kit knows
+// how. Tests narrow it to describe the terminal they are about.
+//
+// previewMode decides only from these fields, never from the environment, so
+// the tests below need no environment at all. That matters: an earlier version
+// read COLORTERM at decision time and passed only on developer machines,
+// because colorprofile reports no colour when TERM is unset the way it is in
+// CI.
+var capableTerminal = Capabilities{
+	KittyGraphics:       true,
+	CellWidth:           10,
+	CellHeight:          20,
+	TrueColor:           true,
+	UnicodePlaceholders: true,
+}
 
+func TestPreviewMode(t *testing.T) {
+	tests := []struct {
+		name string
+		caps Capabilities
+		want Mode
+	}{
+		{
+			name: "graphics terminal",
+			caps: capableTerminal,
+			want: ModePlaceholder,
+		},
+		{
+			// Zellij forwards the protocol and draws real images, but strips
+			// the combining marks placeholders are built from.
+			name: "placeholders stripped",
+			caps: withCaps(func(c *Capabilities) { c.UnicodePlaceholders = false }),
+			want: ModeDirect,
+		},
+		{
+			name: "no protocol support",
+			caps: withCaps(func(c *Capabilities) { c.KittyGraphics = false }),
+			want: ModeHalfBlock,
+		},
+		{
+			// A borrowed answer: a multiplexer forwarded the query to the
+			// terminal behind it and reports no pixel geometry of its own.
+			name: "no cell size",
+			caps: withCaps(func(c *Capabilities) { c.CellWidth, c.CellHeight = 0, 0 }),
+			want: ModeHalfBlock,
+		},
+		{
+			// Placeholders carry the image id in their foreground colour, which
+			// a 256-colour terminal would quantise and corrupt.
+			name: "no truecolor",
+			caps: withCaps(func(c *Capabilities) { c.TrueColor = false }),
+			want: ModeHalfBlock,
+		},
+		{
+			name: "nothing detected",
+			caps: Capabilities{},
+			want: ModeHalfBlock,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := previewMode(tt.caps); got != tt.want {
+				t.Errorf("previewMode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// withCaps returns capableTerminal with one field changed.
+func withCaps(f func(*Capabilities)) Capabilities {
+	c := capableTerminal
+	f(&c)
+	return c
+}
+
+// The preview mode must not depend on the environment it is called in. It is
+// consulted for every thumbnail render, and an ambient read there is both a
+// per-render cost and a source of decisions that differ between a developer's
+// terminal and CI.
+func TestPreviewModeIgnoresEnvironment(t *testing.T) {
+	want := previewMode(capableTerminal)
+
+	t.Setenv("TERM", "")
+	t.Setenv("COLORTERM", "")
+	t.Setenv("ZELLIJ", "1")
+	t.Setenv("TMUX", "1")
+	t.Setenv("NO_COLOR", "1")
+
+	if got := previewMode(capableTerminal); got != want {
+		t.Errorf("previewMode() = %v with the environment cleared, want %v", got, want)
+	}
+}
+
+// Zellij is the terminal that needs a direct placement, so detection must
+// report its placeholders as unusable.
+func TestUnicodePlaceholdersDetection(t *testing.T) {
 	t.Setenv("ZELLIJ", "0")
-	if got := previewMode(capable); got != ModeDirect {
-		t.Errorf("previewMode() in zellij = %v, want %v", got, ModeDirect)
+	if unicodePlaceholdersWork() {
+		t.Error("unicodePlaceholdersWork() = true in zellij, where the marks are stripped")
 	}
 
 	t.Setenv("ZELLIJ", "")
-	if got := previewMode(capable); got != ModePlaceholder {
-		t.Errorf("previewMode() in a bare terminal = %v, want %v", got, ModePlaceholder)
+	if !unicodePlaceholdersWork() {
+		t.Error("unicodePlaceholdersWork() = false outside zellij")
 	}
 }
 
@@ -145,17 +231,16 @@ func TestUseKittyGraphicsRequiresCellSize(t *testing.T) {
 		caps = nil
 		capsMu.Unlock()
 	})
-	t.Setenv("COLORTERM", "truecolor")
 
-	Set(Capabilities{KittyGraphics: true, CellWidth: 0, CellHeight: 0})
+	Set(withCaps(func(c *Capabilities) { c.CellWidth, c.CellHeight = 0, 0 }))
 	if UseKittyGraphics() {
 		t.Error("UseKittyGraphics() = true without a reported cell size")
 	}
-	Set(Capabilities{KittyGraphics: true, CellWidth: 10, CellHeight: 20})
+	Set(capableTerminal)
 	if !UseKittyGraphics() {
 		t.Error("UseKittyGraphics() = false with support and a cell size")
 	}
-	Set(Capabilities{KittyGraphics: false, CellWidth: 10, CellHeight: 20})
+	Set(withCaps(func(c *Capabilities) { c.KittyGraphics = false }))
 	if UseKittyGraphics() {
 		t.Error("UseKittyGraphics() = true without protocol support")
 	}
@@ -168,7 +253,7 @@ func TestEnvOverride(t *testing.T) {
 	for _, v := range []string{"kitty", "KITTY"} {
 		t.Run(v, func(t *testing.T) {
 			t.Setenv(EnvOverride, v)
-			t.Setenv("COLORTERM", "truecolor")
+			t.Setenv("ZELLIJ", "")
 			got := detect(nil, nil, time.Second)
 			if !got.KittyGraphics {
 				t.Errorf("detect() = %+v, want graphics support", got)

--- a/internal/ui/termgfx/winsize_unix.go
+++ b/internal/ui/termgfx/winsize_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package termgfx
+
+import "golang.org/x/sys/unix"
+
+// ptyPixelSize returns the pixel dimensions the terminal reports for the whole
+// pty, or zeros when it reports none.
+//
+// A terminal emulator that draws images knows its own pixel geometry and fills
+// these fields in. A multiplexer that only forwards text leaves them at zero,
+// even while it forwards graphics queries to the terminal behind it and lets
+// that terminal answer them. That makes this the honest test of whether the
+// program on the other end of the pty is the one drawing.
+//
+// Kitty's own icat gates on the same report, and refuses to display an image
+// when it is missing.
+func ptyPixelSize(fd int) (width, height int) {
+	ws, err := unix.IoctlGetWinsize(fd, unix.TIOCGWINSZ)
+	if err != nil || ws == nil {
+		return 0, 0
+	}
+	return int(ws.Xpixel), int(ws.Ypixel)
+}

--- a/internal/ui/termgfx/winsize_windows.go
+++ b/internal/ui/termgfx/winsize_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package termgfx
+
+// ptyPixelSize reports no pixel geometry on Windows.
+//
+// The console API exposes no per-pty pixel size, so image previews there fall
+// back to half-block rendering. See the Unix implementation for why the report
+// is required.
+func ptyPixelSize(fd int) (width, height int) {
+	return 0, 0
+}

--- a/www/pages/cli/commands.md
+++ b/www/pages/cli/commands.md
@@ -220,10 +220,17 @@ Attach images to your next prompt straight from the clipboard:
 
 When a terminal supports color, Kit renders a small low-resolution **thumbnail preview** of each pending image directly in the input, below the `[N image(s) attached]` indicator, so you can confirm the right image was attached before sending.
 
-The preview is drawn with Unicode half-block characters and ordinary terminal colors — not a graphics protocol — so it renders correctly inside terminal multiplexers like **tmux** and **zellij**. Thumbnails are capped to a small cell box for a glanceable, low-res look.
+Kit probes the terminal at startup and draws the preview the best way it actually supports. A terminal that answers the **Kitty graphics protocol** gets a real image; anything else gets a thumbnail built from Unicode half-block characters and ordinary terminal colors, which renders correctly everywhere. Thumbnails are capped to a small cell box for a glanceable, low-res look.
 
+Detection is a live query rather than a guess from `$TERM`, because a multiplexer can forward the query to the terminal behind it and appear to support graphics it cannot draw:
+
+- **kitty** and similar: real images, in both the input preview and the transcript.
+- **zellij**: real images in the input preview. Submitted images fall back to half blocks in the transcript, because a scrolling transcript needs the image to move with its message and zellij cannot yet do that.
+- **tmux**: half blocks. tmux answers the query itself while forwarding it onward, so the terminal's late reply would be printed into the UI as stray escape codes.
 - Best fidelity needs a **truecolor** terminal (`COLORTERM=truecolor`); Kit degrades to 256-color where truecolor is unavailable.
 - On terminals with neither, the preview is skipped and the `[N image(s) attached]` text indicator is shown alone.
+
+Set `KIT_IMAGE_PROTOCOL=kitty` to force the graphics protocol, or `KIT_IMAGE_PROTOCOL=halfblock` to force half blocks, when the probe gets it wrong.
 
 You can also attach image files by referencing them with `@path/to/image.png` — binary files are auto-detected by MIME type. See [Quick Start](/quick-start) for the `@` attachment syntax.
 


### PR DESCRIPTION
## Description

Pasted image attachments were always drawn as half-block Unicode art. That survives any terminal but wastes the graphics protocol where one exists. This adds runtime detection and uses the Kitty graphics protocol where it genuinely works, keeping half blocks as the fallback everywhere else.

Detection is empirical rather than a lookup on `$TERM`. `internal/ui/termgfx` writes a Kitty graphics query terminated by a DA1 request — which every terminal answers, so the probe cannot block on a reply that never comes — and runs once at startup before the event loop owns stdin. The probe alone is not sufficient, because the answer can be *borrowed*: a multiplexer forwards the query to the terminal behind it and lets that terminal answer, which looks like support it cannot deliver. Requiring the pty to also report pixel geometry separates the two.

Three modes result. **kitty** gets Unicode placeholders, so the image travels as view text and moves, scrolls and clips with the layout around it. **zellij** gets direct placement: it forwards the protocol and draws real images, but discards the combining marks that tell each placeholder cell which part of the image it holds. **tmux** stays on half blocks, because it answers DA1 itself while forwarding the graphics query onward, so the terminal's late reply lands after the probe stops reading and is printed into the UI as stray escape codes.

Direct placement is the awkward path, since the image is painted over the screen at the cursor instead of being part of the frame. `View` computes the absolute row once every section is measured and `Update` writes it with `tea.Raw`. Two details are load-bearing and were each found by measuring rather than reasoning: rows are counted **up from the bottom**, because the composer is bottom-anchored and counting down depends on the scrollback's rendered height; and the placement is re-emitted whenever the **rendered frame changes**, not only when the computed row changes, because the renderer scrolls the screen and terminals scroll their images along with the text.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / internal change

## Checklist

- [x] Code follows the style guidelines of this project (`gofmt`, `go vet`, `golangci-lint` clean on changed files)
- [x] Self-review of the code performed
- [x] Comments added in hard-to-understand areas, explaining *why* rather than *what*
- [x] Documentation updated (`www/pages/cli/commands.md` said the preview is "not a graphics protocol", which this change makes false)
- [x] Tests added that prove the change works (34 new tests)
- [x] New and existing tests pass locally (`go test -race ./internal/ui/...`)
- [x] No new warnings introduced

## Verification

Behaviour was confirmed by hand in each terminal, not just by unit tests:

| | composer preview | transcript preview |
|---|---|---|
| **kitty** | graphics | graphics |
| **zellij 0.45** | graphics | half blocks (see below) |
| **tmux** | half blocks | half blocks |

Placement, redraw as the composer grows, and clearing with <kbd>Ctrl</kbd>+<kbd>U</kbd> were each verified in kitty and zellij.

Unit tests cover the probe's reply classification, its timeout and early-EOF paths, both renderers, the placement encoding, the layout arithmetic that anchors a preview to the composer, and both branches of the transcript mode selection. Two regression tests were checked by reintroducing the original bug and confirming they fail.

## Additional Information

**Added**
- `internal/ui/termgfx/` — capability probe and mode selection (`termgfx.go`, `winsize_unix.go`, `winsize_windows.go`, plus tests)
- `internal/ui/imagepreview/kitty.go` — placeholder and direct renderers, placement and delete encoding
- `internal/ui/gfx_placement_test.go`, `internal/ui/imagepreview/kitty_test.go`

**Modified**
- `internal/ui/input.go` — renderer selection for the composer preview; tracks image ids so they can be freed on clear/submit
- `internal/ui/model.go` — computes and flushes direct placements; transcript previews use placeholders where supported
- `cmd/root.go` — resolves capabilities at startup, before the TUI takes stdin
- `www/pages/cli/commands.md` — corrects the claim that previews never use a graphics protocol

**Backward compatibility**

No breaking changes. Half blocks remain the fallback for every terminal that does not answer the probe, and for any render that fails, so a terminal that cannot draw images still shows a preview rather than a gap. `KIT_IMAGE_PROTOCOL=kitty|halfblock` forces either path without a rebuild.

**Known limitation**

Transcript previews use placeholders only, never direct placement, so a submitted image still renders as half blocks in zellij. This is deliberate: the transcript lives in the scrollback, which scrolls and clips its items. Placeholder cells are text and move with their message; a directly placed image is painted at a fixed screen position, would sit still while the transcript scrolled beneath it, and would outlive the message scrolling away entirely. Closing this needs transcript images tracked across scroll offsets and clipped when partially visible, which belongs in its own change. Both branches are pinned by tests so the reasoning is not lost.

**Incidental fix**

`cmd/root.go` now raises the `charmbracelet/log` level to debug under `--debug`. Structured debug output was already routed to the log file but silently dropped at the default Info level.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added terminal image previews for Kitty-compatible terminals.
  * Automatically detects terminal graphics support and selects the best preview mode.
  * Added image placement, redraws, cleanup, and aspect-preserving scaling.
  * Added `KIT_IMAGE_PROTOCOL` to override graphics detection.
  * Added debug logging for interactive mode.

* **Bug Fixes**
  * Improved fallback behavior for unsupported terminals, tmux, and Windows.
  * Prevented stale or replaced image previews from accumulating.

* **Documentation**
  * Documented terminal-specific image preview behavior and fallback modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->