### PR TITLE
feat: add --bare for running without project context

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,6 +87,9 @@ var (
 	// Named agents control
 	noAgentsFlag bool
 
+	// Bare mode — no automatic context discovery from any directory.
+	bareFlag bool
+
 	// TLS configuration
 	tlsSkipVerify bool
 
@@ -174,7 +177,11 @@ func GetRootCommand(v string) *cobra.Command {
 // InitConfig, injecting the CLI-specific configFile flag and debug mode.
 // This function is automatically called by cobra before command execution.
 func InitConfig() {
-	if err := kit.InitConfig(configFile, debugMode); err != nil {
+	if err := kit.InitConfigWithOptions(kit.ConfigInitOptions{
+		ConfigFile: configFile,
+		Debug:      debugMode,
+		Bare:       bareFlag,
+	}); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
@@ -292,6 +299,11 @@ func init() {
 		BoolVar(&noSessionFlag, "no-session", false, "ephemeral mode — no session persistence")
 	rootCmd.PersistentFlags().
 		BoolVar(&noExtensionsFlag, "no-extensions", false, "disable all extensions")
+	// --bare is deliberately NOT bound to viper. Every other flag can be set
+	// from a config file, but this one exists to ignore project config, so
+	// letting a project .kit.yml set it would be self-defeating.
+	rootCmd.PersistentFlags().
+		BoolVar(&bareFlag, "bare", false, "no project context: skip AGENTS.md, skills, extensions, agents, prompt templates and project .kit.yml")
 	rootCmd.PersistentFlags().
 		BoolVar(&noCoreToolsFlag, "no-core-tools", false, "disable all built-in core tools (bash, read, write, edit, grep, find, ls, subagent)")
 	rootCmd.PersistentFlags().
@@ -917,6 +929,7 @@ func runNormalMode(ctx context.Context) error {
 		CoreToolList:     coreToolList,
 		NoSkills:         noSkillsFlag,
 		NoAgents:         noAgentsFlag,
+		Bare:             bareFlag,
 		Skills:           skillsPaths,
 		SkillsDir:        skillsDir,
 		SkillsDisable:    skillsDisable,
@@ -1087,6 +1100,7 @@ func runNormalMode(ctx context.Context) error {
 			ExtraPaths:      promptTemplatePaths,
 			ConfigPaths:     viper.GetStringSlice("prompts"),
 			IncludeDefaults: true,
+			Bare:            bareFlag,
 		})
 		if err != nil {
 			log.Printf("Warning: failed to load some prompt templates: %v", err)
@@ -1135,6 +1149,7 @@ func runNormalMode(ctx context.Context) error {
 			ExtraPaths:      promptTemplatePaths,
 			ConfigPaths:     viper.GetStringSlice("prompts"),
 			IncludeDefaults: true,
+			Bare:            bareFlag,
 		})
 		if err != nil {
 			log.Printf("Warning: failed to reload prompt templates: %v", err)
@@ -1343,7 +1358,15 @@ func runNormalMode(ctx context.Context) error {
 
 	// Start file watcher for automatic extension hot-reload.
 	extraPaths := viper.GetStringSlice("extension")
-	watchDirs := extensions.WatchedDirs(extraPaths)
+	// In bare mode only explicitly named extensions are loaded, so only those
+	// are watched. Watching the discovery directories would let a reload pull
+	// in extensions that startup deliberately skipped.
+	var watchDirs []string
+	if bareFlag {
+		watchDirs = watcher.CollectDirs(nil, extraPaths)
+	} else {
+		watchDirs = extensions.WatchedDirs(extraPaths)
+	}
 	if len(watchDirs) > 0 {
 		extWatcher, watchErr := extensions.NewWatcher(watchDirs, func() {
 			if err := reloadExtensionsForUI(); err != nil {
@@ -1361,30 +1384,36 @@ func runNormalMode(ctx context.Context) error {
 		}
 	}
 
-	// Start file watchers for automatic prompt and skill hot-reload.
+	// Start file watchers for automatic prompt and skill hot-reload. Bare
+	// mode watches only explicitly supplied paths: the standard directories
+	// were never loaded, so reacting to changes in them would reintroduce the
+	// context the mode exists to avoid.
 	{
 		homeDir, _ := os.UserHomeDir()
 		cwd, _ := os.Getwd()
 
-		// Collect prompt template directories.
-		promptDirs := watcher.CollectDirs(
-			[]string{
+		var promptStdDirs, skillStdDirs []string
+		if !bareFlag {
+			promptStdDirs = []string{
 				filepath.Join(homeDir, ".kit", "prompts"),
 				prompts.GlobalDir(),
 				filepath.Join(cwd, ".kit", "prompts"),
-			},
+			}
+			skillStdDirs = []string{
+				filepath.Join(homeDir, ".config", "kit", "skills"),
+				filepath.Join(cwd, ".agents", "skills"),
+				filepath.Join(cwd, ".kit", "skills"),
+			}
+		}
+
+		// Collect prompt template directories.
+		promptDirs := watcher.CollectDirs(
+			promptStdDirs,
 			append(promptTemplatePaths, viper.GetStringSlice("prompts")...),
 		)
 
 		// Collect skill directories.
-		skillDirs := watcher.CollectDirs(
-			[]string{
-				filepath.Join(homeDir, ".config", "kit", "skills"),
-				filepath.Join(cwd, ".agents", "skills"),
-				filepath.Join(cwd, ".kit", "skills"),
-			},
-			nil,
-		)
+		skillDirs := watcher.CollectDirs(skillStdDirs, skillsPaths)
 
 		// Combine all content directories and start a single watcher.
 		allContentDirs := append(promptDirs, skillDirs...)
@@ -1424,6 +1453,7 @@ func runNormalMode(ctx context.Context) error {
 		extCommands:              extCommands,
 		promptTemplates:          promptTemplates,
 		contextPaths:             contextPaths,
+		bare:                     bareFlag,
 		skillItems:               skillItems,
 		extensionItems:           extensionItems,
 		getPromptTemplates:       getPromptTemplates,
@@ -1587,6 +1617,7 @@ type runModeDeps struct {
 	extCommands              []commands.ExtensionCommand
 	promptTemplates          []*prompts.PromptTemplate
 	contextPaths             []string
+	bare                     bool
 	skillItems               []ui.SkillItem
 	extensionItems           []ui.ExtensionItem
 	getPromptTemplates       func() []*prompts.PromptTemplate
@@ -1767,6 +1798,7 @@ func runInteractiveModeBubbleTea(_ context.Context, deps runModeDeps) error {
 		GetMCPPrompts:            deps.getMCPPrompts,
 		ExpandMCPPrompt:          deps.expandMCPPrompt,
 		ContextPaths:             deps.contextPaths,
+		Bare:                     deps.bare,
 		SkillItems:               deps.skillItems,
 		GetSkillItems:            deps.getSkillItems,
 		ExtensionItems:           deps.extensionItems,

--- a/internal/extensions/bare_test.go
+++ b/internal/extensions/bare_test.go
@@ -1,0 +1,69 @@
+package extensions
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeBareExt creates a minimal extension file and returns its path.
+func writeBareExt(t *testing.T, dir, name string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// TestDiscoverExtensionPaths_BareSkipsDirectories asserts that bare mode
+// ignores every discovery directory — system, user and project-local — so no
+// extension runs merely because Kit started in a particular directory.
+func TestDiscoverExtensionPaths_BareSkipsDirectories(t *testing.T) {
+	sysDir := t.TempDir()
+	writeBareExt(t, sysDir, "sys.go")
+	t.Setenv(SystemExtensionsDirEnv, sysDir)
+
+	configHome := t.TempDir()
+	writeBareExt(t, filepath.Join(configHome, "kit", "extensions"), "user.go")
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	// Project-local discovery uses a relative path, so run from a temp cwd.
+	project := t.TempDir()
+	writeBareExt(t, filepath.Join(project, ".kit", "extensions"), "project.go")
+	t.Chdir(project)
+
+	// Sanity check: without bare, all three are discovered.
+	if got := discoverExtensionPaths(nil, false); len(got) != 3 {
+		t.Fatalf("non-bare discovery: want 3 extensions, got %d (%v)", len(got), got)
+	}
+
+	if got := discoverExtensionPaths(nil, true); len(got) != 0 {
+		t.Errorf("bare discovery: want no extensions, got %v", got)
+	}
+}
+
+// TestDiscoverExtensionPaths_BareKeepsExplicitPaths asserts that --extension
+// still loads under bare mode. Bare suppresses implicit context, not the
+// choices the user made on the command line.
+func TestDiscoverExtensionPaths_BareKeepsExplicitPaths(t *testing.T) {
+	t.Setenv(SystemExtensionsDirEnv, t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	project := t.TempDir()
+	writeBareExt(t, filepath.Join(project, ".kit", "extensions"), "project.go")
+	t.Chdir(project)
+
+	explicit := writeBareExt(t, t.TempDir(), "explicit.go")
+
+	got := discoverExtensionPaths([]string{explicit}, true)
+	want, _ := filepath.Abs(explicit)
+	if len(got) != 1 || got[0] != want {
+		t.Errorf("bare discovery with explicit path: want [%s], got %v", want, got)
+	}
+}

--- a/internal/extensions/loader.go
+++ b/internal/extensions/loader.go
@@ -28,7 +28,15 @@ import (
 // any extra paths. Each extension is loaded into its own Yaegi interpreter
 // for isolation. Extensions that fail to load are logged and skipped.
 func LoadExtensions(extraPaths []string) ([]LoadedExtension, error) {
-	paths := discoverExtensionPaths(extraPaths)
+	return LoadExtensionsScoped(extraPaths, false)
+}
+
+// LoadExtensionsScoped is [LoadExtensions] with control over discovery. When
+// bare is true no directory is scanned — system, user and project locations
+// are all skipped — and only extraPaths load. Use it so that running Kit
+// inside a directory does not silently execute that directory's extensions.
+func LoadExtensionsScoped(extraPaths []string, bare bool) ([]LoadedExtension, error) {
+	paths := discoverExtensionPaths(extraPaths, bare)
 	if len(paths) == 0 {
 		return nil, nil
 	}
@@ -70,10 +78,22 @@ func (ps *pathSet) add(p string) bool {
 
 // discoverExtensionPaths returns deduplicated paths to extension files in
 // load-order (system-wide first, then user, then project-local, then
-// explicit).
-func discoverExtensionPaths(extraPaths []string) []string {
+// explicit). When bare is true every directory scan is skipped and only
+// extraPaths are returned.
+func discoverExtensionPaths(extraPaths []string, bare bool) []string {
 	ps := newPathSet()
 
+	if !bare {
+		discoverExtensionDirs(ps)
+	}
+
+	// Explicit paths (highest precedence)
+	return appendExplicitExtensionPaths(ps, extraPaths)
+}
+
+// discoverExtensionDirs adds every auto-discovered extension path to ps, in
+// ascending order of precedence.
+func discoverExtensionDirs(ps *pathSet) {
 	// System-wide extensions: /usr/share/kit/extensions/ (packaged installs)
 	for _, dir := range systemExtensionsDirs() {
 		for _, p := range findExtensionsInDir(dir) {
@@ -104,8 +124,12 @@ func discoverExtensionPaths(extraPaths []string) []string {
 	for _, p := range findExtensionsInGitPackages(projectGitDir) {
 		ps.add(p)
 	}
+}
 
-	// Explicit paths (highest precedence)
+// appendExplicitExtensionPaths adds user-supplied extension paths (from
+// --extension / -e) to ps and returns the final ordered list. These always
+// load, including in bare mode, because the user named them.
+func appendExplicitExtensionPaths(ps *pathSet, extraPaths []string) []string {
 	for _, p := range extraPaths {
 		info, err := os.Stat(p)
 		if err != nil {

--- a/internal/extensions/loader_test.go
+++ b/internal/extensions/loader_test.go
@@ -16,7 +16,7 @@ func TestDiscoverExtensionPaths_ExplicitFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	paths := discoverExtensionPaths([]string{f})
+	paths := discoverExtensionPaths([]string{f}, false)
 	if len(paths) == 0 {
 		t.Fatal("expected at least 1 path")
 	}
@@ -34,7 +34,7 @@ func TestDiscoverExtensionPaths_ExplicitDir(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	paths := discoverExtensionPaths([]string{dir})
+	paths := discoverExtensionPaths([]string{dir}, false)
 	abs, _ := filepath.Abs(f)
 	if !slices.Contains(paths, abs) {
 		t.Errorf("expected %q in discovered paths %v", abs, paths)
@@ -52,7 +52,7 @@ func TestDiscoverExtensionPaths_SubdirMainGo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	paths := discoverExtensionPaths([]string{dir})
+	paths := discoverExtensionPaths([]string{dir}, false)
 	abs, _ := filepath.Abs(main)
 	if !slices.Contains(paths, abs) {
 		t.Errorf("expected %q in discovered paths %v", abs, paths)
@@ -67,7 +67,7 @@ func TestDiscoverExtensionPaths_Dedup(t *testing.T) {
 	}
 
 	// Pass the same file twice.
-	paths := discoverExtensionPaths([]string{f, f})
+	paths := discoverExtensionPaths([]string{f, f}, false)
 	count := 0
 	abs, _ := filepath.Abs(f)
 	for _, p := range paths {
@@ -87,7 +87,7 @@ func TestDiscoverExtensionPaths_NonGoFileIgnored(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	paths := discoverExtensionPaths([]string{f})
+	paths := discoverExtensionPaths([]string{f}, false)
 	for _, p := range paths {
 		abs, _ := filepath.Abs(f)
 		if p == abs {
@@ -97,7 +97,7 @@ func TestDiscoverExtensionPaths_NonGoFileIgnored(t *testing.T) {
 }
 
 func TestDiscoverExtensionPaths_NonexistentIgnored(t *testing.T) {
-	paths := discoverExtensionPaths([]string{"/nonexistent/path/ext.go"})
+	paths := discoverExtensionPaths([]string{"/nonexistent/path/ext.go"}, false)
 	for _, p := range paths {
 		if p == "/nonexistent/path/ext.go" {
 			t.Error("nonexistent path should not be discovered")
@@ -485,7 +485,7 @@ func TestDiscoverExtensionPaths_SystemDir(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 
-	paths := discoverExtensionPaths(nil)
+	paths := discoverExtensionPaths(nil, false)
 	want, _ := filepath.Abs(sysExt)
 	if len(paths) == 0 || paths[0] != want {
 		t.Errorf("expected system extension %q first, got %v", want, paths)
@@ -557,7 +557,7 @@ func TestDiscoverExtensionPaths_SystemBeforeUser(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", configHome)
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 
-	paths := discoverExtensionPaths(nil)
+	paths := discoverExtensionPaths(nil, false)
 	sysAbs, _ := filepath.Abs(sysExt)
 	userAbs, _ := filepath.Abs(userExt)
 

--- a/internal/kitsetup/setup.go
+++ b/internal/kitsetup/setup.go
@@ -71,6 +71,9 @@ type AgentSetupOptions struct {
 	// NoExtensions skips extension loading. When false, viper is consulted.
 	// Only meaningful when ProviderConfig is also set.
 	NoExtensions bool
+	// Bare restricts extension loading to paths named explicitly via
+	// --extension / -e. No system, user or project directory is scanned.
+	Bare bool
 	// MaxSteps overrides the agent step limit. 0 means use viper value.
 	// Only meaningful when ProviderConfig is also set.
 	MaxSteps int
@@ -227,7 +230,7 @@ func SetupAgent(ctx context.Context, opts AgentSetupOptions) (*AgentSetupResult,
 	var extCreationOpts extensionCreationOpts
 	if !noExtensions {
 		var extErr error
-		extRunner, extCreationOpts, extErr = loadExtensions(v)
+		extRunner, extCreationOpts, extErr = loadExtensions(v, opts.Bare)
 		if extErr != nil {
 			fmt.Printf("Warning: Failed to load extensions: %v\n", extErr)
 		}
@@ -297,12 +300,12 @@ type extensionCreationOpts struct {
 // and returns the tool wrapper/extra tools. The supplied store is used to
 // resolve the "extension" config key and is attached to the runner so
 // extension option lookups stay isolated to this Kit instance.
-func loadExtensions(v *viper.Viper) (*extensions.Runner, extensionCreationOpts, error) {
+func loadExtensions(v *viper.Viper, bare bool) (*extensions.Runner, extensionCreationOpts, error) {
 	if v == nil {
 		v = viper.GetViper()
 	}
 	extraPaths := v.GetStringSlice("extension")
-	loaded, err := extensions.LoadExtensions(extraPaths)
+	loaded, err := extensions.LoadExtensionsScoped(extraPaths, bare)
 	if err != nil {
 		return nil, extensionCreationOpts{}, err
 	}

--- a/internal/prompts/loader.go
+++ b/internal/prompts/loader.go
@@ -21,6 +21,11 @@ type LoadOptions struct {
 	ConfigPaths []string
 	// IncludeDefaults determines whether to include built-in default templates.
 	IncludeDefaults bool
+	// Bare skips directory discovery entirely — the global, XDG and
+	// project-local prompt directories are not scanned. Built-in defaults
+	// (when IncludeDefaults is set), ConfigPaths and ExtraPaths still load,
+	// so templates named explicitly remain available.
+	Bare bool
 }
 
 // Diagnostic reports a template collision or loading issue.
@@ -91,23 +96,28 @@ func LoadAll(opts LoadOptions) ([]*PromptTemplate, []Diagnostic, error) {
 	}
 
 	// 2. Legacy global user templates: ~/.kit/prompts/
-	legacyGlobalDir := filepath.Join(opts.HomeDir, ".kit", "prompts")
-	if templates, err := LoadFromDir(legacyGlobalDir); err == nil {
-		addTemplates(templates, "global")
-	}
-
 	// 3. XDG global user templates: $XDG_CONFIG_HOME/kit/prompts/
-	//    Default: ~/.config/kit/prompts/. Aligns with extensions and skills.
-	if xdgDir := GlobalDir(); xdgDir != "" && xdgDir != legacyGlobalDir {
-		if templates, err := LoadFromDir(xdgDir); err == nil {
+	// 4. Project-local templates: .kit/prompts/
+	//
+	// Bare mode skips all three: nothing is picked up from a directory just
+	// because Kit was started there.
+	if !opts.Bare {
+		legacyGlobalDir := filepath.Join(opts.HomeDir, ".kit", "prompts")
+		if templates, err := LoadFromDir(legacyGlobalDir); err == nil {
 			addTemplates(templates, "global")
 		}
-	}
 
-	// 4. Project-local templates: .kit/prompts/
-	localDir := filepath.Join(opts.Cwd, ".kit", "prompts")
-	if templates, err := LoadFromDir(localDir); err == nil {
-		addTemplates(templates, "local")
+		//    Default: ~/.config/kit/prompts/. Aligns with extensions and skills.
+		if xdgDir := GlobalDir(); xdgDir != "" && xdgDir != legacyGlobalDir {
+			if templates, err := LoadFromDir(xdgDir); err == nil {
+				addTemplates(templates, "global")
+			}
+		}
+
+		localDir := filepath.Join(opts.Cwd, ".kit", "prompts")
+		if templates, err := LoadFromDir(localDir); err == nil {
+			addTemplates(templates, "local")
+		}
 	}
 
 	// 4. Config paths

--- a/internal/session/bare_dir_test.go
+++ b/internal/session/bare_dir_test.go
@@ -1,0 +1,58 @@
+package session
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestDefaultSessionDir_BareBucketCannotCollide is a regression test for the
+// bare session bucket sharing a directory with a real working directory
+// (CodeRabbit review on #109).
+//
+// encodeCwdForDir is lossy: it strips a leading separator, so "/__bare__" and
+// "__bare__" both encode to "__bare__". Routing bare sessions through the
+// encoder therefore let a project at /__bare__ land in the bare bucket, where
+// `--continue` could resume the wrong conversation.
+func TestDefaultSessionDir_BareBucketCannotCollide(t *testing.T) {
+	bare := DefaultSessionDir(BareSessionKey)
+
+	// The premise the bug rested on: these two cwds are indistinguishable
+	// after encoding. If this ever stops being true the encoder changed and
+	// this test should be revisited rather than deleted.
+	if encodeCwdForDir("/"+BareSessionKey) != encodeCwdForDir(BareSessionKey) {
+		t.Fatalf("premise changed: %q and %q no longer encode alike",
+			"/"+BareSessionKey, BareSessionKey)
+	}
+
+	// Despite that, the directories must differ.
+	collider := DefaultSessionDir("/" + BareSessionKey)
+	if bare == collider {
+		t.Errorf("a project at /%s shares the bare bucket %q", BareSessionKey, bare)
+	}
+
+	// Bare must live outside the cwd-keyed namespace entirely, which is what
+	// makes the separation structural rather than a special case per input.
+	if filepath.Base(filepath.Dir(bare)) == "sessions" {
+		t.Errorf("bare bucket %q is inside the cwd-keyed sessions/ namespace", bare)
+	}
+	if filepath.Base(filepath.Dir(collider)) != "sessions" {
+		t.Errorf("ordinary cwd %q should live under sessions/", collider)
+	}
+}
+
+// TestDefaultSessionDir_OrdinaryCwdsUnchanged guards the existing on-disk
+// convention: real working directories must keep resolving to
+// ~/.kit/sessions/<encoded-cwd>, so the bare special case does not orphan
+// anyone's existing sessions.
+func TestDefaultSessionDir_OrdinaryCwdsUnchanged(t *testing.T) {
+	for _, cwd := range []string{"/home/u/proj", "/tmp", `C:\work\repo`} {
+		got := DefaultSessionDir(cwd)
+		want := filepath.Base(got)
+		if want != encodeCwdForDir(cwd) {
+			t.Errorf("DefaultSessionDir(%q) basename = %q, want %q", cwd, want, encodeCwdForDir(cwd))
+		}
+		if filepath.Base(filepath.Dir(got)) != "sessions" {
+			t.Errorf("DefaultSessionDir(%q) = %q, want it under sessions/", cwd, got)
+		}
+	}
+}

--- a/internal/session/bare_dir_test.go
+++ b/internal/session/bare_dir_test.go
@@ -56,3 +56,45 @@ func TestDefaultSessionDir_OrdinaryCwdsUnchanged(t *testing.T) {
 		}
 	}
 }
+
+// TestFindSessionPathByID_FindsBareSessions is a regression test for bare
+// sessions becoming unreachable by ID (CodeRabbit review on #109).
+//
+// Moving the bare bucket out of ~/.kit/sessions fixed the cwd collision but
+// put it beyond the reach of FindSessionPathByID, which scans only the cwd
+// directory and the sessions/ subtree. A subagent started in bare mode could
+// then not be resumed by SessionID.
+func TestFindSessionPathByID_FindsBareSessions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // Windows
+
+	tm, err := CreateTreeSession(BareSessionKey)
+	if err != nil {
+		t.Fatalf("CreateTreeSession: %v", err)
+	}
+	id := tm.GetSessionID()
+	_ = tm.Close()
+
+	// Look up from an unrelated working directory, as Kit.Subagent does:
+	// it passes the parent's real cwd, not the bare sentinel.
+	got, err := FindSessionPathByID(filepath.Join(home, "some", "project"), id)
+	if err != nil {
+		t.Fatalf("bare session %q not found by ID: %v", id, err)
+	}
+	if filepath.Base(filepath.Dir(got)) != bareSessionDirName {
+		t.Errorf("resolved %q, want a file in %s/", got, bareSessionDirName)
+	}
+}
+
+// TestFindSessionPathByID_MissingIDStillErrors guards the negative path: the
+// added bare-bucket fallback must not turn "not found" into a false match.
+func TestFindSessionPathByID_MissingIDStillErrors(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	if _, err := FindSessionPathByID(home, "nonexistent-id"); err == nil {
+		t.Error("expected an error for an unknown session ID")
+	}
+}

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -300,9 +300,10 @@ func DeleteSession(path string) error {
 // FindSessionPathByID locates the JSONL session file whose header ID matches
 // the given session UUID. The session directory for cwd is searched first
 // (the common case for subagent sessions, which live alongside the parent's
-// sessions), then all session directories under ~/.kit/sessions. Only file
-// headers (first line) are read, so the scan is cheap even with many
-// sessions. Returns an error when no session with that ID exists.
+// sessions), then all session directories under ~/.kit/sessions, and finally
+// the bare bucket. Only file headers (first line) are read, so the scan is
+// cheap even with many sessions. Returns an error when no session with that
+// ID exists.
 func FindSessionPathByID(cwd, id string) (string, error) {
 	if id == "" {
 		return "", fmt.Errorf("session ID is required")
@@ -319,18 +320,25 @@ func FindSessionPathByID(cwd, id string) (string, error) {
 		return "", fmt.Errorf("session %q not found", id)
 	}
 	sessionsRoot := filepath.Join(home, ".kit", "sessions")
-	dirs, err := os.ReadDir(sessionsRoot)
-	if err != nil {
-		return "", fmt.Errorf("session %q not found", id)
-	}
-	for _, dir := range dirs {
-		if !dir.IsDir() {
-			continue
-		}
-		if path, ok := findSessionInDir(filepath.Join(sessionsRoot, dir.Name()), id); ok {
-			return path, nil
+	if dirs, err := os.ReadDir(sessionsRoot); err == nil {
+		for _, dir := range dirs {
+			if !dir.IsDir() {
+				continue
+			}
+			if path, ok := findSessionInDir(filepath.Join(sessionsRoot, dir.Name()), id); ok {
+				return path, nil
+			}
 		}
 	}
+
+	// Bare sessions deliberately live outside the cwd-keyed sessions/ subtree
+	// (see DefaultSessionDir), so neither the fast path nor the scan above can
+	// reach them. Without this a subagent session started in bare mode could
+	// not be resumed by ID. Checked last so ordinary lookups are unaffected.
+	if path, ok := findSessionInDir(DefaultSessionDir(BareSessionKey), id); ok {
+		return path, nil
+	}
+
 	return "", fmt.Errorf("session %q not found", id)
 }
 

--- a/internal/session/tree_manager.go
+++ b/internal/session/tree_manager.go
@@ -1436,6 +1436,13 @@ func (tm *TreeManager) buildTreeNodeDepth(id string, depth int, visited map[stri
 
 // --- Path conventions ---
 
+// BareSessionKey is the session bucket used in bare mode. Bare sessions are
+// not tied to a working directory — that is the point of the mode — so they
+// all share one bucket and `--continue` resumes the last bare conversation
+// from anywhere. The value contains no path separator and no character that
+// is illegal on Windows, so encodeCwdForDir passes it through unchanged.
+const BareSessionKey = "__bare__"
+
 // DefaultSessionDir returns the default session storage directory for a cwd.
 // Convention: ~/.kit/sessions/<encoded-cwd>, where path separators are
 // encoded as "--" with no leading or trailing dashes — e.g.

--- a/internal/session/tree_manager.go
+++ b/internal/session/tree_manager.go
@@ -1436,22 +1436,41 @@ func (tm *TreeManager) buildTreeNodeDepth(id string, depth int, visited map[stri
 
 // --- Path conventions ---
 
-// BareSessionKey is the session bucket used in bare mode. Bare sessions are
-// not tied to a working directory — that is the point of the mode — so they
-// all share one bucket and `--continue` resumes the last bare conversation
-// from anywhere. The value contains no path separator and no character that
-// is illegal on Windows, so encodeCwdForDir passes it through unchanged.
+// BareSessionKey is the sentinel passed in place of a working directory when
+// Kit runs in bare mode. Bare sessions are not tied to a working directory —
+// that is the point of the mode — so they all share one bucket and
+// `--continue` resumes the last bare conversation from anywhere.
+//
+// [DefaultSessionDir] maps this sentinel to a directory that sits beside the
+// cwd-keyed namespace rather than inside it, so no working directory can ever
+// resolve to the bare bucket. See the comment there.
 const BareSessionKey = "__bare__"
+
+// bareSessionDirName is the on-disk home for bare sessions. It deliberately
+// lives next to "sessions", not under it: every cwd-derived key is joined
+// beneath "sessions", so keeping bare outside that subtree makes a collision
+// structurally impossible rather than merely unlikely.
+const bareSessionDirName = "bare-sessions"
 
 // DefaultSessionDir returns the default session storage directory for a cwd.
 // Convention: ~/.kit/sessions/<encoded-cwd>, where path separators are
 // encoded as "--" with no leading or trailing dashes — e.g.
 // /home/user/proj becomes home--user--proj. See encodeCwdForDir for the
 // full encoding rules (including Windows path handling).
+//
+// The bare sentinel is special-cased to ~/.kit/bare-sessions. The encoding is
+// lossy — "/__bare__" and "__bare__" both encode to "__bare__" — so routing
+// bare sessions through it would let a project directory named /__bare__ share
+// the bare bucket and have `--continue` resume the wrong conversation.
+// Matching on the raw sentinel before encoding keeps the two namespaces apart:
+// a real /__bare__ directory still gets ~/.kit/sessions/__bare__.
 func DefaultSessionDir(cwd string) string {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		home = "."
+	}
+	if cwd == BareSessionKey {
+		return filepath.Join(home, ".kit", bareSessionDirName)
 	}
 	return filepath.Join(home, ".kit", "sessions", encodeCwdForDir(cwd))
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -452,6 +452,11 @@ type AppModelOptions struct {
 	// AGENTS.md). Displayed in the [Context] startup section.
 	ContextPaths []string
 
+	// Bare reports that Kit started with no automatic context discovery.
+	// The splash says so, so an absent AGENTS.md or skill list reads as a
+	// deliberate choice rather than a failure to load.
+	Bare bool
+
 	// SkillItems lists loaded skills for the [Skills] startup section.
 	SkillItems []SkillItem
 
@@ -760,7 +765,9 @@ type AppModel struct {
 	// contextPaths and skillItems are used by AddStartupMessageToScrollList for the
 	// [Context] and [Skills] sections.
 	contextPaths []string
-	skillItems   []SkillItem
+	// bare reports that no automatic context discovery ran.
+	bare       bool
+	skillItems []SkillItem
 
 	// splashItem is the scrollback item holding the startup splash, retained
 	// while the logo animation is running so each frame can be painted into
@@ -1159,6 +1166,7 @@ func NewAppModel(appCtrl AppController, opts AppModelOptions) *AppModel {
 
 	// Store context/skills metadata and tool counts for startup display.
 	m.contextPaths = opts.ContextPaths
+	m.bare = opts.Bare
 	m.skillItems = opts.SkillItems
 	m.getSkillItems = opts.GetSkillItems
 	m.extensionItems = opts.ExtensionItems
@@ -1329,8 +1337,11 @@ func (m *AppModel) AddStartupMessageToScrollList() {
 		pairs = append(pairs, [2]string{"status", m.loadingMessage})
 	}
 
-	// Context — loaded AGENTS.md files.
-	if len(m.contextPaths) > 0 {
+	// Context — loaded AGENTS.md files. Bare mode reports itself instead, so
+	// the absence of context below is legible as intent.
+	if m.bare {
+		pairs = append(pairs, [2]string{"context", "bare — no project context"})
+	} else if len(m.contextPaths) > 0 {
 		contextStr := tildeHome(m.contextPaths[0])
 		if len(m.contextPaths) > 1 {
 			contextStr += fmt.Sprintf(" +%d more", len(m.contextPaths)-1)

--- a/pkg/kit/bare_config_test.go
+++ b/pkg/kit/bare_config_test.go
@@ -1,0 +1,80 @@
+package kit
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// TestBareConfig_SkipsProjectConfig is the security-relevant half of bare
+// mode. A project .kit.yml can define mcpServers, which spawn processes, and
+// can override system-prompt. Bare mode must not read it.
+func TestBareConfig_SkipsProjectConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	project := t.TempDir()
+	cfg := "model: project/should-not-load\n"
+	if err := os.WriteFile(filepath.Join(project, ".kit.yml"), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(project)
+
+	// Control: without bare, the project config is picked up.
+	v := viper.New()
+	if err := initConfig(v, "", false, false); err != nil {
+		t.Fatalf("initConfig: %v", err)
+	}
+	if got := v.GetString("model"); got != "project/should-not-load" {
+		t.Fatalf("non-bare: want project config to load, got model %q", got)
+	}
+
+	// Bare must not see it.
+	vBare := viper.New()
+	if err := initConfig(vBare, "", false, true); err != nil {
+		t.Fatalf("initConfig bare: %v", err)
+	}
+	if got := vBare.GetString("model"); got != "" {
+		t.Errorf("bare: project config leaked, model = %q", got)
+	}
+}
+
+// TestBareConfig_KeepsExplicitConfigFile confirms --config still wins under
+// bare mode. Bare drops discovery, not an explicitly named file.
+func TestBareConfig_KeepsExplicitConfigFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "custom.yml")
+	if err := os.WriteFile(path, []byte("model: explicit/model\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	v := viper.New()
+	if err := initConfig(v, path, false, true); err != nil {
+		t.Fatalf("initConfig: %v", err)
+	}
+	if got := v.GetString("model"); got != "explicit/model" {
+		t.Errorf("bare with --config: want explicit/model, got %q", got)
+	}
+}
+
+// TestBareConfig_KeepsHomeConfig confirms the user's own config still loads.
+// Without it bare mode would lose API keys and the default model, making the
+// flag unusable rather than merely quiet.
+func TestBareConfig_KeepsHomeConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.WriteFile(filepath.Join(home, ".kit.yml"), []byte("model: home/model\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(t.TempDir())
+
+	v := viper.New()
+	if err := initConfig(v, "", false, true); err != nil {
+		t.Fatalf("initConfig: %v", err)
+	}
+	if got := v.GetString("model"); got != "home/model" {
+		t.Errorf("bare: want home config to load, got model %q", got)
+	}
+}

--- a/pkg/kit/bare_test.go
+++ b/pkg/kit/bare_test.go
@@ -155,3 +155,29 @@ func TestBare_ExplicitSkillsStillLoad(t *testing.T) {
 		t.Error("explicitly named skill should reach the system prompt in bare mode")
 	}
 }
+
+// TestBare_SubagentInheritsIsolation is a regression test for a bare parent
+// spawning a non-bare child (CodeRabbit review on #109). The child would
+// re-run project discovery and load the AGENTS.md, skills and extensions the
+// parent deliberately refused — including executing extension code.
+//
+// It exercises the real helper Kit.Subagent uses, so any future isolation
+// field added to inheritIsolationOptions is covered automatically.
+func TestBare_SubagentInheritsIsolation(t *testing.T) {
+	child := &Options{}
+	inheritIsolationOptions(child, &Options{Bare: true})
+	if !child.Bare {
+		t.Error("bare parent must spawn a bare child")
+	}
+
+	// A non-bare parent must not silently make children bare.
+	child = &Options{}
+	inheritIsolationOptions(child, &Options{Bare: false})
+	if child.Bare {
+		t.Error("non-bare parent must not produce a bare child")
+	}
+
+	// Nil operands are a no-op rather than a panic.
+	inheritIsolationOptions(nil, &Options{Bare: true})
+	inheritIsolationOptions(&Options{}, nil)
+}

--- a/pkg/kit/bare_test.go
+++ b/pkg/kit/bare_test.go
@@ -1,0 +1,157 @@
+package kit
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newBareTestKit builds a Kit in a temp directory that is deliberately
+// "polluted" with an AGENTS.md and a project skill, so tests can assert what
+// bare mode does and does not pick up.
+func newBareTestKit(t *testing.T, bare bool) *Kit {
+	t.Helper()
+	t.Setenv("OPENAI_API_KEY", "sk-test")
+
+	project := t.TempDir()
+	agents := filepath.Join(project, "AGENTS.md")
+	if err := os.WriteFile(agents, []byte("Always speak in Latin."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	skillDir := filepath.Join(project, ".agents", "skills", "demo")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	skill := "---\nname: demo-skill\ndescription: A project skill that must not leak.\n---\n\nBody.\n"
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(skill), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Keep user-level discovery out of the way so the test observes the
+	// project directory only.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Chdir(project)
+
+	k, err := New(context.Background(), &Options{
+		Model:            "openai/gpt-4o-mini",
+		Quiet:            true,
+		NoSession:        true,
+		NoExtensions:     true,
+		DisableCoreTools: true,
+		SkipConfig:       true,
+		Bare:             bare,
+	})
+	if err != nil {
+		t.Fatalf("kit.New: %v", err)
+	}
+	t.Cleanup(func() { _ = k.Close() })
+	return k
+}
+
+// TestBare_ExcludesProjectContextFromSystemPrompt is the load-bearing
+// assertion for bare mode: nothing from the working directory reaches the
+// model. It checks the composed system prompt rather than the loader
+// internals, because that string is what actually ships to the provider.
+func TestBare_ExcludesProjectContextFromSystemPrompt(t *testing.T) {
+	k := newBareTestKit(t, true)
+
+	prompt := k.v.GetString("system-prompt")
+
+	for _, needle := range []string{
+		"Instructions from:", // AGENTS.md section header
+		"Always speak in Latin.",
+		"demo-skill",
+		"A project skill that must not leak.",
+	} {
+		if strings.Contains(prompt, needle) {
+			t.Errorf("bare system prompt leaked project context: contains %q", needle)
+		}
+	}
+
+	if !strings.Contains(prompt, "bare mode") {
+		t.Error("bare system prompt should state that no project context was loaded")
+	}
+
+	if got := k.GetContextFiles(); len(got) != 0 {
+		t.Errorf("bare mode: want no context files, got %d", len(got))
+	}
+	if got := k.GetSkills(); len(got) != 0 {
+		t.Errorf("bare mode: want no skills, got %d", len(got))
+	}
+}
+
+// TestBare_Disabled_LoadsProjectContext is the control: the same directory
+// without --bare must still load AGENTS.md and the project skill. Without it
+// the test above could pass for the wrong reason.
+func TestBare_Disabled_LoadsProjectContext(t *testing.T) {
+	k := newBareTestKit(t, false)
+
+	prompt := k.v.GetString("system-prompt")
+
+	if !strings.Contains(prompt, "Always speak in Latin.") {
+		t.Error("non-bare system prompt should contain AGENTS.md content")
+	}
+	if !strings.Contains(prompt, "demo-skill") {
+		t.Error("non-bare system prompt should contain the project skill")
+	}
+	if strings.Contains(prompt, "bare mode") {
+		t.Error("non-bare system prompt should not mention bare mode")
+	}
+
+	if got := k.GetContextFiles(); len(got) != 1 {
+		t.Errorf("non-bare mode: want 1 context file, got %d", len(got))
+	}
+}
+
+// TestBare_KeepsWorkingDirectoryLine confirms bare mode still tells the model
+// where it is. The file tools resolve relative paths against the working
+// directory, so removing the line would break them; bare suppresses project
+// context, not basic orientation.
+func TestBare_KeepsWorkingDirectoryLine(t *testing.T) {
+	k := newBareTestKit(t, true)
+
+	if prompt := k.v.GetString("system-prompt"); !strings.Contains(prompt, "Current working directory:") {
+		t.Error("bare system prompt should still report the working directory")
+	}
+}
+
+// TestBare_ExplicitSkillsStillLoad verifies that --skill overrides bare mode.
+// Bare suppresses discovery, never an explicit instruction from the user.
+func TestBare_ExplicitSkillsStillLoad(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-test")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	dir := t.TempDir()
+	skill := "---\nname: explicit-skill\ndescription: Named on the command line.\n---\n\nBody.\n"
+	path := filepath.Join(dir, "explicit.md")
+	if err := os.WriteFile(path, []byte(skill), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	k, err := New(context.Background(), &Options{
+		Model:            "openai/gpt-4o-mini",
+		Quiet:            true,
+		NoSession:        true,
+		NoExtensions:     true,
+		DisableCoreTools: true,
+		SkipConfig:       true,
+		Bare:             true,
+		Skills:           []string{path},
+	})
+	if err != nil {
+		t.Fatalf("kit.New: %v", err)
+	}
+	defer func() { _ = k.Close() }()
+
+	if got := k.GetSkills(); len(got) != 1 {
+		t.Fatalf("bare mode with explicit skill: want 1 skill, got %d", len(got))
+	}
+	if prompt := k.v.GetString("system-prompt"); !strings.Contains(prompt, "explicit-skill") {
+		t.Error("explicitly named skill should reach the system prompt in bare mode")
+	}
+}

--- a/pkg/kit/config.go
+++ b/pkg/kit/config.go
@@ -83,12 +83,38 @@ func setSDKDefaults(v *viper.Viper) {
 // This wraps [initConfig] using the process-global store and is retained for
 // the CLI, which binds its flags to the global viper.
 func InitConfig(configFile string, debug bool) error {
-	return initConfig(viper.GetViper(), configFile, debug)
+	return initConfig(viper.GetViper(), configFile, debug, false)
+}
+
+// ConfigInitOptions controls configuration discovery for
+// [InitConfigWithOptions].
+type ConfigInitOptions struct {
+	// ConfigFile is an explicit config file path. Empty means search the
+	// default locations (working directory, then home directory).
+	ConfigFile string
+
+	// Debug prints warnings about missing configs to stderr.
+	Debug bool
+
+	// Bare skips config discovery in the current working directory, so a
+	// project-local .kit.yml cannot contribute settings — most importantly
+	// mcpServers, which spawn processes, and system-prompt. The home
+	// directory config is still loaded, as are KIT_* environment overrides.
+	// An explicit ConfigFile is always honoured.
+	Bare bool
+}
+
+// InitConfigWithOptions initializes the process-global viper configuration
+// system with explicit control over discovery. Use it instead of [InitConfig]
+// when project-local configuration must be ignored.
+func InitConfigWithOptions(opts ConfigInitOptions) error {
+	return initConfig(viper.GetViper(), opts.ConfigFile, opts.Debug, opts.Bare)
 }
 
 // initConfig loads configuration into the supplied per-instance store. When v
-// is nil the process-global store is used.
-func initConfig(v *viper.Viper, configFile string, debug bool) error {
+// is nil the process-global store is used. When bare is true the working
+// directory is excluded from the config search path.
+func initConfig(v *viper.Viper, configFile string, debug, bare bool) error {
 	if v == nil {
 		v = viper.GetViper()
 	}
@@ -119,8 +145,12 @@ func initConfig(v *viper.Viper, configFile string, debug bool) error {
 		return fmt.Errorf("error finding home directory: %w", err)
 	}
 
-	// Current directory has higher priority than home directory.
-	v.AddConfigPath(".")
+	// Current directory has higher priority than home directory. Bare mode
+	// drops the working directory entirely so an unfamiliar project cannot
+	// inject settings simply because Kit was started inside it.
+	if !bare {
+		v.AddConfigPath(".")
+	}
 	v.AddConfigPath(home)
 
 	configLoaded := false

--- a/pkg/kit/kit.go
+++ b/pkg/kit/kit.go
@@ -1259,10 +1259,11 @@ type Options struct {
 	//   - named agent definitions
 	//   - project-local .kit.yml (see [ConfigInitOptions])
 	//
-	// Explicitly supplied values are unaffected: Skills, Extensions and
-	// SystemPrompt all still apply, as do the equivalent CLI flags. Core
-	// tools remain enabled and the working directory is unchanged; combine
-	// with NoCoreTools to remove filesystem access as well.
+	// Explicitly supplied values are unaffected: [Options.Skills],
+	// [Options.SystemPrompt] and extensions named via the "extension" config
+	// key (or the -e CLI flag) all still apply. Core tools remain enabled and
+	// the working directory is unchanged; combine with
+	// [Options.DisableCoreTools] to remove filesystem access as well.
 	//
 	// Subagents spawned by a bare Kit inherit Bare, so delegated work cannot
 	// reintroduce the project context the parent excluded.

--- a/pkg/kit/kit.go
+++ b/pkg/kit/kit.go
@@ -1255,7 +1255,7 @@ type Options struct {
 	//
 	//   - project context files (AGENTS.md)
 	//   - skills, from both project and user directories
-	//   - extensions, from both project and user directories
+	//   - extensions, from every source: project, user and system directories
 	//   - named agent definitions
 	//   - project-local .kit.yml (see [ConfigInitOptions])
 	//
@@ -1263,6 +1263,9 @@ type Options struct {
 	// SystemPrompt all still apply, as do the equivalent CLI flags. Core
 	// tools remain enabled and the working directory is unchanged; combine
 	// with NoCoreTools to remove filesystem access as well.
+	//
+	// Subagents spawned by a bare Kit inherit Bare, so delegated work cannot
+	// reintroduce the project context the parent excluded.
 	Bare bool
 
 	// MCPConfig provides a pre-loaded MCP configuration. When set,
@@ -2405,6 +2408,21 @@ func inheritProviderConfig(child *Options, v *viper.Viper) {
 	}
 }
 
+// inheritIsolationOptions copies the parent's context-isolation settings onto
+// child Options so a subagent inherits the parent's discovery boundary.
+// Without it a bare parent spawns a child that re-runs project discovery and
+// loads the AGENTS.md, skills and extensions the parent deliberately refused.
+//
+// Kept as a helper rather than an inline assignment so that any future
+// isolation field is propagated by editing one place, and so the behaviour is
+// testable without spawning a real subagent. A nil child or parent is a no-op.
+func inheritIsolationOptions(child, parent *Options) {
+	if child == nil || parent == nil {
+		return
+	}
+	child.Bare = parent.Bare
+}
+
 // toolsIncludeMCP reports whether the provided tool set already contains any
 // of the parent's loaded MCP tools (matched by prefixed name). Used to decide
 // whether a spawned subagent needs to re-load MCP servers or can rely on the
@@ -2587,6 +2605,12 @@ func (m *Kit) Subagent(ctx context.Context, cfg SubagentConfig) (*SubagentResult
 	// polling and no progress feedback even when the parent had configured
 	// custom values.
 	inheritMCPTaskOptions(childOpts, m.opts)
+	// Propagate context isolation. A bare parent must not spawn a child that
+	// re-discovers the working directory: the child would load AGENTS.md,
+	// skills and extensions the parent deliberately refused, reintroducing
+	// exactly the context (and the arbitrary extension code) bare mode exists
+	// to keep out.
+	inheritIsolationOptions(childOpts, m.opts)
 	child, err := New(ctx, childOpts)
 	if err != nil {
 		return &SubagentResult{Elapsed: time.Since(start)}, fmt.Errorf("failed to create subagent: %w", err)

--- a/pkg/kit/kit.go
+++ b/pkg/kit/kit.go
@@ -866,12 +866,30 @@ func (m *Kit) composeSystemPrompt(basePrompt string) string {
 	}
 
 	// Append current date/time and working directory.
-	pb.WithSection("", fmt.Sprintf(
-		"Current date and time: %s\nCurrent working directory: %s",
-		time.Now().Format("Monday, January 2, 2006, 3:04:05 PM MST"), cwd,
-	))
+	bare := m.opts != nil && m.opts.Bare
+	pb.WithSection("", environmentSection(cwd, bare))
 
 	return pb.Build()
+}
+
+// environmentSection renders the trailing system-prompt block describing the
+// runtime environment: the current time and working directory, plus a notice
+// when bare mode suppressed project context. Both Kit.New and
+// composeSystemPrompt use it so the two paths cannot drift.
+func environmentSection(cwd string, bare bool) string {
+	s := fmt.Sprintf(
+		"Current date and time: %s\nCurrent working directory: %s",
+		time.Now().Format("Monday, January 2, 2006, 3:04:05 PM MST"), cwd,
+	)
+	// The working directory is still reported in bare mode because the file
+	// tools resolve relative paths against it. The notice stops the model
+	// treating that directory as the subject of the conversation.
+	if bare {
+		s += "\n\nNo project context was loaded (bare mode): no project" +
+			" instructions, skills or extensions are in effect. Treat the" +
+			" working directory as incidental unless the user refers to it."
+	}
+	return s
 }
 
 // GetCurrentModel returns the fully qualified "provider/model" string for the
@@ -927,9 +945,11 @@ func (m *Kit) ReloadExtensions() error {
 		_, _ = m.extRunner.Emit(extensions.SessionShutdownEvent{})
 	}
 
-	// Re-load from disk.
+	// Re-load from disk. Bare mode is preserved across the reload so a hot
+	// reload cannot pull in directory-discovered extensions that startup
+	// deliberately skipped.
 	extraPaths := m.v.GetStringSlice("extension")
-	loaded, err := extensions.LoadExtensions(extraPaths)
+	loaded, err := extensions.LoadExtensionsScoped(extraPaths, m.opts != nil && m.opts.Bare)
 	if err != nil {
 		return fmt.Errorf("reloading extensions: %w", err)
 	}
@@ -1229,6 +1249,22 @@ type Options struct {
 	// [SubagentConfig].Agent cannot resolve.
 	NoAgents bool
 
+	// Bare disables every form of automatic context discovery, so starting
+	// Kit inside a directory does not implicitly load that directory's
+	// instructions, tooling or configuration. It suppresses:
+	//
+	//   - project context files (AGENTS.md)
+	//   - skills, from both project and user directories
+	//   - extensions, from both project and user directories
+	//   - named agent definitions
+	//   - project-local .kit.yml (see [ConfigInitOptions])
+	//
+	// Explicitly supplied values are unaffected: Skills, Extensions and
+	// SystemPrompt all still apply, as do the equivalent CLI flags. Core
+	// tools remain enabled and the working directory is unchanged; combine
+	// with NoCoreTools to remove filesystem access as well.
+	Bare bool
+
 	// MCPConfig provides a pre-loaded MCP configuration. When set,
 	// LoadAndValidateConfig is skipped during Kit creation — avoiding
 	// viper access entirely. This is set automatically for in-process
@@ -1392,6 +1428,7 @@ type CLIOptions struct {
 //
 // Behaviour based on Options:
 //   - NoSession:   in-memory tree session (no persistence)
+//   - Bare:        shared bare bucket, not tied to a working directory
 //   - Continue:    resume most recent session for SessionDir (or cwd)
 //   - SessionPath: open a specific JSONL session file
 //   - default:     create a new tree session for SessionDir (or cwd)
@@ -1403,6 +1440,14 @@ func InitTreeSession(opts *Options) (*TreeManager, error) {
 	sessionDir := opts.SessionDir
 	if sessionDir == "" {
 		sessionDir, _ = os.Getwd()
+	}
+
+	// Bare sessions are deliberately not filed under the working directory:
+	// the mode exists so the directory does not matter. One shared bucket
+	// keeps `--continue` and `--resume` working across directories. An
+	// explicit SessionPath still wins, below.
+	if opts.Bare {
+		sessionDir = session.BareSessionKey
 	}
 
 	if opts.NoSession {
@@ -1488,7 +1533,7 @@ func New(ctx context.Context, opts *Options) (*Kit, error) {
 		// seeds "model", which would otherwise mask an empty store.
 		// SkipConfig bypasses .kit.yml file loading (viper defaults and env vars still apply).
 		if !opts.SkipConfig && opts.CLI == nil {
-			if err := initConfig(v, opts.ConfigFile, false); err != nil {
+			if err := initConfig(v, opts.ConfigFile, false, opts.Bare); err != nil {
 				return fmt.Errorf("failed to initialize config: %w", err)
 			}
 		}
@@ -1566,7 +1611,7 @@ func New(ctx context.Context, opts *Options) (*Kit, error) {
 		}
 
 		// Load context files (AGENTS.md) from the project root.
-		if !opts.NoContextFiles {
+		if !opts.NoContextFiles && !opts.Bare {
 			contextFiles = loadContextFiles(cwd)
 		}
 
@@ -1609,7 +1654,7 @@ func New(ctx context.Context, opts *Options) (*Kit, error) {
 		// subagent tool description and resolvable via SubagentConfig.Agent.
 		// Per-file parse failures are non-fatal: usable agents still load and
 		// a warning is printed unless quiet.
-		if !opts.NoAgents && !v.GetBool("no-agents") {
+		if !opts.NoAgents && !opts.Bare && !v.GetBool("no-agents") {
 			var agErr error
 			namedAgents, agErr = LoadAgentDefinitions(cwd)
 			if agErr != nil && !opts.Quiet {
@@ -1685,10 +1730,7 @@ func New(ctx context.Context, opts *Options) (*Kit, error) {
 			}
 
 			// Append current date/time and working directory.
-			pb.WithSection("", fmt.Sprintf(
-				"Current date and time: %s\nCurrent working directory: %s",
-				time.Now().Format("Monday, January 2, 2006, 3:04:05 PM MST"), cwd,
-			))
+			pb.WithSection("", environmentSection(cwd, opts.Bare))
 
 			v.Set("system-prompt", pb.Build())
 		}
@@ -1823,6 +1865,7 @@ func New(ctx context.Context, opts *Options) (*Kit, error) {
 		Debug:             debug,
 		DebugLogger:       opts.DebugLogger,
 		NoExtensions:      noExtensions,
+		Bare:              opts.Bare,
 		MaxSteps:          maxSteps,
 		StreamingEnabled:  streaming,
 		OnMCPServerLoaded: opts.OnMCPServerLoaded,
@@ -2078,6 +2121,13 @@ func loadSkills(opts *Options) ([]*skills.Skill, error) {
 	// Auto-discover from the standard scopes rooted at the session directory.
 	// Project-local skills are injected into the system prompt, so they are
 	// gated on a trust decision when a SkillTrustPrompt is configured.
+	//
+	// Bare mode stops here: only skills named explicitly on the command line
+	// (handled above) load, so no directory contributes instructions merely
+	// because Kit happens to be running inside it.
+	if opts.Bare {
+		return nil, nil
+	}
 	cwd := opts.SessionDir
 	if cwd == "" {
 		cwd, _ = os.Getwd()

--- a/www/pages/cli/flags.md
+++ b/www/pages/cli/flags.md
@@ -40,6 +40,49 @@ These flags control Kit's behavior. When a prompt is passed as a positional argu
 | `--compact` | — | `false` | Enable compact output mode |
 | `--auto-compact` | — | `false` | Compact proactively when near the context limit (reactive compact-and-retry on provider overflow errors is [always on](/sessions#reactive-compaction-on-overflow)) |
 
+## Context
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--bare` | — | `false` | No project context — skip all automatic discovery |
+
+`--bare` starts Kit without reading anything from the directory it runs in, so
+you can ask a question without first loading whatever project you happen to be
+standing in. It disables:
+
+- project context files (`AGENTS.md`)
+- skills, from both project and user directories
+- extensions, from both project and user directories
+- named agent definitions
+- prompt template directories
+- project-local `.kit.yml`
+
+Your home `~/.kit.yml` still loads, so API keys and your default model keep
+working, as do `KIT_*` environment variables and an explicit `--config` file.
+
+Anything you name on the command line still applies — `--extension`,
+`--skill`, `--prompt-template`, `--system-prompt` and `@file` attachments are
+unaffected. Bare mode suppresses what Kit finds on its own, never what you
+asked for.
+
+Core tools stay enabled and the working directory is unchanged, so the agent
+can still read files when you ask it to. Combine with `--no-core-tools` for a
+pure question-answering session:
+
+```bash
+kit --bare "why does a TLS handshake fail with an SNI mismatch"
+kit --bare --no-core-tools "explain the CAP theorem"
+kit --bare -e ~/my-ext.go "..."   # explicit extension still loads
+```
+
+Because a bare session is not tied to a directory, bare sessions share a
+single store rather than the usual per-directory one. `kit --bare -c` resumes
+your last bare conversation from anywhere on the filesystem.
+
+`--bare` cannot be set from a config file. It exists to ignore project
+configuration, so allowing a project config to enable it would be
+self-defeating.
+
 ## Extensions
 
 | Flag | Short | Default | Description |

--- a/www/pages/cli/flags.md
+++ b/www/pages/cli/flags.md
@@ -52,7 +52,7 @@ standing in. It disables:
 
 - project context files (`AGENTS.md`)
 - skills, from both project and user directories
-- extensions, from both project and user directories
+- extensions, from every source — project, user and system directories
 - named agent definitions
 - prompt template directories
 - project-local `.kit.yml`


### PR DESCRIPTION
# Description

Kit reads a lot from whatever directory it starts in: `AGENTS.md`, skills, extensions, named agents, prompt templates and a project `.kit.yml`. That is the right behaviour when working on a project and the wrong one when you just want to ask a question — `cd` into an unfamiliar repo and the agent's context is shaped by it before you type anything.

The existing off-switches don't cover this. `--no-skills` and `--no-extensions` are scope-blind: they disable the user's own `~/.agents/skills` and `~/.config/kit/extensions` along with the project's. And project `.kit.yml` has no off-switch at all, despite being the most consequential of the lot — it can define `mcpServers` (which spawn processes) and override `system-prompt`.

This adds a single `--bare` flag that disables every form of automatic discovery. The governing rule is **explicit stays, implicit goes**: anything named on the command line still applies (`--extension`, `--skill`, `--prompt-template`, `--system-prompt`, `@file`), while anything Kit would have found on its own is skipped. Core tools remain enabled and the working directory is unchanged, so `--bare` composes with `--no-core-tools` rather than deciding tool policy itself.

```bash
kit --bare "why does a TLS handshake fail with an SNI mismatch"
kit --bare --no-core-tools "explain the CAP theorem"   # no filesystem access
kit --bare -e ~/my-ext.go "..."                        # explicit extension still loads
```

Before / after in the same repo:

```
without --bare:  context     ~/Workspace/kit/AGENTS.md
                 skills      btca-cli, kit-extensions, kit-sdk, skill-creator
                 extensions  go-edit-lint, subagent-monitor, sysbar (1 tools)

with --bare:     context     bare — no project context
```

Two deliberate design decisions worth reviewer attention:

- **`--bare` is not bound to viper.** Every other flag can be set from a config file. This one exists to ignore project config, so letting a project `.kit.yml` enable or disable it would be self-defeating. It follows the precedent of `--quiet` and `--continue`, which are also package-level vars.
- **Bare sessions still persist**, but to a shared `~/.kit/sessions/__bare__` bucket rather than the per-directory one. A bare session isn't tied to a directory, so `kit --bare -c` resumes your last bare conversation from anywhere on the filesystem.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / chore

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (`go vet`, `gofmt` and `golangci-lint` clean; the 17 pre-existing `modernize` hints are unchanged from `master`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`go test -race ./...`)

## Additional Information

### Public SDK surface

Two additions to `pkg/kit/`, both backward compatible:

- `Options.Bare bool` — disables automatic discovery for SDK consumers
- `ConfigInitOptions` + `InitConfigWithOptions(opts)` — config loading with control over project-directory discovery

`InitConfig(configFile, debug)` is unchanged and keeps its existing behaviour; it now delegates to the same internal path with `bare=false`. No deprecation needed.

### Internal API changes

- `extensions.LoadExtensionsScoped(paths, bare)` added; `LoadExtensions(paths)` retained as a wrapper
- `prompts.LoadOptions.Bare` field added
- `session.BareSessionKey` constant added
- `kitsetup.AgentSetupOptions.Bare` field added

### Files

**Added**

- `pkg/kit/bare_test.go` — 4 tests over the composed system prompt
- `pkg/kit/bare_config_test.go` — 3 tests over config discovery
- `internal/extensions/bare_test.go` — 2 tests over extension path discovery

**Modified**

- `cmd/root.go` — flag registration, `kit.Options` wiring, prompt-template and file-watcher gating
- `pkg/kit/kit.go` — `Options.Bare`, gating for context files / skills / agents, `environmentSection` helper, bare session bucket
- `pkg/kit/config.go` — `ConfigInitOptions`, `InitConfigWithOptions`, project config-path gating
- `internal/extensions/loader.go` — scoped discovery, split into `discoverExtensionDirs` / `appendExplicitExtensionPaths`
- `internal/prompts/loader.go` — `Bare` option gating the three discovery directories
- `internal/session/tree_manager.go` — `BareSessionKey`
- `internal/kitsetup/setup.go` — threads `Bare` into extension loading
- `internal/ui/model.go` — splash reports `bare — no project context`
- `internal/extensions/loader_test.go` — updated for the new `discoverExtensionPaths` signature
- `www/pages/cli/flags.md` — new **Context** section documenting the flag

### Testing notes

Each behavioural test has a paired control that runs the same fixture *without* `--bare`, so a passing assertion can't be a false positive from a broken fixture — e.g. `TestBare_Disabled_LoadsProjectContext` proves the test directory really does contain a loadable `AGENTS.md` and skill.

The primary assertion checks the composed system prompt string rather than loader internals, since that is what actually ships to the provider.

Manually verified in tmux against a live model, including an adversarial `/tmp/evil-repo` containing an `AGENTS.md` instruction override and a `.kit.yml` model override: normal mode adopted both, bare mode adopted neither. Cross-directory session continuity (`--bare -c` from a different directory) also confirmed.

### Backward compatibility

No behaviour changes when the flag is absent. All existing flags, config keys and SDK entry points behave as before.

### Known unrelated issue

The startup banner reports `extensions  N tools` for skill-registered tools even when no extensions are loaded (`GetExtensionToolCount()` returns `len(extraTools)`). Reproducible on `master` with `--no-extensions --skill <path>`, so it predates this change and is left alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--bare` mode to start Kit without automatic project-context discovery.
  * Skips project context files, skills, extensions, agents, prompt directories, and local configuration.
  * Explicitly supplied configuration, extensions, skills, prompts, and core tools remain available.
  * Bare sessions use a shared session store across directories.
  * Startup messaging now indicates bare mode and unavailable project context.
* **Documentation**
  * Added CLI documentation, behavior details, and usage examples for `--bare`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->