### PR TITLE
fix(core): stop cmd.Wait truncating bash output mid-drain

### DIFF
--- a/internal/core/bash.go
+++ b/internal/core/bash.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"charm.land/fantasy"
@@ -258,36 +259,123 @@ func executeBash(ctx context.Context, call fantasy.ToolCall, workDir string, def
 	return executeBashBuffered(cmdCtx, call, cmd, sudoPassword)
 }
 
+// pipeDrainGrace bounds how long the parent waits for the output readers to
+// finish after the child process has exited. It only matters when a grandchild
+// process inherited the write end and is holding it open, in which case the
+// readers never observe EOF. Normal commands drain immediately and never touch
+// this timer.
+const pipeDrainGrace = 500 * time.Millisecond
+
+// bashPipes holds the parent's read ends of the child's output pipes. They are
+// created with os.Pipe and assigned to cmd.Stdout/cmd.Stderr rather than
+// obtained from cmd.StdoutPipe, which matters for correctness:
+//
+// Cmd.Wait closes the pipes it creates as soon as it observes the child exit,
+// without waiting for the reader to drain them. Any output still sitting in
+// the kernel buffer is then lost. Owning the read ends here keeps them open
+// until the readers reach EOF, so Wait can never truncate output.
+//
+// The cost is that Cmd.WaitDelay no longer force-closes these descriptors, so
+// the caller must bound the drain itself — see waitForDrain.
+type bashPipes struct {
+	stdout *os.File
+	stderr *os.File
+
+	// forced records that close was called deliberately by waitForDrain
+	// rather than the pipes reaching EOF. Readers use it to tell a real
+	// truncation from the expected shutdown of a lingering grandchild.
+	forced atomic.Bool
+}
+
+// close releases the parent's read ends, unblocking any reader still waiting
+// on a pipe that a surviving grandchild holds open. Safe to call more than
+// once.
+func (p *bashPipes) close() {
+	if p == nil {
+		return
+	}
+	if p.stdout != nil {
+		_ = p.stdout.Close()
+	}
+	if p.stderr != nil {
+		_ = p.stderr.Close()
+	}
+}
+
+// waitForDrain waits for the output readers to finish after the child has
+// exited. It returns once readersDone is closed, or force-closes the pipes
+// after pipeDrainGrace so a grandchild holding the write end cannot hang the
+// call. Either way it does not return until the readers have stopped, so the
+// caller can read the collected output without a race.
+func (p *bashPipes) waitForDrain(readersDone <-chan struct{}) {
+	select {
+	case <-readersDone:
+		// Normal path: both readers reached EOF and drained everything.
+	case <-time.After(pipeDrainGrace):
+		// A grandchild still holds a write end. Closing the read ends makes
+		// the pending reads fail, which ends the reader loops. Flag it first
+		// so those failures are not misreported as truncated output.
+		p.forced.Store(true)
+		p.close()
+		<-readersDone
+	}
+}
+
 // setupBashPipes opens stdout/stderr pipes (plus an optional sudo stdin),
 // starts the command, and asynchronously writes the sudo password if any.
 // Returns the readers ready for the caller to consume. If setup fails,
 // errResp is non-nil and the readers must not be used; the caller should
 // return the response directly.
