### PR TITLE
fix(daemon): terminal hand-back, alt screen, hub routing and sidecar orphans

### DIFF
--- a/cmd/attach.go
+++ b/cmd/attach.go
@@ -280,6 +280,26 @@ func reportSkippedHosts(skipped []string) {
 	fmt.Fprintf(os.Stderr, "Skipped unreachable host(s): %s\n", strings.Join(skipped, ", "))
 }
 
+// appendRemoteSessions adds every paired host's sessions to entries.
+//
+// Cancellation is reported before the skipped hosts are named: it fails
+// every host query at once, and telling the user their machines are
+// unreachable when the listing was simply abandoned is a false report
+// about their infrastructure. A missing host book is not an error — there
+// is simply nothing to add.
+func appendRemoteSessions(ctx context.Context, entries []daemon.SessionEntry) ([]daemon.SessionEntry, error) {
+	hosts, err := daemon.ListHosts()
+	if err != nil {
+		return entries, nil
+	}
+	remote, skipped := remoteSessionEntries(ctx, hosts, "")
+	if cerr := ctx.Err(); cerr != nil {
+		return entries, cerr
+	}
+	reportSkippedHosts(skipped)
+	return append(entries, remote...), nil
+}
+
 var lsCmd = &cobra.Command{
 	Use:   "ls",
 	Short: "List live kit sessions",
@@ -295,14 +315,13 @@ skipped.`,
 			return err
 		}
 		if attachAll {
-			if hosts, herr := daemon.ListHosts(); herr == nil {
-				remote, skipped := remoteSessionEntries(ctx, hosts, "")
-				entries = append(entries, remote...)
-				reportSkippedHosts(skipped)
+			entries, err = appendRemoteSessions(ctx, entries)
+			if err != nil {
+				return err
 			}
 		}
-		// Same reasoning as runHubAttach: a cancelled listing is empty,
-		// and printing "no live sessions" for it would be a false report.
+		// A cancelled listing is also an empty one, and printing "no live
+		// sessions" for it would be a false report.
 		if cerr := ctx.Err(); cerr != nil {
 			return cerr
 		}

--- a/cmd/attach.go
+++ b/cmd/attach.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -27,7 +28,7 @@ var (
 // internal/daemon must not import internal/ui: the daemon runs headless as
 // a service, and the client is driven from here. This converter is the
 // same pattern cmd/root.go uses for the extension widget providers.
-func sessionPickerFor(entries []daemon.SessionEntry, input *os.File, title string, keepAlt bool) (daemon.SessionChoice, error) {
+func sessionPickerFor(entries []daemon.SessionEntry, input *os.File, title string) (daemon.SessionChoice, error) {
 	view := make([]ui.SessionEntry, len(entries))
 	for i, e := range entries {
 		view[i] = ui.SessionEntry{
@@ -39,7 +40,7 @@ func sessionPickerFor(entries []daemon.SessionEntry, input *os.File, title strin
 			Host:    e.Host,
 		}
 	}
-	pick, err := ui.RunSessionPicker(view, input, title, keepAlt)
+	pick, err := ui.RunSessionPicker(view, input, title)
 	if err != nil {
 		return daemon.SessionChoice{Cancel: true}, err
 	}
@@ -55,14 +56,12 @@ func sessionPickerFor(entries []daemon.SessionEntry, input *os.File, title strin
 
 // localPicker is the single-daemon picker.
 func localPicker(entries []daemon.SessionEntry, input *os.File) (daemon.SessionChoice, error) {
-	// Called from inside an attached client, which owns the alt screen.
-	return sessionPickerFor(entries, input, "Live sessions", true)
+	return sessionPickerFor(entries, input, "Live sessions")
 }
 
 // hubPicker is the cross-host picker behind Ctrl-] w.
 func hubPicker(entries []daemon.SessionEntry, input *os.File) (daemon.SessionChoice, error) {
-	// Called from inside an attached client, which owns the alt screen.
-	return sessionPickerFor(entries, input, "Sessions across all paired hosts", true)
+	return sessionPickerFor(entries, input, "Sessions across all paired hosts")
 }
 
 var attachCmd = &cobra.Command{
@@ -110,15 +109,6 @@ Inside a session, Ctrl-] is the multiplexer prefix:
 			ForceNew: attachNew,
 		}
 
-		// The hub is only wired when there is more than one daemon to
-		// choose between; otherwise Ctrl-] w has nothing to offer.
-		if hosts, err := daemon.ListHosts(); err == nil && len(hosts) > 0 {
-			opts.Hub = hubPicker
-			opts.HubEntries = func() []daemon.SessionEntry {
-				return remoteSessionEntries(hosts, attachHost)
-			}
-		}
-
 		if attachAll {
 			return runHubAttach(cmd, opts)
 		}
@@ -138,7 +128,25 @@ const maxHostSwitches = 16
 // host here. Session ids are per-daemon, so the id only means anything
 // once we are talking to the daemon that issued it.
 func runFollowingHostSwitches(ctx context.Context, host string, opts daemon.AttachOptions) error {
+	hosts, _ := daemon.ListHosts()
+
 	for range maxHostSwitches {
+		// The hub lists every daemon EXCEPT the one this client is talking
+		// to, whose sessions the client already knows. That set changes on
+		// every hop, so it is rebuilt here rather than once up front:
+		// wired to the starting host, Ctrl-] w would list the current host
+		// twice after a switch and never offer a way back to this machine.
+		current := host
+		if len(hosts) > 0 {
+			opts.Hub = hubPicker
+			opts.HubEntries = func() []daemon.SessionEntry {
+				return otherDaemonSessions(hosts, current)
+			}
+		} else {
+			opts.Hub = nil
+			opts.HubEntries = nil
+		}
+
 		var err error
 		if host == "" {
 			err = daemon.RunLocal(ctx, opts)
@@ -157,6 +165,24 @@ func runFollowingHostSwitches(ctx context.Context, host string, opts daemon.Atta
 	return fmt.Errorf("too many host switches in one session (limit %d)", maxHostSwitches)
 }
 
+// otherDaemonSessions collects the sessions the current client cannot
+// reach itself: every paired host except the one it is attached to, plus
+// this machine's own daemon when the client is attached elsewhere.
+//
+// Local sessions carry an empty host, which is exactly what the client
+// reports for the local daemon, so choosing one is recognised as a switch
+// back to this machine.
+func otherDaemonSessions(hosts []daemon.HostEntry, current string) []daemon.SessionEntry {
+	var all []daemon.SessionEntry
+	if current != "" {
+		if local, err := daemon.ListLocalSessions(); err == nil {
+			all = append(all, local...)
+		}
+	}
+	entries, _ := remoteSessionEntries(hosts, current)
+	return append(all, entries...)
+}
+
 // runHubAttach opens the cross-host picker before connecting anywhere, so
 // the first session can be on any paired machine.
 func runHubAttach(cmd *cobra.Command, opts daemon.AttachOptions) error {
@@ -167,14 +193,16 @@ func runHubAttach(cmd *cobra.Command, opts daemon.AttachOptions) error {
 	}
 
 	entries, _ := daemon.ListLocalSessions() // a missing local daemon is fine
-	entries = append(entries, remoteSessionEntries(hosts, "")...)
+	remote, skipped := remoteSessionEntries(hosts, "")
+	entries = append(entries, remote...)
+	reportSkippedHosts(skipped)
 	if len(entries) == 0 {
 		fmt.Println("No live sessions anywhere. Start one with: kit attach")
 		return nil
 	}
 
 	// Runs before any client attaches, so this picker owns the screen.
-	choice, err := sessionPickerFor(entries, os.Stdin, "Sessions across all paired hosts", false)
+	choice, err := sessionPickerFor(entries, os.Stdin, "Sessions across all paired hosts")
 	if err != nil || choice.Cancel {
 		return err
 	}
@@ -183,27 +211,61 @@ func runHubAttach(cmd *cobra.Command, opts daemon.AttachOptions) error {
 }
 
 // remoteSessionEntries collects sessions from every paired host, tagged
-// with the host they came from.
+// with the host they came from, and names the hosts that did not answer.
 //
-// Hosts are queried one at a time and failures are skipped silently: a
-// laptop that is asleep should not stop the picker from listing the hosts
-// that did answer.
-func remoteSessionEntries(hosts []daemon.HostEntry, skip string) []daemon.SessionEntry {
-	var all []daemon.SessionEntry
-	for _, h := range hosts {
+// Hosts are queried in parallel: asking one at a time made a picker wait
+// out every sleeping laptop in the host book before it could draw, and the
+// wait grew with each host paired.
+func remoteSessionEntries(hosts []daemon.HostEntry, skip string) (entries []daemon.SessionEntry, skipped []string) {
+	type result struct {
+		entries []daemon.SessionEntry
+		err     error
+	}
+
+	// Each goroutine owns one slot, so the results keep the host book's
+	// order however the answers interleave.
+	var wg sync.WaitGroup
+	results := make([]result, len(hosts))
+	for i, h := range hosts {
 		if h.Name == skip {
 			continue
 		}
-		entries, err := daemon.ListHostSessions(h.Name, 8*time.Second)
-		if err != nil {
+		wg.Add(1)
+		go func(i int, name string) {
+			defer wg.Done()
+			found, err := daemon.ListHostSessions(name, hostQueryTimeout)
+			for j := range found {
+				found[j].Host = name
+			}
+			results[i] = result{entries: found, err: err}
+		}(i, h.Name)
+	}
+	wg.Wait()
+
+	for i, h := range hosts {
+		if h.Name == skip {
 			continue
 		}
-		for i := range entries {
-			entries[i].Host = h.Name
+		if results[i].err != nil {
+			skipped = append(skipped, h.Name)
+			continue
 		}
-		all = append(all, entries...)
+		entries = append(entries, results[i].entries...)
 	}
-	return all
+	return entries, skipped
+}
+
+// hostQueryTimeout bounds one host's session listing. It covers a relay
+// round trip with room to spare; a host that needs longer is asleep.
+const hostQueryTimeout = 8 * time.Second
+
+// reportSkippedHosts names the hosts that did not answer, so an incomplete
+// list is never mistaken for an empty one.
+func reportSkippedHosts(skipped []string) {
+	if len(skipped) == 0 {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "Skipped unreachable host(s): %s\n", strings.Join(skipped, ", "))
 }
 
 var lsCmd = &cobra.Command{
@@ -221,7 +283,9 @@ skipped.`,
 		}
 		if attachAll {
 			if hosts, herr := daemon.ListHosts(); herr == nil {
-				entries = append(entries, remoteSessionEntries(hosts, "")...)
+				remote, skipped := remoteSessionEntries(hosts, "")
+				entries = append(entries, remote...)
+				reportSkippedHosts(skipped)
 			}
 		}
 		if len(entries) == 0 {

--- a/cmd/attach.go
+++ b/cmd/attach.go
@@ -28,7 +28,7 @@ var (
 // internal/daemon must not import internal/ui: the daemon runs headless as
 // a service, and the client is driven from here. This converter is the
 // same pattern cmd/root.go uses for the extension widget providers.
-func sessionPickerFor(entries []daemon.SessionEntry, input *os.File, title string) (daemon.SessionChoice, error) {
+func sessionPickerFor(ctx context.Context, entries []daemon.SessionEntry, input *os.File, title string) (daemon.SessionChoice, error) {
 	view := make([]ui.SessionEntry, len(entries))
 	for i, e := range entries {
 		view[i] = ui.SessionEntry{
@@ -40,7 +40,7 @@ func sessionPickerFor(entries []daemon.SessionEntry, input *os.File, title strin
 			Host:    e.Host,
 		}
 	}
-	pick, err := ui.RunSessionPicker(view, input, title)
+	pick, err := ui.RunSessionPicker(ctx, view, input, title)
 	if err != nil {
 		return daemon.SessionChoice{Cancel: true}, err
 	}
@@ -55,13 +55,13 @@ func sessionPickerFor(entries []daemon.SessionEntry, input *os.File, title strin
 }
 
 // localPicker is the single-daemon picker.
-func localPicker(entries []daemon.SessionEntry, input *os.File) (daemon.SessionChoice, error) {
-	return sessionPickerFor(entries, input, "Live sessions")
+func localPicker(ctx context.Context, entries []daemon.SessionEntry, input *os.File) (daemon.SessionChoice, error) {
+	return sessionPickerFor(ctx, entries, input, "Live sessions")
 }
 
 // hubPicker is the cross-host picker behind Ctrl-] w.
-func hubPicker(entries []daemon.SessionEntry, input *os.File) (daemon.SessionChoice, error) {
-	return sessionPickerFor(entries, input, "Sessions across all paired hosts")
+func hubPicker(ctx context.Context, entries []daemon.SessionEntry, input *os.File) (daemon.SessionChoice, error) {
+	return sessionPickerFor(ctx, entries, input, "Sessions across all paired hosts")
 }
 
 var attachCmd = &cobra.Command{
@@ -139,8 +139,8 @@ func runFollowingHostSwitches(ctx context.Context, host string, opts daemon.Atta
 		current := host
 		if len(hosts) > 0 {
 			opts.Hub = hubPicker
-			opts.HubEntries = func() []daemon.SessionEntry {
-				return otherDaemonSessions(hosts, current)
+			opts.HubEntries = func(ctx context.Context) []daemon.SessionEntry {
+				return otherDaemonSessions(ctx, hosts, current)
 			}
 		} else {
 			opts.Hub = nil
@@ -172,14 +172,14 @@ func runFollowingHostSwitches(ctx context.Context, host string, opts daemon.Atta
 // Local sessions carry an empty host, which is exactly what the client
 // reports for the local daemon, so choosing one is recognised as a switch
 // back to this machine.
-func otherDaemonSessions(hosts []daemon.HostEntry, current string) []daemon.SessionEntry {
+func otherDaemonSessions(ctx context.Context, hosts []daemon.HostEntry, current string) []daemon.SessionEntry {
 	var all []daemon.SessionEntry
 	if current != "" {
-		if local, err := daemon.ListLocalSessions(); err == nil {
+		if local, err := daemon.ListLocalSessions(ctx); err == nil {
 			all = append(all, local...)
 		}
 	}
-	entries, _ := remoteSessionEntries(hosts, current)
+	entries, _ := remoteSessionEntries(ctx, hosts, current)
 	return append(all, entries...)
 }
 
@@ -192,8 +192,8 @@ func runHubAttach(cmd *cobra.Command, opts daemon.AttachOptions) error {
 		return err
 	}
 
-	entries, _ := daemon.ListLocalSessions() // a missing local daemon is fine
-	remote, skipped := remoteSessionEntries(hosts, "")
+	entries, _ := daemon.ListLocalSessions(ctx) // a missing local daemon is fine
+	remote, skipped := remoteSessionEntries(ctx, hosts, "")
 	entries = append(entries, remote...)
 	reportSkippedHosts(skipped)
 	if len(entries) == 0 {
@@ -202,7 +202,7 @@ func runHubAttach(cmd *cobra.Command, opts daemon.AttachOptions) error {
 	}
 
 	// Runs before any client attaches, so this picker owns the screen.
-	choice, err := sessionPickerFor(entries, os.Stdin, "Sessions across all paired hosts")
+	choice, err := sessionPickerFor(ctx, entries, os.Stdin, "Sessions across all paired hosts")
 	if err != nil || choice.Cancel {
 		return err
 	}
@@ -215,8 +215,10 @@ func runHubAttach(cmd *cobra.Command, opts daemon.AttachOptions) error {
 //
 // Hosts are queried in parallel: asking one at a time made a picker wait
 // out every sleeping laptop in the host book before it could draw, and the
-// wait grew with each host paired.
-func remoteSessionEntries(hosts []daemon.HostEntry, skip string) (entries []daemon.SessionEntry, skipped []string) {
+// wait grew with each host paired. ctx cancels the queries: each one is a
+// sidecar process, so a caller that gives up must not leave a fan-out of
+// them running until their timeouts expire.
+func remoteSessionEntries(ctx context.Context, hosts []daemon.HostEntry, skip string) (entries []daemon.SessionEntry, skipped []string) {
 	type result struct {
 		entries []daemon.SessionEntry
 		err     error
@@ -233,7 +235,7 @@ func remoteSessionEntries(hosts []daemon.HostEntry, skip string) (entries []daem
 		wg.Add(1)
 		go func(i int, name string) {
 			defer wg.Done()
-			found, err := daemon.ListHostSessions(name, hostQueryTimeout)
+			found, err := daemon.ListHostSessions(ctx, name, hostQueryTimeout)
 			for j := range found {
 				found[j].Host = name
 			}
@@ -276,14 +278,15 @@ var lsCmd = &cobra.Command{
 With --all, also queries every paired host. Hosts that do not answer are
 skipped.`,
 	Args: cobra.NoArgs,
-	RunE: func(_ *cobra.Command, _ []string) error {
-		entries, err := daemon.ListLocalSessions()
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		ctx := cmd.Context()
+		entries, err := daemon.ListLocalSessions(ctx)
 		if err != nil && err != daemon.ErrNoLocalDaemon {
 			return err
 		}
 		if attachAll {
 			if hosts, herr := daemon.ListHosts(); herr == nil {
-				remote, skipped := remoteSessionEntries(hosts, "")
+				remote, skipped := remoteSessionEntries(ctx, hosts, "")
 				entries = append(entries, remote...)
 				reportSkippedHosts(skipped)
 			}

--- a/cmd/attach.go
+++ b/cmd/attach.go
@@ -193,7 +193,17 @@ func runHubAttach(cmd *cobra.Command, opts daemon.AttachOptions) error {
 	}
 
 	entries, _ := daemon.ListLocalSessions(ctx) // a missing local daemon is fine
+	if cerr := ctx.Err(); cerr != nil {
+		return cerr
+	}
 	remote, skipped := remoteSessionEntries(ctx, hosts, "")
+	if cerr := ctx.Err(); cerr != nil {
+		// Cancellation empties both listings, and an empty listing is
+		// indistinguishable from "nothing is running anywhere". Reporting
+		// that would tell the user something untrue about their machines,
+		// and marking every host unreachable would compound it.
+		return cerr
+	}
 	entries = append(entries, remote...)
 	reportSkippedHosts(skipped)
 	if len(entries) == 0 {
@@ -290,6 +300,11 @@ skipped.`,
 				entries = append(entries, remote...)
 				reportSkippedHosts(skipped)
 			}
+		}
+		// Same reasoning as runHubAttach: a cancelled listing is empty,
+		// and printing "no live sessions" for it would be a false report.
+		if cerr := ctx.Err(); cerr != nil {
+			return cerr
 		}
 		if len(entries) == 0 {
 			fmt.Println("No live sessions. Start one with: kit attach")

--- a/cmd/attach_test.go
+++ b/cmd/attach_test.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/kit/internal/daemon"
+)
+
+// TestRemoteSessionEntriesHonoursCancellation checks that a cancelled
+// context stops the fan-out of host queries.
+//
+// Every paired host is queried at once and each query starts a sidecar
+// process, so a caller that gives up — a picker torn down, the client
+// shutting down — must be able to end them. Without a context the
+// goroutines ran to their eight second timeout regardless, holding a
+// sidecar each for the whole of it.
+//
+// The hosts here are not paired, so each query fails on the host lookup
+// before any process starts; what is under test is that the call returns
+// on a dead context rather than the transport behaviour.
+func TestRemoteSessionEntriesHonoursCancellation(t *testing.T) {
+	hosts := []daemon.HostEntry{
+		{Name: "unreachable-a"},
+		{Name: "unreachable-b"},
+		{Name: "unreachable-c"},
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // already dead when the queries start
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		entries, skipped := remoteSessionEntries(ctx, hosts, "")
+		if len(entries) != 0 {
+			t.Errorf("entries = %d, want none from unreachable hosts", len(entries))
+		}
+		if len(skipped) != len(hosts) {
+			t.Errorf("skipped = %v, want all %d hosts reported", skipped, len(hosts))
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(hostQueryTimeout):
+		t.Fatal("a cancelled context did not stop the host queries")
+	}
+}
+
+// TestRemoteSessionEntriesSkipsTheCurrentHost pins the hub's contract: the
+// daemon the client is already talking to is left out, because the client
+// lists that one itself and a duplicate row would attach by an id that
+// means something different on each daemon.
+func TestRemoteSessionEntriesSkipsTheCurrentHost(t *testing.T) {
+	hosts := []daemon.HostEntry{{Name: "keep-me"}, {Name: "skip-me"}}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, skipped := remoteSessionEntries(ctx, hosts, "skip-me")
+
+	if len(skipped) != 1 || skipped[0] != "keep-me" {
+		t.Fatalf("skipped = %v, want only [keep-me]: the current host must not be queried", skipped)
+	}
+}

--- a/cmd/attach_test.go
+++ b/cmd/attach_test.go
@@ -2,8 +2,11 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
+
+	"github.com/spf13/cobra"
 
 	"github.com/mark3labs/kit/internal/daemon"
 )
@@ -63,5 +66,26 @@ func TestRemoteSessionEntriesSkipsTheCurrentHost(t *testing.T) {
 
 	if len(skipped) != 1 || skipped[0] != "keep-me" {
 		t.Fatalf("skipped = %v, want only [keep-me]: the current host must not be queried", skipped)
+	}
+}
+
+// TestHubAttachReportsCancellation checks that a cancelled discovery is
+// reported as cancellation rather than as an empty world.
+//
+// Cancellation empties both listings: the local query fails and every host
+// query is recorded as skipped. Without a check that is indistinguishable
+// from "nothing is running anywhere", so the command printed exactly that
+// and exited zero — telling the user something untrue about their machines
+// while also marking every host unreachable.
+func TestHubAttachReportsCancellation(t *testing.T) {
+	cmd := &cobra.Command{}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	cmd.SetContext(ctx)
+
+	err := runHubAttach(cmd, daemon.AttachOptions{})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("runHubAttach error = %v, want context.Canceled", err)
 	}
 }

--- a/cmd/attach_test.go
+++ b/cmd/attach_test.go
@@ -3,6 +3,9 @@ package cmd
 import (
 	"context"
 	"errors"
+	"io"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -88,4 +91,67 @@ func TestHubAttachReportsCancellation(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("runHubAttach error = %v, want context.Canceled", err)
 	}
+}
+
+// TestAppendRemoteSessionsReportsCancellationBeforeNamingHosts pins the
+// ordering of the cancellation check in the `--all` listing.
+//
+// This is the mid-flight case: the local sessions were listed fine and the
+// user gave up during the host fan-out. Cancellation fails every host
+// query at once, so all of them end up on the skipped list — and naming
+// them tells the user their machines are unreachable, which is a false
+// report about their infrastructure, printed on the way to returning the
+// cancellation anyway.
+func TestAppendRemoteSessionsReportsCancellationBeforeNamingHosts(t *testing.T) {
+	if hosts, err := daemon.ListHosts(); err != nil || len(hosts) == 0 {
+		t.Skip("no paired hosts on this machine: nothing could be named unreachable")
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	local := []daemon.SessionEntry{{ID: 1}} // already listed before the cancel
+	cancel()
+
+	var entries []daemon.SessionEntry
+	var err error
+	stderr := captureStderr(t, func() {
+		entries, err = appendRemoteSessions(ctx, local)
+	})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if strings.Contains(stderr, "Skipped unreachable host") {
+		t.Fatalf("a cancelled listing named hosts as unreachable: %q", stderr)
+	}
+	if len(entries) != len(local) {
+		t.Fatalf("entries = %d, want the %d already listed locally", len(entries), len(local))
+	}
+}
+
+// captureStderr runs fn with os.Stderr redirected and returns what it
+// wrote. Reads happen on a goroutine so a write larger than the pipe
+// buffer cannot deadlock fn.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	real := os.Stderr
+	os.Stderr = w
+
+	out := make(chan string, 1)
+	go func() {
+		var b strings.Builder
+		_, _ = io.Copy(&b, r)
+		out <- b.String()
+	}()
+
+	fn()
+
+	os.Stderr = real
+	_ = w.Close()
+	got := <-out
+	_ = r.Close()
+	return got
 }

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require github.com/creack/pty v1.1.24 // indirect
+require github.com/creack/pty v1.1.24
 
 require (
 	cloud.google.com/go v0.123.0 // indirect
@@ -137,12 +137,12 @@ require (
 require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/x/ansi v0.11.8
-	github.com/charmbracelet/x/term v0.2.2 // indirect
+	github.com/charmbracelet/x/term v0.2.2
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.1 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/mattn/go-runewidth v0.0.28 // indirect
-	github.com/muesli/cancelreader v0.2.2 // indirect
+	github.com/muesli/cancelreader v0.2.2
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.10

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -259,13 +259,17 @@ func dialHostQuiet(ctx context.Context, name string, entry HostEntry, quiet bool
 // attaching, for the multi-host picker. The whole exchange is bounded by
 // timeout: an unreachable host must not stall a picker that has other
 // hosts to show.
-func ListHostSessions(name string, timeout time.Duration) ([]SessionEntry, error) {
+//
+// ctx cancels the query early. The picker queries every paired host at
+// once, and each query is a sidecar process, so a caller that gives up
+// must be able to take them down without waiting out the timeout.
+func ListHostSessions(ctx context.Context, name string, timeout time.Duration) ([]SessionEntry, error) {
 	entry, err := GetHost(name)
 	if err != nil {
 		return nil, err
 	}
 	deadline := time.Now().Add(timeout)
-	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	ctx, cancel := context.WithDeadline(ctx, deadline)
 	defer cancel()
 
 	tun, err := dialHostQuiet(ctx, name, entry, true)

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -195,7 +195,9 @@ func RunHost(ctx context.Context, name string, opts AttachOptions) error {
 	// switch.
 	opts.Host = name
 	if opts.Reattach == "" {
-		opts.Reattach = "kit remote --host " + name
+		// The hint is completed with the session id, and only 'kit attach'
+		// takes one: 'kit remote --host X 1' is not a valid command line.
+		opts.Reattach = "kit attach --host " + name
 	}
 	return RunClient(ctx, tunnelStream{tun}, opts)
 }
@@ -245,7 +247,7 @@ func dialHostQuiet(ctx context.Context, name string, entry HostEntry, quiet bool
 		case strings.Contains(last, "No addressing information available"):
 			return nil, fmt.Errorf("could not resolve the daemon's endpoint (is 'kit daemon' running on the host?)")
 		case strings.Contains(last, "timed out"):
-			return nil, fmt.Errorf("could not reach the daemon (network or relay issue)")
+			return nil, fmt.Errorf("%s did not answer — check that 'kit daemon' is running there, or that the network allows the connection", name)
 		}
 		return nil, fmt.Errorf("daemon: %w", err)
 	}

--- a/internal/daemon/client_attach.go
+++ b/internal/daemon/client_attach.go
@@ -155,6 +155,12 @@ type clientConn struct {
 	stdinStop     chan struct{}
 	stdinDone     chan struct{}
 	stdinStopOnce sync.Once
+	// stdinStopped is closed once stopStdin has finished, and
+	// stdinReleased records whether the terminal actually came back.
+	// Concurrent callers wait on the first so none of them reports a
+	// hand-off that has not happened yet.
+	stdinStopped  chan struct{}
+	stdinReleased atomic.Bool
 
 	// divert, when non-nil, sends terminal input to a running picker
 	// instead of the session pump.
@@ -244,26 +250,40 @@ func (c *clientConn) readStdin(ctx context.Context) error {
 
 // stopStdin ends the terminal reader and releases stdin.
 //
-// Safe to call more than once and from any goroutine. The reader is
-// cancelled first and closed only once the goroutine has left it: closing
-// a cancel reader under an in-flight read is a data race on the file.
-func (c *clientConn) stopStdin() {
+// Safe to call more than once and from any goroutine; every caller gets
+// the same answer. The reader is cancelled first and closed only once the
+// goroutine has left it: closing a cancel reader under an in-flight read
+// is a data race on the file.
+//
+// Reports whether the terminal was actually released. Cancel is not
+// guaranteed to work — the fallback reader always refuses, and the
+// Windows one gives up if a read is wedged — and a caller that hands the
+// terminal to another client on a false promise gets the stolen-keystroke
+// bug this whole path exists to prevent. Callers that pass stdin on must
+// check it; callers that are exiting the process need not.
+func (c *clientConn) stopStdin() bool {
 	c.stdinStopOnce.Do(func() {
 		close(c.stdinStop)
 		if c.stdinReader == nil {
-			return // readStdin never ran
+			c.stdinReleased.Store(true) // readStdin never ran: nothing holds stdin
+			close(c.stdinStopped)
+			return
 		}
 		c.stdinReader.Cancel()
 		select {
 		case <-c.stdinDone:
 			_ = c.stdinReader.Close()
+			c.stdinReleased.Store(true)
 		case <-time.After(2 * time.Second):
 			// The reader did not acknowledge the cancel. Leaving its fd
 			// open costs one descriptor for the rest of the process;
 			// closing it under a live read would corrupt an unrelated
 			// file the descriptor is later reused for.
 		}
+		close(c.stdinStopped)
 	})
+	<-c.stdinStopped // a concurrent caller must not answer before the result is known
+	return c.stdinReleased.Load()
 }
 
 // pickerTTY diverts terminal input to a picker for as long as it is open.
@@ -347,15 +367,16 @@ func (c *clientConn) divertPicker() *pickerTTY {
 
 func newClientConn(rw io.ReadWriter) *clientConn {
 	return &clientConn{
-		rw:        rw,
-		sink:      newFrameSink(rw),
-		ctrlCh:    make(chan Frame, 16),
-		endedCh:   make(chan struct{}),
-		closedCh:  make(chan struct{}),
-		stdinCh:   make(chan []byte, 8),
-		stdinErr:  make(chan error, 1),
-		stdinStop: make(chan struct{}),
-		stdinDone: make(chan struct{}),
+		rw:           rw,
+		sink:         newFrameSink(rw),
+		ctrlCh:       make(chan Frame, 16),
+		endedCh:      make(chan struct{}),
+		closedCh:     make(chan struct{}),
+		stdinCh:      make(chan []byte, 8),
+		stdinErr:     make(chan error, 1),
+		stdinStop:    make(chan struct{}),
+		stdinDone:    make(chan struct{}),
+		stdinStopped: make(chan struct{}),
 	}
 }
 
@@ -552,7 +573,7 @@ func runPicker(ctx context.Context, conn *clientConn, pick SessionPicker, entrie
 // the user detaches, the session ends, or the connection drops.
 //
 // The caller owns rw and closes it.
-func RunClient(ctx context.Context, rw io.ReadWriter, opts AttachOptions) error {
+func RunClient(ctx context.Context, rw io.ReadWriter, opts AttachOptions) (err error) {
 	if !term.IsTerminal(int(os.Stdin.Fd())) || !term.IsTerminal(int(os.Stdout.Fd())) {
 		return fmt.Errorf("attaching to a session needs an interactive terminal")
 	}
@@ -581,7 +602,20 @@ func RunClient(ctx context.Context, rw io.ReadWriter, opts AttachOptions) error 
 	// switch starts a second client, and an error returned from here is
 	// rendered by a printer that queries the terminal — and a reader still
 	// parked on stdin would swallow their input, or deadlock them.
-	defer conn.stopStdin()
+	//
+	// A hand-off that cannot be made is reported rather than hidden: the
+	// next client would look alive while every keystroke went to this one.
+	defer func() {
+		if conn.stopStdin() {
+			return
+		}
+		if err == nil || errors.Is(err, errSessionEnded) {
+			// Nothing is going to run after us that needs the terminal,
+			// and the process is on its way out; saying so would be noise.
+			return
+		}
+		err = fmt.Errorf("%w (this terminal did not release its input; start a new one to continue)", err)
+	}()
 
 	choice, err := chooseSession(ctx, conn, opts)
 	if err != nil {

--- a/internal/daemon/client_attach.go
+++ b/internal/daemon/client_attach.go
@@ -142,7 +142,13 @@ type clientConn struct {
 	// cross-host switch starts a second client with its own reader — and
 	// that caller then blocks behind our reader forever. Reading through a
 	// cancel reader lets stopStdin give the terminal back.
-	stdinReader   cancelreader.CancelReader
+	stdinReader cancelreader.CancelReader
+	// stdinStop asks the reader to stop; stdinDone reports that it has.
+	// Closing a cancel reader while a read is in flight is a data race on
+	// the file, so the two are separate: stopStdin cancels, waits for the
+	// goroutine to leave, and only then closes.
+	stdinStop     chan struct{}
+	stdinDone     chan struct{}
 	stdinStopOnce sync.Once
 
 	// divert, when non-nil, sends terminal input to a running picker
@@ -165,6 +171,10 @@ func (c *clientConn) readStdin() {
 		src = cr
 	}
 	go func() {
+		// stdinDone is registered first so it closes last: a waiter woken
+		// by it must find the goroutine completely finished with the
+		// reader, not merely past the channel close.
+		defer close(c.stdinDone)
 		defer close(c.stdinCh)
 		buf := make([]byte, 256)
 		for {
@@ -176,14 +186,22 @@ func (c *clientConn) readStdin() {
 				// send, and its channel is buffered, so a blind send can
 				// park here forever with no receiver — which would kill
 				// keyboard input for the rest of the process. Abandon the
-				// keystroke if the picker is gone.
+				// keystroke if the picker is gone, or if we are stopping:
+				// a send that cannot be abandoned would outlive the
+				// client and deadlock stopStdin.
 				if pt := c.divertPicker(); pt != nil {
 					select {
 					case pt.ch <- chunk:
 					case <-pt.done:
+					case <-c.stdinStop:
+						return
 					}
 				} else {
-					c.stdinCh <- chunk
+					select {
+					case c.stdinCh <- chunk:
+					case <-c.stdinStop:
+						return
+					}
 				}
 			}
 			if err != nil {
@@ -193,20 +211,38 @@ func (c *clientConn) readStdin() {
 				}
 				return
 			}
+			select {
+			case <-c.stdinStop:
+				return
+			default:
+			}
 		}
 	}()
 }
 
 // stopStdin ends the terminal reader and releases stdin.
 //
-// Safe to call more than once and from any goroutine.
+// Safe to call more than once and from any goroutine. The reader is
+// cancelled first and closed only once the goroutine has left it: closing
+// a cancel reader under an in-flight read is a data race on the file.
+// Without a cancel reader (an unusual stdin) there is nothing to stop, and
+// waiting would hang on a goroutine parked in an uninterruptible read.
 func (c *clientConn) stopStdin() {
 	c.stdinStopOnce.Do(func() {
+		close(c.stdinStop)
 		if c.stdinReader == nil {
 			return
 		}
 		c.stdinReader.Cancel()
-		_ = c.stdinReader.Close()
+		select {
+		case <-c.stdinDone:
+			_ = c.stdinReader.Close()
+		case <-time.After(2 * time.Second):
+			// The reader did not acknowledge the cancel. Leaving its fd
+			// open costs one descriptor for the rest of the process;
+			// closing it under a live read would corrupt an unrelated
+			// file the descriptor is later reused for.
+		}
 	})
 }
 
@@ -291,13 +327,15 @@ func (c *clientConn) divertPicker() *pickerTTY {
 
 func newClientConn(rw io.ReadWriter) *clientConn {
 	return &clientConn{
-		rw:       rw,
-		sink:     newFrameSink(rw),
-		ctrlCh:   make(chan Frame, 16),
-		endedCh:  make(chan struct{}),
-		closedCh: make(chan struct{}),
-		stdinCh:  make(chan []byte, 8),
-		stdinErr: make(chan error, 1),
+		rw:        rw,
+		sink:      newFrameSink(rw),
+		ctrlCh:    make(chan Frame, 16),
+		endedCh:   make(chan struct{}),
+		closedCh:  make(chan struct{}),
+		stdinCh:   make(chan []byte, 8),
+		stdinErr:  make(chan error, 1),
+		stdinStop: make(chan struct{}),
+		stdinDone: make(chan struct{}),
 	}
 }
 

--- a/internal/daemon/client_attach.go
+++ b/internal/daemon/client_attach.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/creack/pty"
+	"github.com/muesli/cancelreader"
 	"golang.org/x/term"
 
 	"github.com/mark3labs/kit/internal/clipboard"
@@ -121,16 +122,28 @@ type clientConn struct {
 
 	// stdinCh carries terminal input for the connection's whole life.
 	//
-	// The reader behind it must NOT be per-attach: os.Stdin.Read blocks
-	// and cannot be cancelled, so a reader started for each attached
-	// session would still be parked in Read after a session switch. Two
-	// readers on one fd split the keystrokes between them at random, and
-	// the ones delivered to a finished session's pump are simply dropped
-	// — chords stop working after the first switch, more so with each
-	// one. One reader per connection, shared by every session, is the
-	// only arrangement that keeps input whole.
+	// The reader behind it must NOT be per-attach: a reader started for
+	// each attached session would still be parked in Read after a session
+	// switch. Two readers on one fd split the keystrokes between them at
+	// random, and the ones delivered to a finished session's pump are
+	// simply dropped — chords stop working after the first switch, more so
+	// with each one. One reader per connection, shared by every session,
+	// is the only arrangement that keeps input whole.
 	stdinCh  chan []byte
 	stdinErr chan error
+
+	// stdinReader is the cancellable reader behind stdinCh.
+	//
+	// os.Stdin.Read cannot be interrupted, and a goroutine parked in it
+	// holds the file's read lock for as long as it stays parked. That lock
+	// outlives this client: a connection that ends in an error hands
+	// control back to a caller that may need the terminal itself — the
+	// error renderer queries the terminal's background colour, and a
+	// cross-host switch starts a second client with its own reader — and
+	// that caller then blocks behind our reader forever. Reading through a
+	// cancel reader lets stopStdin give the terminal back.
+	stdinReader   cancelreader.CancelReader
+	stdinStopOnce sync.Once
 
 	// divert, when non-nil, sends terminal input to a running picker
 	// instead of the session pump.
@@ -140,12 +153,22 @@ type clientConn struct {
 
 // readStdin starts the connection's single terminal reader. Chunks go to
 // the session pump, or to the picker while one is on screen.
+//
+// The reader is cancellable so the terminal can be handed back; see
+// clientConn.stdinReader. A stdin that will not take a cancel reader falls
+// back to reading the file directly: input still works, only the hand-back
+// is unavailable.
 func (c *clientConn) readStdin() {
+	var src io.Reader = os.Stdin
+	if cr, err := cancelreader.NewReader(os.Stdin); err == nil {
+		c.stdinReader = cr
+		src = cr
+	}
 	go func() {
 		defer close(c.stdinCh)
 		buf := make([]byte, 256)
 		for {
-			n, err := os.Stdin.Read(buf)
+			n, err := src.Read(buf)
 			if n > 0 {
 				chunk := make([]byte, n)
 				copy(chunk, buf[:n])
@@ -164,11 +187,27 @@ func (c *clientConn) readStdin() {
 				}
 			}
 			if err != nil {
-				c.stdinErr <- err
+				select {
+				case c.stdinErr <- err:
+				default: // nobody left to tell
+				}
 				return
 			}
 		}
 	}()
+}
+
+// stopStdin ends the terminal reader and releases stdin.
+//
+// Safe to call more than once and from any goroutine.
+func (c *clientConn) stopStdin() {
+	c.stdinStopOnce.Do(func() {
+		if c.stdinReader == nil {
+			return
+		}
+		c.stdinReader.Cancel()
+		_ = c.stdinReader.Close()
+	})
 }
 
 // pickerTTY diverts terminal input to a picker for as long as it is open.
@@ -375,7 +414,14 @@ func (c *clientConn) attach(id uint64) (uint64, error) {
 		return 0, err
 	}
 	if len(ack.Payload) < 9 || ack.Payload[8] != 1 {
-		return 0, fmt.Errorf("the daemon refused the attach")
+		// The daemon refuses an attach for exactly two reasons, and they
+		// need different advice: a session id that is not live any more
+		// (mistyped, or ended since it was listed), or a new session it
+		// could not start.
+		if id == 0 {
+			return 0, fmt.Errorf("the daemon could not start a session")
+		}
+		return 0, fmt.Errorf("no live session %d on this daemon — list the live ones with 'kit ls'", id)
 	}
 	return binary.BigEndian.Uint64(ack.Payload[:8]), nil
 }
@@ -432,6 +478,14 @@ func runPicker(conn *clientConn, pick SessionPicker, entries []SessionEntry) (Se
 		return SessionChoice{Cancel: true}, err
 	}
 	defer tty.Close()
+	// The picker owns the alternate screen while it runs and leaves it on
+	// exit, which would drop the client's own alt screen with it: Bubble
+	// Tea always restores the screen state it entered, so a picker that
+	// stayed in the alt screen for its last frame still emits the exit
+	// sequence when the program shuts down. Re-enter it here instead of
+	// asking the picker not to leave. The session repaints right after
+	// (runAttached sends a redraw), so an empty alt screen is never seen.
+	defer func() { _, _ = os.Stdout.WriteString(altScreenEnter) }()
 	return pick(entries, tty.File())
 }
 
@@ -462,6 +516,12 @@ func RunClient(ctx context.Context, rw io.ReadWriter, opts AttachOptions) error 
 	conn := newClientConn(rw)
 	go conn.readLoop()
 	conn.readStdin()
+	// Give the terminal back on the way out. Everything above this call
+	// may hand control to a caller that reads stdin itself — a cross-host
+	// switch starts a second client, and an error returned from here is
+	// rendered by a printer that queries the terminal — and a reader still
+	// parked on stdin would swallow their input, or deadlock them.
+	defer conn.stopStdin()
 
 	choice, err := chooseSession(conn, opts)
 	if err != nil {
@@ -518,7 +578,8 @@ func RunClient(ctx context.Context, rw io.ReadWriter, opts AttachOptions) error 
 			choice = next
 			continue
 		case out.detached:
-			parting = fmt.Sprintf("Detached — the session keeps running on the daemon. Reattach with: %s", opts.Reattach)
+			parting = fmt.Sprintf("Detached — the session keeps running on the daemon. Reattach with: %s %d",
+				opts.Reattach, conn.current())
 			return nil
 		case out.ended:
 			parting = "Session ended."

--- a/internal/daemon/client_attach.go
+++ b/internal/daemon/client_attach.go
@@ -165,21 +165,25 @@ type clientConn struct {
 // readStdin starts the connection's single terminal reader. Chunks go to
 // the session pump, or to the picker while one is on screen.
 //
-// The reader is cancellable so the terminal can be handed back; see
-// clientConn.stdinReader. A stdin that will not take a cancel reader falls
-// back to reading the file directly: input still works, only the hand-back
-// is unavailable.
+// The reader must be cancellable, so a terminal that will not take a
+// cancel reader is a setup failure rather than something to work around.
+// Falling back to reading os.Stdin directly would start a goroutine that
+// nothing can stop, and stopStdin would return having released nothing —
+// the captured terminal this whole path exists to prevent, reintroduced
+// silently on the one path nobody exercises. RunClient has already
+// established that stdin is a terminal by the time we are called, so this
+// error means the terminal is genuinely unusable to us.
 //
 // ctx releases the terminal as soon as it is cancelled. The client also
 // stops the reader when it unwinds, but that can trail the cancellation by
 // as long as an in-flight daemon request takes to time out, and a caller
 // that cancelled is usually a caller that wants stdin back now.
-func (c *clientConn) readStdin(ctx context.Context) {
-	var src io.Reader = os.Stdin
-	if cr, err := cancelreader.NewReader(os.Stdin); err == nil {
-		c.stdinReader = cr
-		src = cr
+func (c *clientConn) readStdin(ctx context.Context) error {
+	src, err := cancelreader.NewReader(os.Stdin)
+	if err != nil {
+		return fmt.Errorf("daemon: this terminal cannot be read cancellably: %w", err)
 	}
+	c.stdinReader = src
 	go func() {
 		select {
 		case <-ctx.Done():
@@ -235,6 +239,7 @@ func (c *clientConn) readStdin(ctx context.Context) {
 			}
 		}
 	}()
+	return nil
 }
 
 // stopStdin ends the terminal reader and releases stdin.
@@ -242,13 +247,11 @@ func (c *clientConn) readStdin(ctx context.Context) {
 // Safe to call more than once and from any goroutine. The reader is
 // cancelled first and closed only once the goroutine has left it: closing
 // a cancel reader under an in-flight read is a data race on the file.
-// Without a cancel reader (an unusual stdin) there is nothing to stop, and
-// waiting would hang on a goroutine parked in an uninterruptible read.
 func (c *clientConn) stopStdin() {
 	c.stdinStopOnce.Do(func() {
 		close(c.stdinStop)
 		if c.stdinReader == nil {
-			return
+			return // readStdin never ran
 		}
 		c.stdinReader.Cancel()
 		select {
@@ -570,7 +573,9 @@ func RunClient(ctx context.Context, rw io.ReadWriter, opts AttachOptions) error 
 
 	conn := newClientConn(rw)
 	go conn.readLoop()
-	conn.readStdin(ctx)
+	if err := conn.readStdin(ctx); err != nil {
+		return err
+	}
 	// Give the terminal back on the way out. Everything above this call
 	// may hand control to a caller that reads stdin itself — a cross-host
 	// switch starts a second client, and an error returned from here is

--- a/internal/daemon/client_attach.go
+++ b/internal/daemon/client_attach.go
@@ -169,12 +169,24 @@ type clientConn struct {
 // clientConn.stdinReader. A stdin that will not take a cancel reader falls
 // back to reading the file directly: input still works, only the hand-back
 // is unavailable.
-func (c *clientConn) readStdin() {
+//
+// ctx releases the terminal as soon as it is cancelled. The client also
+// stops the reader when it unwinds, but that can trail the cancellation by
+// as long as an in-flight daemon request takes to time out, and a caller
+// that cancelled is usually a caller that wants stdin back now.
+func (c *clientConn) readStdin(ctx context.Context) {
 	var src io.Reader = os.Stdin
 	if cr, err := cancelreader.NewReader(os.Stdin); err == nil {
 		c.stdinReader = cr
 		src = cr
 	}
+	go func() {
+		select {
+		case <-ctx.Done():
+			c.stopStdin()
+		case <-c.stdinStop: // stopped by the client instead
+		}
+	}()
 	go func() {
 		// stdinDone is registered first so it closes last: a waiter woken
 		// by it must find the goroutine completely finished with the
@@ -558,7 +570,7 @@ func RunClient(ctx context.Context, rw io.ReadWriter, opts AttachOptions) error 
 
 	conn := newClientConn(rw)
 	go conn.readLoop()
-	conn.readStdin()
+	conn.readStdin(ctx)
 	// Give the terminal back on the way out. Everything above this call
 	// may hand control to a caller that reads stdin itself — a cross-host
 	// switch starts a second client, and an error returned from here is

--- a/internal/daemon/client_attach.go
+++ b/internal/daemon/client_attach.go
@@ -57,7 +57,11 @@ type SessionChoice struct {
 // input is the terminal input the picker must read from. The client keeps
 // a single reader on os.Stdin for its whole life, so a picker that opened
 // its own would race it for keystrokes.
-type SessionPicker func(entries []SessionEntry, input *os.File) (SessionChoice, error)
+//
+// ctx cancels the picker. It is the one blocking call in an attached
+// client that the user cannot always end from the keyboard, so it has to
+// honour the same cancellation as the session loop around it.
+type SessionPicker func(ctx context.Context, entries []SessionEntry, input *os.File) (SessionChoice, error)
 
 // AttachOptions configures a client attach loop.
 type AttachOptions struct {
@@ -83,7 +87,8 @@ type AttachOptions struct {
 	// Hub, when set, handles a cross-host switch request.
 	Hub SessionPicker
 	// HubEntries supplies sessions from other hosts for the hub picker.
-	HubEntries func() []SessionEntry
+	// The context bounds the queries it makes.
+	HubEntries func(ctx context.Context) []SessionEntry
 }
 
 // attachOutcome reports why a single attached session stopped.
@@ -466,7 +471,7 @@ func (c *clientConn) attach(id uint64) (uint64, error) {
 
 // chooseSession runs the picker when sessions exist, and short-circuits to
 // a new session when none do.
-func chooseSession(conn *clientConn, opts AttachOptions) (SessionChoice, error) {
+func chooseSession(ctx context.Context, conn *clientConn, opts AttachOptions) (SessionChoice, error) {
 	// A choice that did not come from a picker is on this daemon by
 	// definition, so it carries this client's host. Leaving it empty would
 	// make hostSwitch read every --host attach as a switch to the local
@@ -493,9 +498,9 @@ func chooseSession(conn *clientConn, opts AttachOptions) (SessionChoice, error) 
 		entries[i].Host = opts.Host
 	}
 	if opts.HubEntries != nil {
-		entries = append(entries, opts.HubEntries()...)
+		entries = append(entries, opts.HubEntries(ctx)...)
 	}
-	return runPicker(conn, opts.Pick, entries)
+	return runPicker(ctx, conn, opts.Pick, entries)
 }
 
 // runPicker runs one picker with input diverted from the session pump.
@@ -503,7 +508,7 @@ func chooseSession(conn *clientConn, opts AttachOptions) (SessionChoice, error) 
 // The terminal is put in raw mode here rather than left to the picker: the
 // picker reads a pty slave, so its own termios setup would apply to that
 // pty instead of the user's terminal.
-func runPicker(conn *clientConn, pick SessionPicker, entries []SessionEntry) (SessionChoice, error) {
+func runPicker(ctx context.Context, conn *clientConn, pick SessionPicker, entries []SessionEntry) (SessionChoice, error) {
 	fd := int(os.Stdin.Fd())
 	oldState, err := term.MakeRaw(fd)
 	if err != nil {
@@ -524,7 +529,7 @@ func runPicker(conn *clientConn, pick SessionPicker, entries []SessionEntry) (Se
 	// asking the picker not to leave. The session repaints right after
 	// (runAttached sends a redraw), so an empty alt screen is never seen.
 	defer func() { _, _ = os.Stdout.WriteString(altScreenEnter) }()
-	return pick(entries, tty.File())
+	return pick(ctx, entries, tty.File())
 }
 
 // RunClient drives a daemon connection for the whole client session: pick a
@@ -561,7 +566,7 @@ func RunClient(ctx context.Context, rw io.ReadWriter, opts AttachOptions) error 
 	// parked on stdin would swallow their input, or deadlock them.
 	defer conn.stopStdin()
 
-	choice, err := chooseSession(conn, opts)
+	choice, err := chooseSession(ctx, conn, opts)
 	if err != nil {
 		return err
 	}
@@ -597,13 +602,20 @@ func RunClient(ctx context.Context, rw io.ReadWriter, opts AttachOptions) error 
 		}
 		switch {
 		case out.wantSwitch:
-			next, cancelled, rerr := resolveSwitch(conn, opts, out)
+			next, cancelled, rerr := resolveSwitch(ctx, conn, opts, out)
 			if rerr != nil {
 				return rerr
 			}
 			if cancelled {
 				// The picker was dismissed: stay on the session we were
 				// on rather than dropping the user back to the shell.
+				//
+				// choice still holds whatever got us here, and for a
+				// client started with --new that is 0, meaning "spawn a
+				// session". Re-attaching it would answer a dismissed
+				// picker with a brand new session instead of the one the
+				// user was already working in.
+				choice = stayOnCurrent(conn, opts)
 				continue
 			}
 			// Release the current session before binding the next one.
@@ -626,6 +638,16 @@ func RunClient(ctx context.Context, rw io.ReadWriter, opts AttachOptions) error 
 			return nil
 		}
 	}
+}
+
+// stayOnCurrent is the choice that leaves a client where it already is,
+// for a picker the user dismissed.
+//
+// It names the session explicitly rather than reusing the choice that
+// opened the picker: that one is 0 for a client started with --new, and 0
+// means "spawn a session" to the daemon.
+func stayOnCurrent(conn *clientConn, opts AttachOptions) SessionChoice {
+	return SessionChoice{ID: conn.current(), Host: opts.Host}
 }
 
 // ErrSwitchHost reports that the user chose a session on a different
@@ -661,7 +683,7 @@ func hostSwitch(opts AttachOptions, choice SessionChoice) *ErrSwitchHost {
 // The chord handlers cannot run a picker themselves — the terminal is still
 // in raw mode while they run — so they hand back a sentinel and the work
 // happens here, after runAttached has restored the terminal.
-func resolveSwitch(conn *clientConn, opts AttachOptions, out attachOutcome) (SessionChoice, bool, error) {
+func resolveSwitch(ctx context.Context, conn *clientConn, opts AttachOptions, out attachOutcome) (SessionChoice, bool, error) {
 	switch out.switchTo {
 	case pickSentinel:
 		entries, err := conn.listSessions()
@@ -674,14 +696,14 @@ func resolveSwitch(conn *clientConn, opts AttachOptions, out attachOutcome) (Ses
 		pick := opts.Pick
 		if out.switchHost == hubMarker {
 			if opts.HubEntries != nil {
-				entries = append(entries, opts.HubEntries()...)
+				entries = append(entries, opts.HubEntries(ctx)...)
 			}
 			pick = opts.Hub
 		}
 		if pick == nil {
 			return SessionChoice{}, true, nil
 		}
-		choice, err := runPicker(conn, pick, entries)
+		choice, err := runPicker(ctx, conn, pick, entries)
 		if err != nil {
 			return SessionChoice{}, false, err
 		}

--- a/internal/daemon/client_attach_test.go
+++ b/internal/daemon/client_attach_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -323,4 +324,66 @@ func TestChooseSessionTagsChoicesWithTheCurrentHost(t *testing.T) {
 // localPickerStub stands in for a picker that is never called.
 func localPickerStub(entries []SessionEntry, _ *os.File) (SessionChoice, error) {
 	return SessionChoice{}, nil
+}
+
+// TestStopStdinReleasesTheTerminal covers the hand-back that makes an
+// attach client survivable.
+//
+// A goroutine parked in os.Stdin.Read holds the file's read lock, and that
+// lock outlives the client: whoever runs next — the error renderer, which
+// queries the terminal, or the second client started by a cross-host
+// switch — blocks behind it, or has its keystrokes stolen by it. The
+// symptoms were a hang with a blank screen after any failed attach, and a
+// completely deaf terminal after Ctrl-] w.
+func TestStopStdinReleasesTheTerminal(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	realStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = realStdin; _ = r.Close() }()
+
+	conn := newClientConn(struct {
+		io.Reader
+		io.Writer
+	}{Reader: strings.NewReader(""), Writer: io.Discard})
+	conn.readStdin()
+
+	if _, err := w.Write([]byte("a")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	select {
+	case chunk := <-conn.stdinCh:
+		if string(chunk) != "a" {
+			t.Fatalf("read %q, want %q", chunk, "a")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the terminal reader delivered nothing")
+	}
+
+	conn.stopStdin()
+
+	// The reader is gone, so a later reader on the same terminal gets the
+	// next keystroke — and, crucially, gets it at all.
+	if _, err := w.Write([]byte("b")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := make(chan string, 1)
+	go func() {
+		buf := make([]byte, 1)
+		if n, rerr := os.Stdin.Read(buf); rerr == nil && n == 1 {
+			got <- string(buf[:n])
+		}
+	}()
+	select {
+	case s := <-got:
+		if s != "b" {
+			t.Fatalf("second reader saw %q, want %q", s, "b")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("stdin was never handed back: the cancelled reader still owns it")
+	}
 }

--- a/internal/daemon/client_attach_test.go
+++ b/internal/daemon/client_attach_test.go
@@ -351,7 +351,7 @@ func TestStopStdinReleasesTheTerminal(t *testing.T) {
 		io.Reader
 		io.Writer
 	}{Reader: strings.NewReader(""), Writer: io.Discard})
-	conn.readStdin()
+	conn.readStdin(t.Context())
 
 	if _, err := w.Write([]byte("a")); err != nil {
 		t.Fatalf("write: %v", err)
@@ -412,7 +412,7 @@ func TestStopStdinWithNobodyReading(t *testing.T) {
 		io.Reader
 		io.Writer
 	}{Reader: strings.NewReader(""), Writer: io.Discard})
-	conn.readStdin()
+	conn.readStdin(t.Context())
 
 	// Overrun the channel with nobody receiving, so the reader is parked
 	// on a send when the client tears down.
@@ -468,5 +468,43 @@ func TestStayOnCurrentNeverSpawnsASession(t *testing.T) {
 				t.Fatalf("staying put on host %q was read as a switch to %q", host, sw.Host)
 			}
 		})
+	}
+}
+
+// TestReadStdinReleasesTheTerminalOnCancel checks that cancelling the
+// client's context hands the terminal back on its own.
+//
+// The client also stops the reader when it unwinds, but that can trail the
+// cancellation: an in-flight attach or session list waits out a fixed
+// timeout, not the context, so the terminal would stay captured for
+// seconds after the caller gave up on it.
+func TestReadStdinReleasesTheTerminalOnCancel(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	realStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = realStdin; _ = r.Close() }()
+
+	conn := newClientConn(struct {
+		io.Reader
+		io.Writer
+	}{Reader: strings.NewReader(""), Writer: io.Discard})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	conn.readStdin(ctx)
+
+	// The reader is parked on the terminal with nothing to read, which is
+	// the state cancellation has to break.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-conn.stdinDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("a cancelled context did not release the terminal")
 	}
 }

--- a/internal/daemon/client_attach_test.go
+++ b/internal/daemon/client_attach_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"io"
 	"net"
 	"os"
@@ -298,7 +299,7 @@ func TestChooseSessionTagsChoicesWithTheCurrentHost(t *testing.T) {
 	for _, host := range []string{"", "violet"} {
 		t.Run("host="+host, func(t *testing.T) {
 			forceNew := AttachOptions{Host: host, ForceNew: true, Pick: nil}
-			choice, err := chooseSession(nil, forceNew)
+			choice, err := chooseSession(t.Context(), nil, forceNew)
 			if err != nil {
 				t.Fatalf("chooseSession: %v", err)
 			}
@@ -307,7 +308,7 @@ func TestChooseSessionTagsChoicesWithTheCurrentHost(t *testing.T) {
 			}
 
 			direct := AttachOptions{Host: host, Target: 7, Pick: localPickerStub}
-			choice, err = chooseSession(nil, direct)
+			choice, err = chooseSession(t.Context(), nil, direct)
 			if err != nil {
 				t.Fatalf("chooseSession: %v", err)
 			}
@@ -322,7 +323,7 @@ func TestChooseSessionTagsChoicesWithTheCurrentHost(t *testing.T) {
 }
 
 // localPickerStub stands in for a picker that is never called.
-func localPickerStub(entries []SessionEntry, _ *os.File) (SessionChoice, error) {
+func localPickerStub(_ context.Context, entries []SessionEntry, _ *os.File) (SessionChoice, error) {
 	return SessionChoice{}, nil
 }
 
@@ -428,5 +429,44 @@ func TestStopStdinWithNobodyReading(t *testing.T) {
 	case <-done:
 	case <-time.After(3 * time.Second):
 		t.Fatal("stopStdin deadlocked on a reader parked mid-send")
+	}
+}
+
+// TestStayOnCurrentNeverSpawnsASession covers the choice made when a user
+// dismisses a session picker.
+//
+// The switch loop reuses the choice that opened the picker, and for a
+// client started with --new that choice is 0 — which the daemon reads as
+// "spawn a session". Pressing Ctrl-] s and then Esc therefore answered a
+// dismissed picker with a brand new session, abandoning the one the user
+// was working in and leaving an empty session behind on the daemon.
+func TestStayOnCurrentNeverSpawnsASession(t *testing.T) {
+	for _, host := range []string{"", "violet"} {
+		t.Run("host="+host, func(t *testing.T) {
+			conn := newClientConn(struct {
+				io.Reader
+				io.Writer
+			}{Reader: strings.NewReader(""), Writer: io.Discard})
+			opts := AttachOptions{Host: host}
+
+			// The client began with --new, so the choice that opened the
+			// picker is the "spawn one" sentinel.
+			opened := SessionChoice{ID: 0, Host: host}
+			conn.setCurrent(4) // ...and the daemon assigned session 4
+
+			stay := stayOnCurrent(conn, opts)
+
+			if stay.ID == opened.ID {
+				t.Fatal("a dismissed picker reattached the --new sentinel: this spawns a second session")
+			}
+			if stay.ID != 4 {
+				t.Fatalf("stay.ID = %d, want the current session 4", stay.ID)
+			}
+			// The choice must stay on this daemon, or the switch loop
+			// reads it as a cross-host hop.
+			if sw := hostSwitch(opts, stay); sw != nil {
+				t.Fatalf("staying put on host %q was read as a switch to %q", host, sw.Host)
+			}
+		})
 	}
 }

--- a/internal/daemon/client_attach_test.go
+++ b/internal/daemon/client_attach_test.go
@@ -387,3 +387,46 @@ func TestStopStdinReleasesTheTerminal(t *testing.T) {
 		t.Fatal("stdin was never handed back: the cancelled reader still owns it")
 	}
 }
+
+// TestStopStdinWithNobodyReading covers the shutdown path taken after the
+// session pump has already gone.
+//
+// The reader forwards keystrokes into a buffered channel. Once the pump
+// stops, nothing drains it, so a reader that cannot abandon a send parks
+// there for good — and stopStdin, which waits for the reader to leave
+// before closing it, would wait forever. Anything typed between the last
+// frame and the client's exit lands in exactly that window.
+func TestStopStdinWithNobodyReading(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	realStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = realStdin; _ = r.Close() }()
+
+	conn := newClientConn(struct {
+		io.Reader
+		io.Writer
+	}{Reader: strings.NewReader(""), Writer: io.Discard})
+	conn.readStdin()
+
+	// Overrun the channel with nobody receiving, so the reader is parked
+	// on a send when the client tears down.
+	for range cap(conn.stdinCh) * 3 {
+		if _, werr := w.Write([]byte("x")); werr != nil {
+			t.Fatalf("write: %v", werr)
+		}
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	done := make(chan struct{})
+	go func() { conn.stopStdin(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("stopStdin deadlocked on a reader parked mid-send")
+	}
+}

--- a/internal/daemon/client_attach_test.go
+++ b/internal/daemon/client_attach_test.go
@@ -367,7 +367,9 @@ func TestStopStdinReleasesTheTerminal(t *testing.T) {
 		t.Fatal("the terminal reader delivered nothing")
 	}
 
-	conn.stopStdin()
+	if !conn.stopStdin() {
+		t.Fatal("stopStdin reported the terminal was not released")
+	}
 
 	// The reader is gone, so a later reader on the same terminal gets the
 	// next keystroke — and, crucially, gets it at all.
@@ -566,3 +568,52 @@ func TestReadStdinRefusesAnUncancellableTerminal(t *testing.T) {
 	default:
 	}
 }
+
+// TestStopStdinReportsAnUnreleasedTerminal covers the case where the
+// reader cannot be cancelled.
+//
+// Cancel is not guaranteed: cancelreader's fallback reader always refuses,
+// and the Windows one gives up when a read is wedged. stopStdin used to
+// return nothing, so the client handed the terminal on regardless — and a
+// cross-host switch would then start a second client whose keystrokes all
+// went to the first one's reader, which is the exact bug this path exists
+// to prevent, in its hardest-to-diagnose form.
+func TestStopStdinReportsAnUnreleasedTerminal(t *testing.T) {
+	conn := newClientConn(struct {
+		io.Reader
+		io.Writer
+	}{Reader: strings.NewReader(""), Writer: io.Discard})
+
+	// A reader that refuses to cancel and never finishes, which is what a
+	// wedged terminal looks like from here.
+	conn.stdinReader = stubbornReader{}
+
+	start := time.Now()
+	if conn.stopStdin() {
+		t.Fatal("stopStdin claimed a terminal it never got back")
+	}
+	if elapsed := time.Since(start); elapsed < time.Second {
+		t.Fatalf("stopStdin gave up after %s: it must wait for the reader before deciding", elapsed)
+	}
+
+	// Every caller must get the same answer, and none may hang: the
+	// result is decided once and shared.
+	second := make(chan bool, 1)
+	go func() { second <- conn.stopStdin() }()
+	select {
+	case got := <-second:
+		if got {
+			t.Fatal("a second caller was told the terminal was released")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("a second stopStdin call blocked")
+	}
+}
+
+// stubbornReader is a CancelReader that cannot be cancelled, standing in
+// for a terminal whose read is wedged.
+type stubbornReader struct{}
+
+func (stubbornReader) Read([]byte) (int, error) { select {} }
+func (stubbornReader) Cancel() bool             { return false }
+func (stubbornReader) Close() error             { return nil }

--- a/internal/daemon/client_attach_test.go
+++ b/internal/daemon/client_attach_test.go
@@ -351,7 +351,9 @@ func TestStopStdinReleasesTheTerminal(t *testing.T) {
 		io.Reader
 		io.Writer
 	}{Reader: strings.NewReader(""), Writer: io.Discard})
-	conn.readStdin(t.Context())
+	if rerr := conn.readStdin(t.Context()); rerr != nil {
+		t.Fatalf("readStdin: %v", rerr)
+	}
 
 	if _, err := w.Write([]byte("a")); err != nil {
 		t.Fatalf("write: %v", err)
@@ -412,7 +414,9 @@ func TestStopStdinWithNobodyReading(t *testing.T) {
 		io.Reader
 		io.Writer
 	}{Reader: strings.NewReader(""), Writer: io.Discard})
-	conn.readStdin(t.Context())
+	if rerr := conn.readStdin(t.Context()); rerr != nil {
+		t.Fatalf("readStdin: %v", rerr)
+	}
 
 	// Overrun the channel with nobody receiving, so the reader is parked
 	// on a send when the client tears down.
@@ -495,7 +499,9 @@ func TestReadStdinReleasesTheTerminalOnCancel(t *testing.T) {
 	}{Reader: strings.NewReader(""), Writer: io.Discard})
 
 	ctx, cancel := context.WithCancel(t.Context())
-	conn.readStdin(ctx)
+	if rerr := conn.readStdin(ctx); rerr != nil {
+		t.Fatalf("readStdin: %v", rerr)
+	}
 
 	// The reader is parked on the terminal with nothing to read, which is
 	// the state cancellation has to break.
@@ -506,5 +512,57 @@ func TestReadStdinReleasesTheTerminalOnCancel(t *testing.T) {
 	case <-conn.stdinDone:
 	case <-time.After(3 * time.Second):
 		t.Fatal("a cancelled context did not release the terminal")
+	}
+}
+
+// TestReadStdinRefusesAnUncancellableTerminal covers the setup failure
+// branch.
+//
+// The client's whole terminal-safety story rests on the reader being
+// stoppable: stopStdin cancels it so the next caller can have stdin back.
+// A fallback to reading os.Stdin directly would look like it worked and
+// then quietly strand the terminal, because stopStdin has nothing to
+// cancel and returns having released nothing. readStdin must refuse
+// instead, so the failure is visible rather than a hang later on.
+//
+// A regular file stands in for a terminal the cancel reader cannot take:
+// epoll rejects it, which is exactly the error path under test.
+func TestReadStdinRefusesAnUncancellableTerminal(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "not-a-terminal-*")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	realStdin := os.Stdin
+	os.Stdin = f
+	defer func() { os.Stdin = realStdin }()
+
+	conn := newClientConn(struct {
+		io.Reader
+		io.Writer
+	}{Reader: strings.NewReader(""), Writer: io.Discard})
+
+	if rerr := conn.readStdin(t.Context()); rerr == nil {
+		t.Fatal("readStdin accepted a terminal it cannot cancel: the reader would strand stdin")
+	}
+	if conn.stdinReader != nil {
+		t.Fatal("a failed setup must not leave a reader behind")
+	}
+
+	// The failure must leave nothing running, and stopStdin must stay safe
+	// to call: the caller cannot know how far setup got.
+	done := make(chan struct{})
+	go func() { conn.stopStdin(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stopStdin blocked after a failed readStdin")
+	}
+
+	select {
+	case <-conn.stdinCh:
+		t.Fatal("a failed readStdin still started a reader goroutine")
+	default:
 	}
 }

--- a/internal/daemon/local.go
+++ b/internal/daemon/local.go
@@ -254,8 +254,8 @@ func RunLocal(ctx context.Context, opts AttachOptions) error {
 // ListLocalSessions reports the local daemon's live sessions without
 // attaching. Returns ErrNoLocalDaemon when nothing is running, so a caller
 // can distinguish "no daemon" from "a daemon with no sessions".
-func ListLocalSessions() ([]SessionEntry, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+func ListLocalSessions(ctx context.Context) ([]SessionEntry, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	conn, err := DialLocal(ctx)
 	if err != nil {

--- a/internal/daemon/local_windows.go
+++ b/internal/daemon/local_windows.go
@@ -44,4 +44,4 @@ func StartLocalDaemon(context.Context) error { return ErrNoLocalDaemon }
 func RunLocal(context.Context, AttachOptions) error { return ErrNoLocalDaemon }
 
 // ListLocalSessions is unsupported on Windows.
-func ListLocalSessions() ([]SessionEntry, error) { return nil, ErrNoLocalDaemon }
+func ListLocalSessions(context.Context) ([]SessionEntry, error) { return nil, ErrNoLocalDaemon }

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -253,6 +253,14 @@ func (s *remoteSession) resizeClient(wire uint32, ws winSize) winSize {
 	return minSizeLocked(s.clients)
 }
 
+// minSize reports the size the PTY is held at: the smallest attached
+// client's window, or the zero size when none has reported one.
+func (s *remoteSession) minSize() winSize {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return minSizeLocked(s.clients)
+}
+
 // clientIDs snapshots the attached wire ids.
 func (s *remoteSession) clientIDs() []uint32 {
 	s.mu.Lock()
@@ -479,9 +487,15 @@ func (t *sessionTable) detachWire(wire uint32) {
 	if sess == nil {
 		return
 	}
-	if _, remaining := sess.detachClient(wire); remaining == 0 {
+	if next, remaining := sess.detachClient(wire); remaining == 0 {
 		log.Info("session detached", "session_id", logical)
 	} else {
+		// The PTY is held at the smallest attached client's size, so a
+		// client leaving can widen it. Without this the session stays
+		// squeezed into a window that is no longer watching it, and the
+		// clients still attached keep drawing into a corner of their
+		// terminals until they happen to resize one.
+		sess.applySize(next)
 		log.Info("client left shared session", "session_id", logical, "remaining", remaining)
 	}
 }
@@ -506,15 +520,22 @@ func (t *sessionTable) killAll() {
 	}
 }
 
+// applySize sets the session's PTY to ws, if it names a real size.
+//
+// The zero size means no attached client has reported one yet, and the
+// PTY is left at its default rather than resized to nothing.
+func (s *remoteSession) applySize(ws winSize) {
+	if ws.cols == 0 || ws.rows == 0 || s.ptmx == nil {
+		return
+	}
+	_ = pty.Setsize(s.ptmx, &pty.Winsize{Cols: uint16(ws.cols), Rows: uint16(ws.rows)})
+}
+
 // applyResize records one client's size and applies the minimum across all
 // attached clients to the PTY — the shared-view equivalent of tmux picking
 // the smallest window.
 func (s *remoteSession) applyResize(wire uint32, cols, rows int) {
-	next := s.resizeClient(wire, winSize{cols, rows})
-	if next.cols == 0 || next.rows == 0 {
-		return // nobody has reported a real size yet
-	}
-	_ = pty.Setsize(s.ptmx, &pty.Winsize{Cols: uint16(next.cols), Rows: uint16(next.rows)})
+	s.applySize(s.resizeClient(wire, winSize{cols, rows}))
 }
 
 // handleClipboardChunk consumes one client clipboard frame. Chunked image
@@ -835,10 +856,14 @@ func (t *sessionTable) attachSession(wire uint32, payload []byte) {
 		sess := t.sessions[requested]
 		if sess != nil {
 			// A wire id drives at most one session: drop any previous
-			// binding first (that session keeps running detached).
+			// binding first (that session keeps running detached, and
+			// regains the room this client was taking from it).
 			if prev, had := t.wireMap[wire]; had && prev != requested {
 				if ps := t.sessions[prev]; ps != nil {
-					ps.detachClient(wire)
+					left, remaining := ps.detachClient(wire)
+					if remaining > 0 {
+						ps.applySize(left)
+					}
 				}
 			}
 			t.wireMap[wire] = requested

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"encoding/binary"
 	"io"
 	"os"
 	"os/exec"
@@ -8,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/creack/pty"
 )
 
 // fakeSessionChild starts a long-running process that looks exactly like a
@@ -340,4 +343,104 @@ func TestTerminateProcessEndsAChild(t *testing.T) {
 		_ = cmd.Process.Kill()
 		t.Fatal("terminateProcess did not end the child")
 	}
+}
+
+// TestSharedSessionRegrowsWhenTheSmallestClientLeaves covers the PTY size
+// of a shared session when a client goes away.
+//
+// The PTY is held at the smallest attached client's window, so a session
+// watched by a 110x32 terminal and a 70x20 one runs at 70x20. When the
+// small client leaves, the PTY must grow back: the new minimum was
+// computed and then thrown away, so the session stayed squeezed into a
+// window that was no longer watching it and the remaining terminal drew
+// into a corner of itself, with no way out but resizing it by hand.
+//
+// The size is read back from a real pty, because that is where the bug
+// was: the client bookkeeping was correct all along.
+func TestSharedSessionRegrowsWhenTheSmallestClientLeaves(t *testing.T) {
+	big := winSize{110, 32}
+	small := winSize{70, 20}
+
+	// ptySession is a session backed by a real pty, so Setsize is
+	// observable. The size starts at the shared minimum, as if both
+	// clients had already reported.
+	ptySession := func(t *testing.T, table *sessionTable, id uint64, wires map[uint32]winSize) *remoteSession {
+		t.Helper()
+		ptmx, tty, err := pty.Open()
+		if err != nil {
+			t.Skipf("no pty available: %v", err)
+		}
+		t.Cleanup(func() { _ = tty.Close(); _ = ptmx.Close() })
+
+		sess := table.fakeSession(id)
+		sess.ptmx = ptmx
+		table.mu.Lock()
+		for wire := range wires {
+			table.wireMap[wire] = id
+		}
+		table.mu.Unlock()
+		for wire, ws := range wires {
+			sess.attachClient(wire, ws)
+		}
+		sess.applySize(sess.minSize())
+		return sess
+	}
+
+	sizeOf := func(t *testing.T, sess *remoteSession) winSize {
+		t.Helper()
+		ws, err := pty.GetsizeFull(sess.ptmx)
+		if err != nil {
+			t.Fatalf("pty size: %v", err)
+		}
+		return winSize{int(ws.Cols), int(ws.Rows)}
+	}
+
+	const bigWire, smallWire uint32 = 1, 2
+
+	t.Run("detach", func(t *testing.T) {
+		table := newTestTable(t)
+		sess := ptySession(t, table, 1, map[uint32]winSize{bigWire: big, smallWire: small})
+		if got := sizeOf(t, sess); got != small {
+			t.Fatalf("shared size = %+v, want the smaller client's %+v", got, small)
+		}
+
+		table.detachWire(smallWire)
+
+		if got := sizeOf(t, sess); got != big {
+			t.Fatalf("pty after the small client left = %+v, want %+v", got, big)
+		}
+	})
+
+	t.Run("switch away", func(t *testing.T) {
+		table := newTestTable(t)
+		left := ptySession(t, table, 1, map[uint32]winSize{bigWire: big, smallWire: small})
+		table.fakeSession(2)
+
+		// The small client moves to session 2; session 1 keeps the big one.
+		table.attachSession(smallWire, encodeSessionID(2))
+
+		if got := sizeOf(t, left); got != big {
+			t.Fatalf("pty after the small client switched away = %+v, want %+v", got, big)
+		}
+	})
+
+	t.Run("last client leaves", func(t *testing.T) {
+		table := newTestTable(t)
+		sess := ptySession(t, table, 1, map[uint32]winSize{smallWire: small})
+
+		table.detachWire(smallWire)
+
+		// Nobody is watching, so there is no size to apply: the pty keeps
+		// its last one until the next client reports its window.
+		if got := sizeOf(t, sess); got != small {
+			t.Fatalf("pty with no clients = %+v, want it left at %+v", got, small)
+		}
+	})
+}
+
+// encodeSessionID builds an attach payload for the given logical id.
+func encodeSessionID(id uint64) []byte {
+	p := make([]byte, 8)
+	binary.BigEndian.PutUint64(p, id)
+	return p
 }

--- a/internal/daemon/tunnel.go
+++ b/internal/daemon/tunnel.go
@@ -82,6 +82,12 @@ func StartTunnel(ctx context.Context, opts TunnelOptions) (*Tunnel, error) {
 		return nil, err
 	}
 	cmd := exec.CommandContext(ctx, bin, append([]string{opts.Mode}, opts.Args...)...)
+	// Tie the sidecar's life to ours. Close() ends it in the normal case,
+	// but a daemon that is killed outright never runs Close, and an
+	// orphaned sidecar keeps serving the daemon's iroh endpoint: the next
+	// daemon then publishes the same node id from a second process and
+	// remote clients reach a sidecar with nothing behind it.
+	cmd.SysProcAttr = applyChildDeathSignal(cmd.SysProcAttr)
 	if len(opts.Env) > 0 {
 		cmd.Env = append(os.Environ(), opts.Env...)
 	}

--- a/internal/ui/session_picker.go
+++ b/internal/ui/session_picker.go
@@ -49,11 +49,8 @@ type sessionPickerModel struct {
 	quitting  bool
 	cancelled bool
 	title     string
-	// keepAlt leaves the alternate screen on for the final render, for a
-	// caller that entered it itself and is still using it.
-	keepAlt bool
-	width   int
-	height  int
+	width     int
+	height    int
 }
 
 func (m *sessionPickerModel) Init() tea.Cmd { return nil }
@@ -97,14 +94,16 @@ func (m *sessionPickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m *sessionPickerModel) View() tea.View {
 	if m.cancelled || m.quitting {
-		// Leave alt screen on the final render so the terminal returns to
-		// the normal buffer cleanly (see dirPickerModel.View) — unless the
-		// caller owns it. The attach client enters the alternate screen
-		// for the whole attachment and keeps rendering the session there
-		// after the picker exits, so emitting the mode-1049 exit sequence
-		// here would drop the caller's screen too.
+		// Leave the alternate screen on the final render so the terminal
+		// returns to the normal buffer cleanly (see dirPickerModel.View).
+		//
+		// A caller that owns the alt screen itself does not get to keep it
+		// either way: Bubble Tea restores whatever screen state it entered
+		// when the program shuts down, so holding the alt screen for this
+		// last frame only moves the exit sequence later. The attach client
+		// re-enters the alt screen after the picker returns.
 		v := tea.NewView("")
-		v.AltScreen = m.keepAlt
+		v.AltScreen = false
 		v.MouseMode = tea.MouseModeNone
 		return v
 	}
@@ -207,15 +206,16 @@ func buildRows(entries []SessionEntry) []pickerRow {
 // RunSessionPicker shows the live sessions and lets the user attach to one
 // or start a new session.
 //
-// keepAltScreen tells the picker that the caller already owns the
-// alternate screen and will keep using it, so the picker must not leave it
-// on exit.
-func RunSessionPicker(entries []SessionEntry, input *os.File, title string, keepAltScreen bool) (SessionPick, error) {
+// The picker owns the alternate screen while it runs and leaves it when it
+// exits. A caller that was in the alt screen itself must re-enter it
+// afterwards; Bubble Tea restores the screen state on shutdown, so the
+// picker cannot hand it over.
+func RunSessionPicker(entries []SessionEntry, input *os.File, title string) (SessionPick, error) {
 	if title == "" {
 		title = "Live sessions"
 	}
 	rows := buildRows(entries)
-	m := &sessionPickerModel{rows: rows, title: title, keepAlt: keepAltScreen}
+	m := &sessionPickerModel{rows: rows, title: title}
 	// Start on the first selectable row, which is a header when grouped.
 	for i, r := range rows {
 		if r.selectable {

--- a/internal/ui/session_picker.go
+++ b/internal/ui/session_picker.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -206,11 +207,15 @@ func buildRows(entries []SessionEntry) []pickerRow {
 // RunSessionPicker shows the live sessions and lets the user attach to one
 // or start a new session.
 //
+// ctx cancels the picker: it blocks in the Bubble Tea run loop, which the
+// caller cannot interrupt any other way. Cancellation ends it as if the
+// user had pressed Esc, so the terminal is restored on the way out.
+//
 // The picker owns the alternate screen while it runs and leaves it when it
 // exits. A caller that was in the alt screen itself must re-enter it
 // afterwards; Bubble Tea restores the screen state on shutdown, so the
 // picker cannot hand it over.
-func RunSessionPicker(entries []SessionEntry, input *os.File, title string) (SessionPick, error) {
+func RunSessionPicker(ctx context.Context, entries []SessionEntry, input *os.File, title string) (SessionPick, error) {
 	if title == "" {
 		title = "Live sessions"
 	}
@@ -232,9 +237,38 @@ func RunSessionPicker(entries []SessionEntry, input *os.File, title string) (Ses
 		opts = append(opts, tea.WithInput(input))
 	}
 	prog := tea.NewProgram(m, opts...)
+
+	// Cancellation quits the program the same way Esc does, rather than
+	// through tea.WithContext. WithContext kills the program: it skips the
+	// final render, so the alt screen and the terminal modes are left as
+	// the picker had them — the very state this picker is careful to
+	// restore. (It also races its own input reader on that path.) Quit
+	// runs the ordinary shutdown, so the caller gets its terminal back.
+	stopWatch := make(chan struct{})
+	defer close(stopWatch)
+	go func() {
+		select {
+		case <-ctx.Done():
+			prog.Quit()
+		case <-stopWatch:
+		}
+	}()
+
 	final, err := prog.Run()
 	if err != nil {
+		// A cancelled context is the caller shutting the client down, not
+		// a picker failure: report it as the cancellation it is so the
+		// caller does not print a picker error on its way out.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return SessionPick{Cancelled: true}, ctxErr
+		}
 		return SessionPick{Cancelled: true}, fmt.Errorf("session picker: %w", err)
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		// Quit on cancellation ends the program cleanly, so Run returns no
+		// error. Report the cancellation rather than the empty choice it
+		// would otherwise look like.
+		return SessionPick{Cancelled: true}, ctxErr
 	}
 	sp, ok := final.(*sessionPickerModel)
 	if !ok {

--- a/internal/ui/session_picker_test.go
+++ b/internal/ui/session_picker_test.go
@@ -1,8 +1,12 @@
 package ui
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
+
+	"github.com/creack/pty"
 )
 
 // TestSessionPickerLeavesTheAltScreen pins the exit contract of the picker.
@@ -62,5 +66,49 @@ func TestSessionPickerGroupsByHost(t *testing.T) {
 	}
 	if len(headers) != 2 || headers[0] != "this machine" || headers[1] != "mev" {
 		t.Fatalf("headers = %v, want [this machine mev]", headers)
+	}
+}
+
+// TestSessionPickerHonoursCancellation checks that a cancelled context ends
+// the picker.
+//
+// The picker blocks in the Bubble Tea run loop reading a terminal. Inside
+// an attached client that terminal is in raw mode, so the caller cannot
+// interrupt it with a signal, and without a context the picker would hold
+// the client open for as long as the user left it on screen. The session
+// loop around it already honours cancellation, so the picker must too.
+func TestSessionPickerHonoursCancellation(t *testing.T) {
+	// A pty gives the picker a real terminal to open without a keystroke
+	// ever arriving, which is the state cancellation has to break out of.
+	ptmx, tty, err := pty.Open()
+	if err != nil {
+		t.Skipf("no pty available: %v", err)
+	}
+	// Only the master is closed here: Bubble Tea takes ownership of the
+	// input file and closes it during shutdown, so closing it from this
+	// goroutine too would race that shutdown. The real caller closes its
+	// pty after the picker has fully returned, which is ordered.
+	defer func() { _ = ptmx.Close() }()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	entries := []SessionEntry{{ID: 1, Started: time.Now()}}
+
+	done := make(chan error, 1)
+	go func() {
+		_, rerr := RunSessionPicker(ctx, entries, tty, "Live sessions")
+		done <- rerr
+	}()
+
+	// Let the program reach its run loop before pulling the context.
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	select {
+	case rerr := <-done:
+		if !errors.Is(rerr, context.Canceled) {
+			t.Fatalf("picker error = %v, want context.Canceled", rerr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("a cancelled context did not end the picker")
 	}
 }

--- a/internal/ui/session_picker_test.go
+++ b/internal/ui/session_picker_test.go
@@ -1,0 +1,66 @@
+package ui
+
+import (
+	"testing"
+	"time"
+)
+
+// TestSessionPickerLeavesTheAltScreen pins the exit contract of the picker.
+//
+// Bubble Tea restores the screen state it entered when the program shuts
+// down: a final view that still claims the alternate screen makes the
+// runtime emit the exit sequence AFTER the last frame, which drops the alt
+// screen of whatever started the picker. The attach client used to lose
+// its screen that way, and every following frame of the session was drawn
+// into the shell's scrollback instead.
+//
+// The picker therefore always leaves the alternate screen itself, and the
+// attach client re-enters it (see daemon.runPicker).
+func TestSessionPickerLeavesTheAltScreen(t *testing.T) {
+	m := &sessionPickerModel{
+		rows:   buildRows([]SessionEntry{{ID: 1, Started: time.Now()}}),
+		title:  "Live sessions",
+		width:  80,
+		height: 24,
+	}
+
+	if v := m.View(); !v.AltScreen {
+		t.Fatal("a running picker must own the alternate screen")
+	}
+
+	m.quitting = true
+	if v := m.View(); v.AltScreen {
+		t.Fatal("the final frame must leave the alternate screen")
+	}
+
+	m.quitting, m.cancelled = false, true
+	if v := m.View(); v.AltScreen {
+		t.Fatal("a cancelled picker must leave the alternate screen")
+	}
+}
+
+// TestSessionPickerGroupsByHost checks that sessions from several daemons
+// are labelled, and that the local daemon (empty host) is named rather
+// than shown under a blank heading.
+func TestSessionPickerGroupsByHost(t *testing.T) {
+	rows := buildRows([]SessionEntry{
+		{ID: 1, Host: ""},
+		{ID: 1, Host: "mev"},
+	})
+
+	var headers []string
+	selectable := 0
+	for _, r := range rows {
+		if r.selectable {
+			selectable++
+			continue
+		}
+		headers = append(headers, r.header)
+	}
+	if selectable != 3 { // two sessions plus "start a new session"
+		t.Fatalf("selectable rows = %d, want 3", selectable)
+	}
+	if len(headers) != 2 || headers[0] != "this machine" || headers[1] != "mev" {
+		t.Fatalf("headers = %v, want [this machine mev]", headers)
+	}
+}

--- a/www/pages/advanced/remote-sessions.md
+++ b/www/pages/advanced/remote-sessions.md
@@ -103,7 +103,10 @@ Kit makes that boundary predictable rather than leaving it to chance:
   so systemd signals the daemon rather than every session at once.
 - On a hard crash (`SIGKILL`, a panic, the OOM killer) the kernel kills
   each session child immediately, through the parent-death signal armed
-  when it was spawned.
+  when it was spawned. The `kit-tunnel` sidecar carries the same signal,
+  so a crashed daemon can never leave a process serving its iroh endpoint
+  behind — the next daemon would otherwise share its node id with a
+  ghost.
 - On the next start, the daemon sweeps any session recorded by a previous
   run that is somehow still alive, and clears its scratch files.
 
@@ -134,8 +137,17 @@ through a session. `Ctrl+X d` still detaches, for compatibility.
 
 `Ctrl+] d` **detaches**: your terminal returns to the local shell and the
 session keeps running on the host — type `/quit` inside the session to end
-it for good. Detached sessions are listed on the next connect, so you can
-pick up exactly where you left off.
+it for good. The parting message names the session (`kit attach 3`, or
+`kit attach --host mev 3`), so reattaching is a copy away. Detached
+sessions are listed on the next connect, so you can pick up exactly where
+you left off.
+
+`Ctrl+] w` lists every **other** daemon: the paired hosts when you are on
+this machine, and the paired hosts plus this machine when you are on a
+remote one. There is always a way back home. Hosts are queried in
+parallel, so one sleeping laptop no longer holds up the list; hosts that
+do not answer within eight seconds are dropped from it, and `kit ls --all`
+names them.
 
 Several clients can also **attach to the same session** (tmux-style shared
 view): every attached terminal mirrors the same screen, keystrokes from any


### PR DESCRIPTION
Five faults in the local and remote daemon modes of v0.101.0, found by driving `kit attach` and `kit remote` through tmux against a local daemon and a paired host (`mev`, running `kit daemon` as a systemd user service).

## What was broken

### 1. A failed attach hung the terminal, unkillable

```
$ kit attach 999      # any id that is not live
<blank screen, no message, Ctrl-C does nothing, forever>
```

`clientConn.readStdin` starts a goroutine in `os.Stdin.Read` and nothing ever stops it. A goroutine parked in `Read` holds the file's read lock, so the error renderer — which queries the terminal's background colour before printing — blocked on the same fd. Stack of the wedged process:

```
main.main → fang.Execute → lipgloss.HasDarkBackground → queryTerminal
  → os.(*File).Read → internal/poll.(*FD).readLock  [semacquire]
```

### 2. Any cross-host switch left the terminal deaf

The session renders (the clock in the status bar keeps ticking) but **no keystroke ever arrives**: not text, not `Ctrl-] s`, not even `Ctrl-] d`. A switch starts a second client with a second reader, and the first one — still parked on stdin — won the race for every keystroke and posted it to a dead connection. The only way out was to kill the process from another terminal.

Two ways in, and the second needs no chord at all:

```
# a) the multiplexer chord
Ctrl-] w  →  pick a session on another host  →  terminal is deaf

# b) plain `kit attach`, from the picker it opens itself
$ kit attach
  Live sessions
  this machine
    session 1 — detached · /home/user
  mev
  ▸ session 1 — detached · /home/user     ← pick this
  →  terminal is deaf
```

Path (b) is the one a user hits first: `kit attach` lists every paired host's sessions in its opening picker, so choosing a remote one is an ordinary first-run action, not an advanced chord. It is reached the same way after detaching a local session and going straight to a remote one, which is how it turned up.

### 3. Every session picker dropped the client's alternate screen

After `Ctrl-] s`, `Ctrl-] w`, or the picker shown at attach time, `tmux display -p '#{alternate_on}'` reported `0` while still attached. From then on the session drew into the shell's normal buffer, and detaching printed the parting message and the shell prompt on top of the session's output:

```
[user@host:~/kit]$ 7s. (tokens: 30 in / 6178 out)
   # Kit Infrastructure Layers
```

Cause: Bubble Tea restores the screen state it entered when the program shuts down. Keeping `AltScreen` on for the final frame (the previous fix) only moved the `1049l` past the last render.

### 4. `Ctrl-] w` had no way home, and listed the current host twice

`HubEntries` was built once from the `--host` flag. Attached to `mev`, the "Sessions across all paired hosts" picker showed only `mev`'s own sessions — this machine was not listed, so a session on the laptop could not be reached from a session on the host. After a switch made from the local daemon, the current host appeared twice instead.

Hosts were also queried one at a time with an eight second timeout each, so one sleeping laptop delayed every picker and `kit ls --all` by eight seconds, silently.

### 5. A shared session never grew back when its smallest client left

Found by running several sessions on one daemon with **mixed clients**: sessions on the host attached from the host's own terminal over the Unix socket, from a paired machine over iroh, and by both at once.

The PTY of a shared session is held at the smallest attached client's window, which is right while they are all watching. `detachClient` computes the new minimum when a client leaves — and the caller throws it away:

```go
if _, remaining := sess.detachClient(wire); remaining == 0 {   // size discarded
```

So a session shared by a 110x32 terminal and a 70x20 one stayed at **70x20 after the small client detached**, and the terminal still watching kept drawing into a corner of itself with no way out but resizing the window by hand. `Ctrl-] s` away from a shared session did the same to the session left behind.

```
mev, 110x32 terminal, sharing with a 70x20 remote client:
  row 20:  ~/Workspace · thinking: medium    anthropic · claude-opus-5 · 0
remote client detaches — 12 rows and 40 columns stay dead:
  row 20:  ~/Workspace · thinking: medium    anthropic · claude-opus-5 · 0
```

### 6. A crashed daemon left its iroh endpoint served by a ghost

```
$ kill -9 $(pgrep -f 'kit daemon')
$ pgrep -af kit-tunnel
2725145 kit-tunnel serve --timeout 30      # still there, minutes later
$ kit daemon &                              # start a fresh one
$ pgrep -af kit-tunnel
2725145 kit-tunnel serve --timeout 30      # ghost
2725903 kit-tunnel serve --timeout 30      # new daemon — same node id
```

`Tunnel.Close` handles the orderly path, but a daemon that is killed never runs it. Session children already carried `Pdeathsig`; the sidecar did not.

## The fixes

- **Cancellable terminal reader** (`internal/daemon/client_attach.go`): stdin is read through `muesli/cancelreader`, and `RunClient` cancels it on the way out, so the terminal goes back to whoever runs next. Fixes 1 and 2.
- **Alt screen ownership** (`internal/ui/session_picker.go`, `runPicker`): the picker always leaves the alternate screen; the attach client re-enters it afterwards. This no longer depends on Bubble Tea's shutdown behaviour. Fixes 3.
- **Hub built per hop** (`cmd/attach.go`): `otherDaemonSessions` lists the paired hosts except the one the client is attached to, plus the local daemon when the client is elsewhere. Hosts are queried in parallel and the unreachable ones are named (`Skipped unreachable host(s): zora`). Fixes 4.
- **Size recomputed when a client leaves** (`internal/daemon/server.go`): both on detach and on a switch away. With three clients it now steps correctly as each leaves — 70x20, then 90x26, then 110x32 — and a session whose last client leaves keeps its size for the next one. Fixes 5.
- **Parent-death signal on the sidecar** (`internal/daemon/tunnel.go`). Fixes 6.
- Message fixes from the same run: a refused attach names the missing session; the detach hint carries the session id and uses a command line that actually exists (`kit attach --host mev 3`, not `kit remote --host mev 3`); an unreachable host suggests checking that `kit daemon` runs there instead of blaming the network.

## Testing

Two machines, real daemons, tmux-driven:

| Case | Before | After |
|------|--------|-------|
| `kit attach 999` | hangs forever, Ctrl-C dead | `No live session 999 on this daemon — list the live ones with 'kit ls'`, exit 1 |
| `Ctrl-] w` to another host, then type | no input at all, cannot detach | text, chords and detach all work |
| `kit attach` → pick a remote session in the opening picker | no input at all, cannot detach, needs an external kill | attaches and accepts input |
| local session → detach → `kit remote --host mev` → detach → local | worked, but any picker on the way lost the alt screen | clean throughout |
| six alternating local/remote attaches in one terminal | — | every keystroke landed in the right session, no alt-screen leak |
| picker → attached | `alternate_on=0`, scrollback trashed on detach | `alternate_on=1`, clean shell on detach |
| `Ctrl-] w` from a remote session | only that host's sessions | `mev` **and** `this machine`, grouped |
| `kit ls --all` with one host asleep | 8.8 s, host silently missing | 3.2 s, `Skipped unreachable host(s): zora` |
| `kill -9` the daemon | sidecar orphaned indefinitely | daemon, sessions and sidecar all gone |
| shared session, small client detaches | stays squeezed at the departed client's size | grows back to the remaining client's window |
| 3 clients (110x32, 90x26, 70x20), smallest leaves, then next | stuck at 70x20 | 70x20 → 90x26 → 110x32 |
| shared session, one client switches away with `Ctrl-] s` | session left behind stays squeezed | grows back |

Also exercised, unchanged and working: local-then-remote and remote-then-local in one terminal (plain, and with the opening picker cancelled by Esc), pairing (accept, reject, wrong code, client disconnect withdrawing the host's prompt), revoke and reconnect, `--pair` against a closed window, multi-client shared view, resize propagation, `Ctrl-] s/c/n/p`, `Ctrl-] Ctrl-]`, killing a session child, `systemctl --user restart kit-daemon` under an attached client, `kit attach --all`, `kit ls`, `--host` with an unknown name, and a second `kit daemon` refusing to start.

The daemon side was verified on the remote host as well: the built binary served sessions there, and `kill -9` on it took the sidecar and children down with it.

`go test -race ./...` passes; new regression tests cover the stdin hand-back and the picker's alt-screen exit contract.

## Mixed-client testing

Three sessions on the host daemon, driven at once from the host's own terminal and from this machine, in every combination:

- **shared view both ways** — a local host client and a remote client on the same session mirror each other's keystrokes, and the PTY is clamped to the smaller window
- **two simultaneous remote clients** from one machine (separate sidecars) on two different sessions — no cross-talk, each keystroke landed in its own session
- **live resize while shared** — shrinking and growing either client's window resizes the session both ways
- **`Ctrl-] n/p` cycling** with mixed attach states — wraps 2→3→1→2 with correct client counts
- **ending a shared session** with `/quit` releases every attached client with `Session ended.`
- **`kill -9` on a session child** with two clients attached releases both and leaves the other sessions untouched
- **daemon restart** with a local and a remote client attached: the local one exits at once, the remote one after ~25 s (the QUIC timeout — see below), both restoring the terminal
- **hub hop home**: `Ctrl-] w` from a session on the host lists `mev` and `this machine`, and switching back lands input in the local session

## Known limitations, not fixed here

- Cancelling the working-directory picker of a session started with `Ctrl-] c` still returns the client to the shell instead of the session it came from. Ending a session tears the connection down — the sidecar breaks its relay on `BYE` — so a fallback needs a protocol change rather than a client one.
- A **remote** client takes about 25 seconds to notice its daemon has died (a local one is instant), because the sidecar waits out the QUIC idle timeout rather than reacting to the connection closing. The client does recover and restores the terminal properly; shortening it is a change in the Rust sidecar.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote session lists query hosts in parallel and omit hosts that do not respond within eight seconds.
  * Added cross-host session navigation and unavailable-host reporting.
  * Detach messages include the session ID for easier reattachment.
  * Session pickers can be cancelled safely while preserving the current session.
* **Bug Fixes**
  * Improved terminal restoration, alternate-screen handling, and shared-session resizing.
  * Prevented tunnel processes from lingering after unexpected daemon shutdown.
  * Added clearer connection and attachment error messages.
* **Documentation**
  * Expanded remote-session guidance and cross-host navigation instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