-func setupBashPipes(cmd *exec.Cmd, sudoPassword string) (stdout, stderr io.Reader, errResp *fantasy.ToolResponse) {
-	stdoutPipe, err := cmd.StdoutPipe()
-	if err != nil {
-		r := fantasy.NewTextErrorResponse("failed to create stdout pipe")
-		return nil, nil, &r
+//
+// The caller owns the returned pipes and must drain them via
+// [bashPipes.waitForDrain] after cmd.Wait returns.
+func setupBashPipes(cmd *exec.Cmd, sudoPassword string) (pipes *bashPipes, errResp *fantasy.ToolResponse) {
+	fail := func(msg string) (*bashPipes, *fantasy.ToolResponse) {
+		r := fantasy.NewTextErrorResponse(msg)
+		return nil, &r
 	}
-	stderrPipe, err := cmd.StderrPipe()
+
+	// os.Pipe rather than cmd.StdoutPipe: see the bashPipes doc comment. The
+	// write ends are handed to the child and closed in the parent right after
+	// Start, so the readers see EOF once every writer has exited.
+	stdoutR, stdoutW, err := os.Pipe()
 	if err != nil {
-		r := fantasy.NewTextErrorResponse("failed to create stderr pipe")
-		return nil, nil, &r
+		return fail("failed to create stdout pipe")
+	}
+	stderrR, stderrW, err := os.Pipe()
+	if err != nil {
+		_ = stdoutR.Close()
+		_ = stdoutW.Close()
+		return fail("failed to create stderr pipe")
+	}
+	cmd.Stdout = stdoutW
+	cmd.Stderr = stderrW
+
+	closeAll := func() {
+		_ = stdoutR.Close()
+		_ = stdoutW.Close()
+		_ = stderrR.Close()
+		_ = stderrW.Close()
 	}
 
 	var stdinPipe io.WriteCloser
 	if sudoPassword != "" {
 		stdinPipe, err = cmd.StdinPipe()
 		if err != nil {
-			r := fantasy.NewTextErrorResponse("failed to create stdin pipe")
-			return nil, nil, &r
+			closeAll()
+			return fail("failed to create stdin pipe")
 		}
 	}
 
 	if err := cmd.Start(); err != nil {
-		r := fantasy.NewTextErrorResponse(fmt.Sprintf("failed to start command: %v", err))
-		return nil, nil, &r
+		closeAll()
+		return fail(fmt.Sprintf("failed to start command: %v", err))
 	}
+
+	// Drop the parent's copies of the write ends. Without this the readers
+	// would never see EOF, because this process would still count as a writer.
+	_ = stdoutW.Close()
+	_ = stderrW.Close()
 
 	if sudoPassword != "" && stdinPipe != nil {
 		go func() {
@@ -296,7 +384,7 @@ func setupBashPipes(cmd *exec.Cmd, sudoPassword string) (stdout, stderr io.Reade
 		}()
 	}
 
-	return stdoutPipe, stderrPipe, nil
+	return &bashPipes{stdout: stdoutR, stderr: stderrR}, nil
 }
 
 // interpretBashExit decodes cmd.Wait()'s error into an exit code, mapping
@@ -322,10 +410,11 @@ func interpretBashExit(waitErr error, cmdCtx context.Context) (exitCode int, err
 // close them when grandchild processes hold pipe handles open after the
 // direct child exits.
 func executeBashBuffered(cmdCtx context.Context, _ fantasy.ToolCall, cmd *exec.Cmd, sudoPassword string) (fantasy.ToolResponse, error) {
-	stdoutPipe, stderrPipe, errResp := setupBashPipes(cmd, sudoPassword)
+	pipes, errResp := setupBashPipes(cmd, sudoPassword)
 	if errResp != nil {
 		return *errResp, nil
 	}
+	defer pipes.close()
 
 	// Read pipes concurrently
 	var wg sync.WaitGroup
@@ -334,20 +423,28 @@ func executeBashBuffered(cmdCtx context.Context, _ fantasy.ToolCall, cmd *exec.C
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		_, _ = io.Copy(&stdout, stdoutPipe)
+		_, _ = io.Copy(&stdout, pipes.stdout)
 	}()
 	go func() {
 		defer wg.Done()
-		_, _ = io.Copy(&stderr, stderrPipe)
+		_, _ = io.Copy(&stderr, pipes.stderr)
 	}()
 
-	// Wait for the process to exit first. cmd.WaitDelay ensures that if
-	// pipes remain open (held by grandchild processes), they'll be forcibly
-	// closed after the grace period, which unblocks the io.Copy goroutines.
+	readersDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(readersDone)
+	}()
+
+	// Wait for the process to exit. cmd.Cancel plus cmd.WaitDelay ensure a
+	// runaway process tree is killed rather than blocking here forever.
+	// Because the output pipes are owned by us rather than by Cmd, this call
+	// cannot close them out from under the readers above.
 	waitErr := cmd.Wait()
 
-	// Wait for pipe readers to finish draining.
-	wg.Wait()
+	// Let the readers finish draining, bounded so a grandchild holding a write
+	// end open cannot hang the call.
+	pipes.waitForDrain(readersDone)
 
 	exitCode, errResp := interpretBashExit(waitErr, cmdCtx)
 	if errResp != nil {
@@ -359,10 +456,11 @@ func executeBashBuffered(cmdCtx context.Context, _ fantasy.ToolCall, cmd *exec.C
 
 // executeBashStreaming streams output as it arrives via the callback.
 func executeBashStreaming(cmdCtx context.Context, call fantasy.ToolCall, cmd *exec.Cmd, outputCallback ToolOutputCallback, sudoPassword string) (fantasy.ToolResponse, error) {
-	stdoutPipe, stderrPipe, errResp := setupBashPipes(cmd, sudoPassword)
+	pipes, errResp := setupBashPipes(cmd, sudoPassword)
 	if errResp != nil {
 		return *errResp, nil
 	}
+	defer pipes.close()
 
 	// Stream stdout and stderr concurrently
 	var wg sync.WaitGroup
@@ -399,7 +497,12 @@ func executeBashStreaming(cmdCtx context.Context, call fantasy.ToolCall, cmd *ex
 		// the whole call hangs until the command timeout fires and every byte
 		// of output is lost. Discard the rest so the process can exit, and
 		// report the truncation instead of failing silently.
-		if err := scanner.Err(); err != nil {
+		//
+		// A read failure caused by our own deliberate close is not truncation:
+		// the foreground command already finished and only a backgrounded
+		// grandchild still holds the pipe. Reporting it would put a spurious
+		// notice on the output of every `cmd &` invocation.
+		if err := scanner.Err(); err != nil && !pipes.forced.Load() {
 			discarded, _ := io.Copy(io.Discard, reader)
 			notice := fmt.Sprintf("[output truncated: %v; discarded %d further bytes]", err, discarded)
 			outputCallback(call.ID, "bash", notice, isStderr)
@@ -414,18 +517,26 @@ func executeBashStreaming(cmdCtx context.Context, call fantasy.ToolCall, cmd *ex
 	}
 
 	wg.Add(2)
-	go streamOutput(stdoutPipe, false)
-	go streamOutput(stderrPipe, true)
+	go streamOutput(pipes.stdout, false)
+	go streamOutput(pipes.stderr, true)
 
-	// Wait for the process to exit. cmd.WaitDelay ensures that if pipes
-	// remain open (held by grandchild processes), they'll be forcibly closed
-	// after the grace period, which unblocks the scanners above.
+	readersDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(readersDone)
+	}()
+
+	// Wait for the process to exit. cmd.Cancel plus cmd.WaitDelay ensure a
+	// runaway process tree is killed rather than blocking here forever.
+	// Because the output pipes are owned by us rather than by Cmd, this call
+	// cannot close them out from under the scanners above — which previously
+	// truncated output whenever the child exited while a scanner was still
+	// draining the kernel buffer.
 	waitErr := cmd.Wait()
 
-	// Wait for the pipe readers to finish draining. This will complete
-	// quickly since cmd.Wait() (with WaitDelay) has already ensured
-	// the pipes are closed.
-	wg.Wait()
+	// Let the scanners finish draining, bounded so a grandchild holding a write
+	// end open cannot hang the call.
+	pipes.waitForDrain(readersDone)
 
 	exitCode, errResp := interpretBashExit(waitErr, cmdCtx)
 	if errResp != nil {

--- a/internal/core/bash_streaming_test.go
+++ b/internal/core/bash_streaming_test.go
@@ -184,7 +184,20 @@ func TestBashStreaming_NoTruncationOnFastExit(t *testing.T) {
 // bogus "[output truncated: file already closed]" line on the output of every
 // `cmd &` invocation.
 func TestBashStreaming_BackgroundProcessNoSpuriousNotice(t *testing.T) {
-	resp, chunks := runStreaming(t, "echo started; sleep 300 &")
+	// The sleep only has to outlive pipeDrainGrace. Keep it short so the test
+	// does not leave a long-lived orphan behind on the runner: the foreground
+	// shell exits immediately, so nothing reaps this process.
+	start := time.Now()
+	resp, chunks := runStreaming(t, "echo started; sleep 3 &")
+	elapsed := time.Since(start)
+
+	// The call should have gone through the watchdog rather than a clean EOF.
+	// Without this the test could pass vacuously on a runner slow enough for
+	// the sleep to finish first, never exercising the forced close.
+	if elapsed < pipeDrainGrace {
+		t.Errorf("returned in %v, before the %v drain grace — the forced-close path was not exercised",
+			elapsed, pipeDrainGrace)
+	}
 
 	if strings.Contains(resp.Content, "output truncated") {
 		t.Errorf("backgrounded process produced a spurious truncation notice: %q", resp.Content)

--- a/internal/core/bash_streaming_test.go
+++ b/internal/core/bash_streaming_test.go
@@ -138,3 +138,63 @@ func TestBashStreaming_LongButUnderLimit(t *testing.T) {
 		t.Errorf("scanner should deliver the full 500000-byte line, got %d", got)
 	}
 }
+
+// TestBashStreaming_NoTruncationOnFastExit is a regression test for output
+// being silently truncated when the child exits while a scanner is still
+// draining the kernel buffer.
+//
+// The cause was Cmd.Wait closing the pipes it owns as soon as it observes the
+// child exit, without waiting for the reader. The fix gives the parent its own
+// os.Pipe read ends, which Wait cannot touch.
+//
+// The race needs the child to exit immediately after writing a large payload,
+// and it is scheduling-dependent, so this runs many iterations. On the
+// unfixed code it reported a spurious "output truncated" notice on the first
+// iteration under -cpu=1,2,4.
+func TestBashStreaming_NoTruncationOnFastExit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping repeated-iteration race check in short mode")
+	}
+
+	const wantBytes = 300000
+	for i := range 40 {
+		resp, chunks := runStreaming(t, `head -c 300000 /dev/zero | tr '\0' 'x'`)
+
+		if strings.Contains(resp.Content, "output truncated") {
+			t.Fatalf("iteration %d: output truncated even though the line is under the scanner limit", i)
+		}
+		total := 0
+		for _, c := range chunks {
+			total += len(c)
+		}
+		if len(chunks) != 1 || total != wantBytes {
+			t.Fatalf("iteration %d: got %d chunk(s) totalling %d bytes, want 1 chunk of %d",
+				i, len(chunks), total, wantBytes)
+		}
+	}
+}
+
+// TestBashStreaming_BackgroundProcessNoSpuriousNotice guards the interaction
+// between the drain watchdog and the truncation notice.
+//
+// When a backgrounded grandchild keeps a write end open, the parent
+// force-closes the pipes to avoid hanging. That makes the pending read fail,
+// which looks like a scan error but is not truncation: the foreground command
+// already completed and nothing it wrote was lost. Reporting it would put a
+// bogus "[output truncated: file already closed]" line on the output of every
+// `cmd &` invocation.
+func TestBashStreaming_BackgroundProcessNoSpuriousNotice(t *testing.T) {
+	resp, chunks := runStreaming(t, "echo started; sleep 300 &")
+
+	if strings.Contains(resp.Content, "output truncated") {
+		t.Errorf("backgrounded process produced a spurious truncation notice: %q", resp.Content)
+	}
+	if !strings.Contains(resp.Content, "started") {
+		t.Errorf("foreground output missing, got %q", resp.Content)
+	}
+	for _, c := range chunks {
+		if strings.Contains(c, "output truncated") {
+			t.Errorf("spurious truncation notice streamed to callback: %q", c)
+		}
+	}
+}

--- a/internal/core/bash_streaming_test.go
+++ b/internal/core/bash_streaming_test.go
@@ -184,19 +184,31 @@ func TestBashStreaming_NoTruncationOnFastExit(t *testing.T) {
 // bogus "[output truncated: file already closed]" line on the output of every
 // `cmd &` invocation.
 func TestBashStreaming_BackgroundProcessNoSpuriousNotice(t *testing.T) {
-	// The sleep only has to outlive pipeDrainGrace. Keep it short so the test
-	// does not leave a long-lived orphan behind on the runner: the foreground
-	// shell exits immediately, so nothing reaps this process.
+	// The background process only has to outlive pipeDrainGrace. It is kept
+	// short so the test does not leave a long-lived orphan on the runner: the
+	// foreground shell exits immediately, so nothing reaps this process.
+	//
+	// The gap between the two outcomes is deliberately wide. A working
+	// watchdog returns after roughly pipeDrainGrace (500ms); an implementation
+	// that regressed to waiting for clean EOF would block for the full
+	// bgSleep. The bound below sits far from both.
+	const bgSleep = 10 * time.Second
+	const maxElapsed = 5 * time.Second
+
 	start := time.Now()
-	resp, chunks := runStreaming(t, "echo started; sleep 3 &")
+	resp, chunks := runStreaming(t, "echo started; sleep 10 &")
 	elapsed := time.Since(start)
 
-	// The call should have gone through the watchdog rather than a clean EOF.
-	// Without this the test could pass vacuously on a runner slow enough for
-	// the sleep to finish first, never exercising the forced close.
+	// Sandwich the timing so the test can only pass via the forced-close path.
+	// The lower bound rejects a clean EOF that never engaged the watchdog; the
+	// upper bound rejects waiting for the background process to exit.
 	if elapsed < pipeDrainGrace {
 		t.Errorf("returned in %v, before the %v drain grace — the forced-close path was not exercised",
 			elapsed, pipeDrainGrace)
+	}
+	if elapsed >= maxElapsed {
+		t.Errorf("returned in %v; expected the watchdog to force-close after ~%v rather than wait out the %v background process",
+			elapsed, pipeDrainGrace, bgSleep)
 	}
 
 	if strings.Contains(resp.Content, "output truncated") {


### PR DESCRIPTION
# Description

`Cmd.Wait` closes the pipes it owns as soon as it observes the child exit, without waiting for the reader to drain them. Any output still sitting in the kernel buffer is silently lost. `os/exec` documents this directly:

> Cmd.Wait will close the pipe after seeing the command exit, so most callers need not close the pipe themselves. **It is thus incorrect to call Wait before all reads from the pipe have completed.**

Both bash execution paths called `Wait()` before `wg.Wait()`. Under CPU contention this loses output on roughly 1 run in 6.

## Why the naive swap does not work

That ordering was deliberate. From `d1cffb85`:

> Reorder streaming path: `cmd.Wait()` before `wg.Wait()` so the WaitDelay timer starts when the child exits, not after pipes close

`cmd.WaitDelay` only engages while `Wait` is in flight. It is what stops a backgrounded grandchild — `echo hi; sleep 3600 &` — from holding a write end open and hanging the call forever. Swapping the two lines fixes truncation and reintroduces the hang, which `TestBash_BackgroundProcessDoesNotHang_Streaming` guards against.

## The fix

Remove the conflict rather than trade one bug for the other. The parent now creates its own `os.Pipe` read ends and assigns the write ends to `cmd.Stdout` / `cmd.Stderr`, instead of using `cmd.StdoutPipe()`. `Cmd` never owns those descriptors, so `Wait` cannot close them — it can run first, exactly as `WaitDelay` requires, without racing the readers.

The grandchild case is then handled explicitly instead of relying on `WaitDelay`: after `Wait` returns, readers get a 500 ms grace period, after which the pipes are force-closed so the call cannot hang.

One consequence needed handling. A forced close makes the pending read fail, which *looks* like a scan error but is not truncation — the foreground command already finished and only a lingering background process still holds the pipe. Left unflagged, every `cmd &` invocation grew a bogus line:

```
started
[output truncated: read |0: file already closed; discarded 0 further bytes]
STDERR:
[output truncated: read |0: file already closed; discarded 0 further bytes]
```

That case is now distinguished, so genuine `bufio.ErrTooLong` truncation is still reported and the background case is silent.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / chore

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — not applicable, internal behaviour only
- [x] My changes generate no new warnings (`go vet`, `gofmt`, `golangci-lint` all clean)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes (`go test -race ./...`, run twice)

## Additional Information

### Verification

The truncation is scheduling-dependent, so a probe hammering the exact scenario — child exits immediately after writing 300 KB — was run against both trees:

| Tree | Result |
|---|---|
| `master` | fails on **iteration 0** (`spurious truncation notice`) |
| this branch | **120/120 iterations clean** under `-cpu=1,2,4` |

`TestBashStreaming_*` passed 8 consecutive `-cpu=1,2,4` rounds where `master` failed roughly 1 in 6.

The hang guards from `d1cffb85` — `TestBash_BackgroundProcessDoesNotHang`, `..._Streaming`, `TestBash_ContextCancellation`, `TestBash_TimeoutKillsProcess` — passed 6 consecutive `-cpu=1,2,4` rounds, confirming the original fix is preserved.

End-to-end through the real tool: a 400 KB command output round-trips exactly (`400000`), and `echo started; sleep 300 &` returns in ~6 s with clean output and no spurious notice.

### Files

- `internal/core/bash.go` — `bashPipes` type owning the read ends, `waitForDrain` watchdog, `setupBashPipes` reworked to `os.Pipe`, both execute paths updated
- `internal/core/bash_streaming_test.go` — two regression tests added

### Notes for the reviewer

- **`pipeDrainGrace` is 500 ms**, matching the existing `WaitDelay` grace it replaces for this case. Only backgrounded-grandchild invocations ever reach it; normal commands return immediately.
- **`setupBashPipes` signature changed** from `(io.Reader, io.Reader, *ToolResponse)` to `(*bashPipes, *ToolResponse)`. It is unexported with two call sites, both updated.
- **The sudo stdin path is unchanged** and still uses `cmd.StdinPipe()`; only stdout/stderr ownership moved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bash command output handling to prevent truncated results when commands exit quickly.
  * Prevented misleading truncation notices when background processes keep output streams open.
  * Preserved complete foreground output while safely handling lingering background processes.

* **Tests**
  * Added regression coverage for large, fast-completing outputs and background processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->