### PR TITLE
core: make the shell configurable and name the tool after it

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A powerful, extensible AI coding agent CLI with multi-provider support, built-in
 ## Features
 
 - **Multi-Provider LLM Support**: Anthropic, OpenAI, Google Gemini, Ollama, Azure OpenAI, AWS Bedrock, OpenRouter, and more
-- **Built-in Core Tools**: bash (with interactive sudo password prompt), read, write, edit, grep, find, ls, subagent - no MCP overhead
+- **Built-in Core Tools**: shell (configurable shell, bash by default, with interactive sudo password prompt), read, write, edit, grep, find, ls, subagent - no MCP overhead
 - **Named Agents**: Reusable subagent presets defined in markdown with per-agent tool allowlists, advertised to the LLM for delegation
 - **Smart @ Attachments**: Binary files auto-detected via MIME type, MCP resources via `@mcp:server:uri`
 - **MCP Integration**: Connect external MCP servers for expanded capabilities
@@ -111,7 +111,7 @@ kit acp
 kit acp --debug
 ```
 
-The ACP server exposes Kit's full capabilities — LLM execution, tool calls (bash, read, write, edit, grep, etc.), and session persistence — over the standard ACP protocol. Sessions are persisted to Kit's normal JSONL session files, so they can be resumed later.
+The ACP server exposes Kit's full capabilities — LLM execution, tool calls (shell, read, write, edit, grep, etc.), and session persistence — over the standard ACP protocol. Sessions are persisted to Kit's normal JSONL session files, so they can be resumed later.
 
 ## Configuration
 
@@ -135,7 +135,12 @@ thinking-level: off       # off, none, minimal, low, medium, high
 no-core-tools: false      # set to true to disable all built-in core tools
 exclude-core-tools:       # List of core tools to exclude, mutually exclusive to `include-core-tools`
 #include-core-tools:
-# - "bash"                # List of core tools to exclude, mutually exclusive to `exclude-core-tools`
+# - "shell"               # List of core tools to exclude, mutually exclusive to `exclude-core-tools`
+shell: "bash"             # shell the shell tool runs commands through, plus
+                          # its own leading arguments, e.g. "busybox ash". Set
+                          # this on images that do not ship bash
+shell-timeout: 120        # default per-call timeout in seconds
+shell-max-timeout: 600    # ceiling a single call may request
 
 # Skills — all keys are optional
 no-skills: false          # set to true to disable all skill loading
@@ -219,9 +224,10 @@ mcpServers:
 # Extensions and tools
 --extension, -e          Load additional extension file(s) (repeatable)
 --no-extensions          Disable all extensions
---no-core-tools          Disable all built-in core tools (bash, read, write, edit, grep, find, ls, subagent)
+--no-core-tools          Disable all built-in core tools (shell, read, write, edit, grep, find, ls, subagent)
 --include-core-tools
 --exclude-core-tools     Mutually exclusive lists of core tool names to include or not to include in agent
+--shell                  Shell the shell tool runs commands through, e.g. "/bin/dash" or "busybox ash" (default "bash")
 
 --prompt-template        Load a specific prompt template by name
 --no-prompt-templates    Disable prompt template loading
@@ -1134,7 +1140,7 @@ internal/acpserver/  - ACP (Agent Client Protocol) server
 internal/clipboard/  - Cross-platform clipboard operations
 internal/compaction/ - Conversation compaction and summarization
 internal/config/     - Configuration management
-internal/core/       - Built-in tools (bash, read, write, edit, grep, find, ls)
+internal/core/       - Built-in tools (shell, read, write, edit, grep, find, ls)
 internal/extensions/ - Yaegi extension system
 internal/kitsetup/   - Initial setup wizard
 internal/message/    - Message content types and structured content blocks

--- a/cmd/extensions.go
+++ b/cmd/extensions.go
@@ -127,9 +127,9 @@ func Init(api ext.API) {
 		return nil // don't block
 	})
 
-	// Block dangerous bash commands.
+	// Block dangerous shell commands.
 	api.OnToolCall(func(tc ext.ToolCallEvent, ctx ext.Context) *ext.ToolCallResult {
-		if tc.ToolName == "bash" && strings.Contains(tc.Input, "rm -rf /") {
+		if tc.ToolName == "shell" && strings.Contains(tc.Input, "rm -rf /") {
 			return &ext.ToolCallResult{Block: true, Reason: "Blocked: dangerous command"}
 		}
 		return nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,6 +81,9 @@ var (
 	excludeCoreToolsFlag []string
 	extensionPaths       []string
 
+	// Shell tool
+	shellFlag string
+
 	// Skills control
 	noSkillsFlag  bool
 	skillsPaths   []string
@@ -166,6 +169,13 @@ var rootCmd = &cobra.Command{
 		}
 		if f := cmd.PersistentFlags().Lookup("thinking-level"); f != nil {
 			thinkingFlagChanged = f.Changed
+		}
+		// An empty --shell is a mistake rather than a request for the default:
+		// the user asked for a shell and named none. Refusing here keeps the
+		// failure at startup instead of on the first tool call.
+		if f := cmd.PersistentFlags().Lookup("shell"); f != nil && f.Changed &&
+			strings.TrimSpace(f.Value.String()) == "" {
+			return fmt.Errorf(`--shell needs a shell, e.g. --shell /bin/dash or --shell "busybox ash"`)
 		}
 		return runKit(context.Background())
 	},
@@ -382,11 +392,16 @@ func init() {
 	rootCmd.PersistentFlags().
 		BoolVar(&bareFlag, "bare", false, "no project context: skip AGENTS.md, skills, extensions, agents, prompt templates and project .kit.yml")
 	rootCmd.PersistentFlags().
-		BoolVar(&noCoreToolsFlag, "no-core-tools", false, "disable all built-in core tools (bash, read, write, edit, grep, find, ls, subagent)")
+		BoolVar(&noCoreToolsFlag, "no-core-tools", false, "disable all built-in core tools (shell, read, write, edit, grep, find, ls, subagent)")
 	rootCmd.PersistentFlags().
 		StringSliceVar(&includeCoreToolsFlag, "include-core-tools", nil, "comma-separated list of core tools to include")
 	rootCmd.PersistentFlags().
 		StringSliceVar(&excludeCoreToolsFlag, "exclude-core-tools", nil, "comma-separated list of core tools to exclude")
+	// The shell tool runs one command string through this shell. The value is
+	// the shell plus its own leading arguments. Empty leaves the built-in
+	// default, which is bash.
+	rootCmd.PersistentFlags().
+		StringVar(&shellFlag, "shell", "", `shell the shell tool runs commands through, e.g. "/bin/dash" or "busybox ash" (default "bash")`)
 	rootCmd.PersistentFlags().
 		StringSliceVarP(&extensionPaths, "extension", "e", nil, "load additional extension file(s)")
 
@@ -456,6 +471,7 @@ func init() {
 	_ = viper.BindPFlag("no-core-tools", rootCmd.PersistentFlags().Lookup("no-core-tools"))
 	_ = viper.BindPFlag("include-core-tools", rootCmd.PersistentFlags().Lookup("include-core-tools"))
 	_ = viper.BindPFlag("exclude-core-tools", rootCmd.PersistentFlags().Lookup("exclude-core-tools"))
+	_ = viper.BindPFlag("shell", rootCmd.PersistentFlags().Lookup("shell"))
 	_ = viper.BindPFlag("extension", rootCmd.PersistentFlags().Lookup("extension"))
 	_ = viper.BindPFlag("prompt-template", rootCmd.PersistentFlags().Lookup("prompt-template"))
 	_ = viper.BindPFlag("no-prompt-templates", rootCmd.PersistentFlags().Lookup("no-prompt-templates"))
@@ -1899,6 +1915,7 @@ func runInteractiveModeBubbleTea(_ context.Context, deps runModeDeps) error {
 		ProviderName:             deps.providerName,
 		LoadingMessage:           deps.loadingMessage,
 		Cwd:                      cwd,
+		Shell:                    viper.GetStringSlice("shell"),
 		Width:                    termWidth,
 		Height:                   termHeight,
 		ServerNames:              deps.serverNames,

--- a/examples/extensions/kit-telegram/main.go
+++ b/examples/extensions/kit-telegram/main.go
@@ -969,7 +969,7 @@ func summarizeToolAction(toolName string, inputJSON string) string {
 		return "writing " + getStr("path", "file")
 	case "edit":
 		return "editing " + getStr("path", "file")
-	case "bash":
+	case "shell", "bash":
 		return "running " + truncate(getStr("command", "command"), 80)
 	case "find":
 		return "finding " + getStr("pattern", getStr("path", "files"))
@@ -1008,7 +1008,7 @@ func summarizeToolResult(toolName string, inputJSON string, isError bool) string
 		return "edited " + getStr("path", "file")
 	case "read":
 		return "read " + getStr("path", "file")
-	case "bash":
+	case "shell", "bash":
 		return "completed " + truncate(getStr("command", "command"), 80)
 	default:
 		return "completed " + toolName

--- a/examples/extensions/plan-mode.go
+++ b/examples/extensions/plan-mode.go
@@ -12,7 +12,7 @@ import (
 // tools. Toggle with /plan (or start in plan mode via KIT_OPT_PLAN=true).
 
 // In plan mode the agent can only use read, grep, find, and ls — it cannot
-// write files, run bash, or make edits. This is useful for exploring a
+// write files, run shell commands, or make edits. This is useful for exploring a
 // codebase, reviewing architecture, or generating plans before executing.
 //
 // The status bar shows the current mode and the system prompt is augmented

--- a/examples/extensions/sudo-handler.go
+++ b/examples/extensions/sudo-handler.go
@@ -2,11 +2,11 @@
 
 // sudo-handler.go - Extension to handle sudo password prompts securely
 //
-// This extension intercepts bash commands containing "sudo" and:
+// This extension intercepts shell-tool commands containing "sudo" and:
 // 1. Checks if sudo credentials are already cached (via sudo -n)
 // 2. If not cached, prompts the user for their password (with masking)
 // 3. Temporarily sets SUDO_PASSWORD environment variable for execution
-// 4. The bash tool automatically uses sudo -S -p '' to pipe the password
+// 4. The shell tool automatically uses sudo -S -p '' to pipe the password
 //
 // Usage: kit -e examples/extensions/sudo-handler.go
 //
@@ -39,7 +39,7 @@ var (
 // Init sets up the sudo handler extension
 func Init(api ext.API) {
 	api.OnToolCall(func(tc ext.ToolCallEvent, ctx ext.Context) *ext.ToolCallResult {
-		if tc.ToolName != "bash" {
+		if tc.ToolName != "shell" && tc.ToolName != "bash" {
 			return nil
 		}
 
@@ -94,7 +94,7 @@ func Init(api ext.API) {
 		hasCachedPassword = true
 		mu.Unlock()
 
-		// Set environment variable for the bash tool to use
+		// Set environment variable for the shell tool to use
 		os.Setenv("SUDO_PASSWORD", result.Value)
 
 		// Show confirmation (without revealing password)

--- a/examples/extensions/tool-renderer-demo.go
+++ b/examples/extensions/tool-renderer-demo.go
@@ -18,7 +18,7 @@ import (
 //
 //	kit -e examples/extensions/tool-renderer-demo.go
 //
-// Then ask the agent to read a file or run a bash command to see
+// Then ask the agent to read a file or run a shell command to see
 // the custom rendering in action.
 func Init(api ext.API) {
 	// Custom renderer for the "read" tool: custom display name,
@@ -64,10 +64,10 @@ func Init(api ext.API) {
 		// which already provides syntax-highlighted code blocks.
 	})
 
-	// Custom renderer for the "bash" tool: renamed to "Shell",
+	// Custom renderer for the "shell" tool: displayed as "Shell",
 	// dark background, custom header with $ prefix.
 	api.RegisterToolRenderer(ext.ToolRenderConfig{
-		ToolName:    "bash",
+		ToolName:    "shell",
 		DisplayName: "Shell",
 		Background:  "#1e1e2e", // Dark background
 		BorderColor: "#a6e3a1", // Catppuccin green

--- a/examples/sdk/crypto-monitor/main.go
+++ b/examples/sdk/crypto-monitor/main.go
@@ -13,7 +13,7 @@ import (
 
 const systemPrompt = `You are a cryptocurrency price monitor. Your job is to:
 
-1. Fetch the current prices of Bitcoin and Ethereum using bash with curl
+1. Fetch the current prices of Bitcoin and Ethereum using the shell tool with curl
 2. Send a desktop notification with the results using notify-send
 
 To fetch prices, use this CoinGecko API endpoint (no API key needed):
@@ -43,7 +43,7 @@ func main() {
 
 	host, err := kit.New(ctx, &kit.Options{
 		SystemPrompt: systemPrompt,
-		Tools:        []kit.Tool{kit.NewBashTool()},
+		Tools:        []kit.Tool{kit.NewShellTool()},
 		NoSession:    true,
 		Quiet:        true,
 	})

--- a/internal/acpserver/session.go
+++ b/internal/acpserver/session.go
@@ -43,8 +43,9 @@ func (r *sessionRegistry) create(ctx context.Context, cwd string) (*acpSession, 
 	// per-session SetModel / SetThinkingLevel calls cannot race or bleed across
 	// the sessionRegistry. We seed the relevant root-command flag values from
 	// the process-global store (which cobra populated from flags) so launching
-	// `kit acp -m <model> [--thinking-level ...] [--provider-url ...]` is still
-	// honored; .kit.yml and KIT_* env vars are loaded per session by kit.New.
+	// `kit acp -m <model> [--thinking-level ...] [--provider-url ...]
+	// [--shell ...]` is still honored; .kit.yml and KIT_* env vars are loaded
+	// per session by kit.New.
 	streamOn := true
 	kitInstance, err := kit.New(ctx, &kit.Options{
 		SessionDir:     cwd,
@@ -54,6 +55,7 @@ func (r *sessionRegistry) create(ctx context.Context, cwd string) (*acpSession, 
 		ThinkingLevel:  viper.GetString("thinking-level"),
 		ProviderURL:    viper.GetString("provider-url"),
 		ProviderAPIKey: viper.GetString("provider-api-key"),
+		Shell:          viper.GetStringSlice("shell"),
 	})
 	if err != nil {
 		// Provide actionable guidance for provider auth errors, which are

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -64,15 +64,20 @@ type AgentConfig struct {
 	// consumed when core tools are built from CoreToolList.
 	NamedAgents []core.NamedAgentSpec
 
-	// BashTimeout sets the default per-call timeout (in seconds) for the bash
+	// ShellTimeout sets the default per-call timeout (in seconds) for the shell
 	// tool. Zero uses the built-in default (120s). Only consumed when core
 	// tools are built from CoreToolList.
-	BashTimeout int
+	ShellTimeout int
 
-	// BashMaxTimeout caps the maximum timeout (in seconds) a bash tool call
+	// ShellMaxTimeout caps the maximum timeout (in seconds) a shell tool call
 	// may request. Zero uses the built-in default (600s). Only consumed when
 	// core tools are built from CoreToolList.
-	BashMaxTimeout int
+	ShellMaxTimeout int
+
+	// Shell is the argument vector prefix the shell tool runs a command
+	// string through. Empty uses the built-in default ["bash"]. Only
+	// consumed when core tools are built from CoreToolList.
+	Shell []string
 
 	// OnMCPServerLoaded, if non-nil, is called when each MCP server finishes
 	// loading (successfully or with error). The callback receives the server
@@ -126,14 +131,14 @@ type ToolCallDeltaHandler func(toolCallID, delta string)
 type ToolCallEndHandler func(toolCallID string)
 
 // ToolOutputHandler is a function type for handling streaming tool output chunks.
-// Used by tools like bash to stream output as it arrives rather than waiting
+// Used by tools like the shell tool to stream output as it arrives rather than waiting
 // for the command to complete. The isStderr flag indicates if the chunk
 // contains stderr output.
 // Note: This is an alias for core.ToolOutputCallback to avoid import cycles.
 type ToolOutputHandler = core.ToolOutputCallback
 
 // PasswordPromptHandler is a function type for password prompts.
-// Used by the bash tool when sudo requires a password. The handler receives
+// Used by the shell tool when sudo requires a password. The handler receives
 // a prompt message and returns the password and whether it was cancelled.
 // Note: This is an alias for core.PasswordPromptCallback.
 type PasswordPromptHandler = core.PasswordPromptCallback
@@ -233,7 +238,7 @@ type GenerateCallbacks struct {
 }
 
 // Agent represents an AI agent with core tool integration using the LLM library.
-// Core tools (bash, read, write, edit, grep, find, ls) are registered as direct
+// Core tools (shell, read, write, edit, grep, find, ls) are registered as direct
 // AgentTool implementations — no MCP layer, no serialization overhead.
 // Additional tools from external MCP servers can be loaded alongside core tools.
 //
@@ -309,7 +314,7 @@ type GenerateWithLoopResult struct {
 }
 
 // NewAgent creates a new Agent with core tools and optional MCP tool integration.
-// Core tools (bash, read, write, edit, grep, find, ls) are always registered.
+// Core tools (shell, read, write, edit, grep, find, ls) are always registered.
 // If MCP servers are configured, their tools are loaded in the background —
 // the agent returns immediately and is usable with core tools only. The first
 // LLM call (GenerateWithLoop) automatically waits for MCP tools to finish
@@ -337,11 +342,14 @@ func NewAgent(ctx context.Context, agentConfig *AgentConfig) (*Agent, error) {
 		if len(agentConfig.NamedAgents) > 0 {
 			toolOpts = append(toolOpts, core.WithNamedAgents(agentConfig.NamedAgents...))
 		}
-		if agentConfig.BashTimeout > 0 {
-			toolOpts = append(toolOpts, core.WithBashTimeout(time.Duration(agentConfig.BashTimeout)*time.Second))
+		if agentConfig.ShellTimeout > 0 {
+			toolOpts = append(toolOpts, core.WithShellTimeout(time.Duration(agentConfig.ShellTimeout)*time.Second))
 		}
-		if agentConfig.BashMaxTimeout > 0 {
-			toolOpts = append(toolOpts, core.WithBashMaxTimeout(time.Duration(agentConfig.BashMaxTimeout)*time.Second))
+		if agentConfig.ShellMaxTimeout > 0 {
+			toolOpts = append(toolOpts, core.WithShellMaxTimeout(time.Duration(agentConfig.ShellMaxTimeout)*time.Second))
+		}
+		if len(agentConfig.Shell) > 0 {
+			toolOpts = append(toolOpts, core.WithShell(agentConfig.Shell))
 		}
 		coreTools = core.ListedTools(agentConfig.CoreToolList, toolOpts...)
 	}
@@ -617,12 +625,12 @@ func (a *Agent) GenerateWithCallbacks(ctx context.Context, messages []fantasy.Me
 	// servers are configured or tools have already been integrated.
 	a.ensureMCPTools()
 
-	// Inject tool output handler into context for use by core tools (e.g., bash).
+	// Inject tool output handler into context for use by core tools (e.g. the shell tool).
 	if cb.OnToolOutput != nil {
 		ctx = core.ContextWithToolOutputCallback(ctx, cb.OnToolOutput)
 	}
 
-	// Inject password prompt handler into context for use by bash tool.
+	// Inject password prompt handler into context for use by the shell tool.
 	if cb.OnPasswordPrompt != nil {
 		ctx = core.ContextWithPasswordPrompt(ctx, cb.OnPasswordPrompt)
 	}

--- a/internal/agent/factory.go
+++ b/internal/agent/factory.go
@@ -57,12 +57,15 @@ type AgentCreationOptions struct {
 	// NamedAgents lists discovered named agent definitions to advertise in
 	// the subagent tool description.
 	NamedAgents []core.NamedAgentSpec
-	// BashTimeout sets the default per-call timeout (seconds) for the bash
+	// ShellTimeout sets the default per-call timeout (seconds) for the shell
 	// tool. Zero uses the built-in default (120s).
-	BashTimeout int
-	// BashMaxTimeout caps the maximum timeout (seconds) a bash tool call may
+	ShellTimeout int
+	// ShellMaxTimeout caps the maximum timeout (seconds) a shell tool call may
 	// request. Zero uses the built-in default (600s).
-	BashMaxTimeout int
+	ShellMaxTimeout int
+	// Shell is the argument vector prefix the shell tool runs a command
+	// string through. Empty uses the built-in default ["bash"].
+	Shell []string
 	// OnMCPServerLoaded, if non-nil, is called when each MCP server finishes
 	// loading (successfully or with error). Called from the background goroutine.
 	OnMCPServerLoaded func(serverName string, toolCount int, err error)
@@ -88,8 +91,9 @@ func CreateAgent(ctx context.Context, opts *AgentCreationOptions) (*Agent, error
 		ToolWrapper:       opts.ToolWrapper,
 		ExtraTools:        opts.ExtraTools,
 		NamedAgents:       opts.NamedAgents,
-		BashTimeout:       opts.BashTimeout,
-		BashMaxTimeout:    opts.BashMaxTimeout,
+		ShellTimeout:      opts.ShellTimeout,
+		ShellMaxTimeout:   opts.ShellMaxTimeout,
+		Shell:             opts.Shell,
 		OnMCPServerLoaded: opts.OnMCPServerLoaded,
 		MCPTaskConfig:     opts.MCPTaskConfig,
 	}

--- a/internal/compaction/compaction.go
+++ b/internal/compaction/compaction.go
@@ -391,7 +391,7 @@ func newFileOps() *fileOps {
 }
 
 // extractFileOps scans messages for tool calls and extracts file paths.
-// It recognises the built-in Kit tools: read, write, edit, bash, grep, find, ls.
+// It recognises the built-in Kit tools: read, write, edit, shell, grep, find, ls.
 func extractFileOps(messages []fantasy.Message) *fileOps {
 	ops := newFileOps()
 	for _, msg := range messages {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -297,13 +297,26 @@ type Config struct {
 	// Custom model definitions (under custom/ provider)
 	CustomModels map[string]CustomModelConfig `json:"customModels,omitempty" yaml:"customModels,omitempty"`
 
-	// Bash tool timeouts (in seconds). BashTimeout sets the default per-call
-	// timeout applied when the model does not specify one (built-in default
-	// 120s). BashMaxTimeout caps the maximum timeout a bash tool call may
-	// request via its timeout argument (built-in default 600s). Zero values
-	// preserve the built-in defaults.
-	BashTimeout    int `json:"bash-timeout,omitempty" yaml:"bash-timeout,omitempty"`
-	BashMaxTimeout int `json:"bash-max-timeout,omitempty" yaml:"bash-max-timeout,omitempty"`
+	// Shell tool timeouts (in seconds). ShellTimeout sets the default
+	// per-call timeout applied when the model does not specify one (built-in
+	// default 120s). ShellMaxTimeout caps the maximum timeout a shell tool
+	// call may request via its timeout argument (built-in default 600s). Zero
+	// values preserve the built-in defaults.
+	//
+	// BashTimeout and BashMaxTimeout are the keys these settings had before
+	// the tool's shell became configurable. They are still read, so existing
+	// configuration keeps working; the shell-named key wins when both are
+	// present.
+	ShellTimeout    int `json:"shell-timeout,omitempty" yaml:"shell-timeout,omitempty"`
+	ShellMaxTimeout int `json:"shell-max-timeout,omitempty" yaml:"shell-max-timeout,omitempty"`
+	BashTimeout     int `json:"bash-timeout,omitempty" yaml:"bash-timeout,omitempty"`
+	BashMaxTimeout  int `json:"bash-max-timeout,omitempty" yaml:"bash-max-timeout,omitempty"`
+
+	// Shell is the shell the shell tool runs a command string through, plus
+	// its own leading arguments, e.g. ["bash"] or ["busybox", "ash"]. Empty
+	// uses the built-in default ["bash"]. Set this on images that do not
+	// ship bash.
+	Shell []string `json:"shell,omitempty" yaml:"shell,omitempty"`
 
 	// Per-model generation parameter overrides. Keys are "provider/model" strings
 	// (e.g. "anthropic/claude-sonnet-4-5-20250929", "openai/gpt-4o"). These
@@ -534,6 +547,15 @@ mcpServers:
 # exclude-core-tools:                      # list of core tool name to exclude
                                            # include-/exclude-core-tools are mutually exclusive
                                            # no-core-tools has precedence
+
+# Shell tool
+# shell: "bash"                            # shell the shell tool runs commands through
+                                           # plus its own leading arguments: "busybox ash"
+                                           # set this on images without bash
+# shell-timeout: 120                       # default per-call timeout in seconds
+# shell-max-timeout: 600                   # ceiling a single call may request
+                                           # bash-timeout and bash-max-timeout
+                                           # are the earlier names and still work
 
 # API Configuration (can also use environment variables)
 # provider-api-key: "your-api-key"         # API key for OpenAI, Anthropic, or Google

--- a/internal/core/shell.go
+++ b/internal/core/shell.go
@@ -3,10 +3,12 @@ package core
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"slices"
 	"strings"
@@ -69,29 +71,183 @@ func sudoPasswordFromContext(ctx context.Context) string {
 	return ""
 }
 
-const defaultBashTimeout = 120 * time.Second
-const maxBashTimeout = 600 * time.Second
+// ---------------------------------------------------------------------------
+// Shell resolution and identity
+// ---------------------------------------------------------------------------
 
-// bannedCmdRe matches bash builtin commands that are not allowed for security reasons.
+// defaultShell is the shell used when none is configured.
+var defaultShell = []string{"bash"}
+
+// errEmptyShellElement reports a shell configuration that contains an empty
+// argument, which is a configuration mistake rather than a runnable shell.
+var errEmptyShellElement = errors.New("shell contains an empty argument")
+
+// posixShells are the shells whose command language is POSIX sh, so the model
+// can be told to write POSIX syntax. zsh, fish, nu and the rest are absent
+// deliberately: instructing POSIX syntax for them would be wrong.
+var posixShells = []string{
+	"sh", "dash", "ash", "busybox", "ksh", "ksh93", "mksh", "loksh", "oksh", "yash",
+}
+
+// shellResolution is the configured shell in the two forms the tool needs: the
+// argument vector prefix to execute, and the path to advertise in SHELL.
+type shellResolution struct {
+	// argv is the shell plus its own leading arguments, e.g. ["bash"] or
+	// ["busybox", "ash"].
+	argv []string
+	// shellPath is written to SHELL for child processes, so that programs
+	// such as tmux use the configured shell rather than the login shell of
+	// the user. It is argv[0] resolved through PATH, or argv[0] unchanged
+	// when the lookup fails. It is empty for a multi-element vector: KIT
+	// cannot know which element of a launcher vector is the shell, and a
+	// wrong SHELL is worse for child programs than the inherited one, so
+	// SHELL is then left alone.
+	shellPath string
+}
+
+// normalizeShell applies the default: an empty or nil shell means bash.
+func normalizeShell(shell []string) []string {
+	if len(shell) == 0 {
+		return defaultShell
+	}
+	return shell
+}
+
+// resolveShell turns a configured shell into a shellResolution.
+//
+// It is pure with respect to process state: it reads only its argument and the
+// PATH lookup, and must not read environment variables, configuration files or
+// package-level state other than the constant default. Each kit.New owns its
+// own configuration store, and a package-level read here would let one host
+// observe another's setting.
+//
+// A PATH lookup failure is not an error. The unresolved name is returned and
+// the failure surfaces through the ordinary execution error path.
+func resolveShell(shell []string) (shellResolution, error) {
+	for _, a := range shell {
+		if a == "" {
+			return shellResolution{}, errEmptyShellElement
+		}
+	}
+	argv := normalizeShell(shell)
+
+	// SHELL is advertised only when the vector is the shell alone; see the
+	// shellPath field comment.
+	shellPath := ""
+	if len(argv) == 1 {
+		shellPath = argv[0]
+		if resolved, err := exec.LookPath(argv[0]); err == nil {
+			shellPath = resolved
+		}
+	}
+	return shellResolution{argv: argv, shellPath: shellPath}, nil
+}
+
+// commandArgs returns the full process argument vector for one command
+// string. The command is passed as exactly one argument, never split or
+// re-quoted.
+func (r shellResolution) commandArgs(command string) []string {
+	args := make([]string, 0, len(r.argv)+2)
+	args = append(args, r.argv...)
+	args = append(args, "-c")
+	return append(args, command)
+}
+
+// ShellCommandArgs returns the process argument vector that runs one command
+// string through the configured shell, and the SHELL value to advertise to
+// child processes, empty when SHELL should stay inherited. It is the same
+// construction the shell tool uses, exported so that the TUI's ! and !!
+// commands execute through the same shell.
+func ShellCommandArgs(shell []string, command string) (args []string, shellPath string, err error) {
+	r, err := resolveShell(shell)
+	if err != nil {
+		return nil, "", err
+	}
+	return r.commandArgs(command), r.shellPath, nil
+}
+
+// shellDisplayName is the shell as the tool descriptions name it: the
+// configured vector joined with spaces.
+func shellDisplayName(argv []string) string {
+	return strings.Join(argv, " ")
+}
+
+// isBashShell reports whether the configured shell is bash, which is the one
+// case that needs no dialect note.
+func isBashShell(argv []string) bool {
+	return filepath.Base(argv[0]) == "bash"
+}
+
+// isPosixShell reports whether the configured shell speaks POSIX sh.
+func isPosixShell(argv []string) bool {
+	return slices.Contains(posixShells, filepath.Base(argv[0]))
+}
+
+// shellToolDescription is the tool description for the configured shell.
+//
+// The model writes the command, so it has to know which shell it is writing
+// for. Described as bash while a POSIX shell runs, it emits bash-only syntax
+// and cannot diagnose the errors, because it believes it is talking to bash.
+// Told to write POSIX syntax for fish or nu it would be wrong the other way,
+// which is why the note has three cases rather than two.
+func shellToolDescription(shell []string) string {
+	const tail = "Returns stdout and stderr. Output is truncated to the last 2000 lines or 50KB. Optionally provide a timeout in seconds."
+
+	argv := normalizeShell(shell)
+	name := shellDisplayName(argv)
+	desc := fmt.Sprintf("Execute a command through %s. %s", name, tail)
+
+	switch {
+	case isBashShell(argv):
+		return desc
+	case isPosixShell(argv):
+		return desc + fmt.Sprintf(
+			" IMPORTANT: the shell is %s, not bash. Write POSIX sh syntax only. "+
+				"Bash-only constructs are unavailable and will fail: [[ ]] tests (use [ ]), "+
+				"arrays, process substitution <(...), brace expansion {a,b}, 'source' (use '.'), "+
+				"the 'function' keyword, 'local -a', ${var^^} case conversion, and $'...' quoting.", name)
+	default:
+		return desc + fmt.Sprintf(
+			" IMPORTANT: the shell is %s, not bash. Write syntax that %s accepts; "+
+				"bash-only constructs are unavailable and will fail.", name, name)
+	}
+}
+
+// shellCommandParamDescription describes the command parameter, which also
+// names the shell.
+func shellCommandParamDescription(shell []string) string {
+	argv := normalizeShell(shell)
+	if isPosixShell(argv) && !isBashShell(argv) {
+		return fmt.Sprintf("Command to execute with %s (POSIX sh syntax)", shellDisplayName(argv))
+	}
+	return fmt.Sprintf("Command to execute with %s", shellDisplayName(argv))
+}
+
+const defaultShellTimeout = 120 * time.Second
+const maxShellTimeout = 600 * time.Second
+
+// bannedCmdRe matches shell builtin commands that are not allowed for security
+// reasons.
 var bannedCmdRe = regexp.MustCompile(`^(alias|bg|bind|builtin|caller|command|compgen|complete|compopt|coproc|dirs|disown|enable|fc|fg|hash|help|history|jobs|kill|logout|mapfile|popd|pushd|readonly|select|set|shopt|source|suspend|times|trap|type|typeset|ulimit|umask|unalias|wait)\s`)
 
-type bashArgs struct {
+type shellArgs struct {
 	Command string  `json:"command"`
 	Timeout float64 `json:"timeout,omitempty"`
 }
 
-// NewBashTool creates the bash core tool.
-func NewBashTool(opts ...ToolOption) fantasy.AgentTool {
+// NewShellTool creates the shell core tool. It runs one command string through
+// the configured shell, which defaults to bash.
+func NewShellTool(opts ...ToolOption) fantasy.AgentTool {
 	cfg := ApplyOptions(opts)
 
 	// Resolve effective timeouts, falling back to the built-in defaults.
-	maxTimeout := maxBashTimeout
-	if cfg.BashMaxTimeout > 0 {
-		maxTimeout = cfg.BashMaxTimeout
+	maxTimeout := maxShellTimeout
+	if cfg.ShellMaxTimeout > 0 {
+		maxTimeout = cfg.ShellMaxTimeout
 	}
-	defTimeout := defaultBashTimeout
-	if cfg.BashTimeout > 0 {
-		defTimeout = cfg.BashTimeout
+	defTimeout := defaultShellTimeout
+	if cfg.ShellTimeout > 0 {
+		defTimeout = cfg.ShellTimeout
 	}
 	// The default must never exceed the ceiling.
 	if defTimeout > maxTimeout {
@@ -100,12 +256,16 @@ func NewBashTool(opts ...ToolOption) fantasy.AgentTool {
 
 	return &coreTool{
 		info: fantasy.ToolInfo{
-			Name:        "bash",
-			Description: "Execute a bash command. Returns stdout and stderr. Output is truncated to the last 2000 lines or 50KB. Optionally provide a timeout in seconds.",
+			// The name does not vary with the shell: a transcript, a
+			// permission rule and a configuration entry all say the same
+			// thing. The descriptions do vary, because that is where the
+			// model learns which shell it is writing for.
+			Name:        ShellToolName,
+			Description: shellToolDescription(cfg.Shell),
 			Parameters: map[string]any{
 				"command": map[string]any{
 					"type":        "string",
-					"description": "Bash command to execute",
+					"description": shellCommandParamDescription(cfg.Shell),
 				},
 				"timeout": map[string]any{
 					"type":        "number",
@@ -115,7 +275,7 @@ func NewBashTool(opts ...ToolOption) fantasy.AgentTool {
 			Required: []string{"command"},
 		},
 		handler: func(ctx context.Context, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
-			return executeBash(ctx, call, cfg.WorkDir, defTimeout, maxTimeout)
+			return executeShell(ctx, call, cfg.WorkDir, cfg.Shell, defTimeout, maxTimeout)
 		},
 	}
 }
@@ -170,8 +330,8 @@ func rewriteSudoForStdin(command string) string {
 	return result
 }
 
-func executeBash(ctx context.Context, call fantasy.ToolCall, workDir string, defaultTimeout, maxTimeout time.Duration) (fantasy.ToolResponse, error) {
-	var args bashArgs
+func executeShell(ctx context.Context, call fantasy.ToolCall, workDir string, shell []string, defaultTimeout, maxTimeout time.Duration) (fantasy.ToolResponse, error) {
+	var args shellArgs
 	if err := parseArgs(call.Input, &args); err != nil {
 		return fantasy.NewTextErrorResponse("command parameter is required"), nil
 	}
@@ -234,29 +394,36 @@ func executeBash(ctx context.Context, call fantasy.ToolCall, workDir string, def
 		command = rewriteSudoForStdin(command)
 	}
 
-	cmd := exec.CommandContext(cmdCtx, "bash", "-c", command)
+	// Resolve the configured shell. With nothing configured, the argument
+	// vector and the SHELL value are the ones this tool has always used.
+	resolution, err := resolveShell(shell)
+	if err != nil {
+		return fantasy.NewTextErrorResponse(fmt.Sprintf("invalid shell configuration: %v", err)), nil
+	}
+	cmdArgs := resolution.commandArgs(command)
+
+	cmd := exec.CommandContext(cmdCtx, cmdArgs[0], cmdArgs[1:]...)
 	if workDir != "" {
 		cmd.Dir = workDir
 	}
 
-	// Ensure SHELL is set to bash so child processes (e.g. tmux) use bash
-	// rather than the user's login shell (which may be nushell, fish, etc.).
-	bashPath, err := exec.LookPath("bash")
-	if err != nil {
-		bashPath = "/bin/bash"
+	// Ensure SHELL is set to the resolved shell so child processes (e.g. tmux)
+	// use it rather than the user's login shell (which may be nushell, fish,
+	// etc.). A launcher vector leaves SHELL inherited; see resolveShell.
+	if resolution.shellPath != "" {
+		cmd.Env = append(os.Environ(), "SHELL="+resolution.shellPath)
 	}
-	cmd.Env = append(os.Environ(), "SHELL="+bashPath)
 
 	// Get the output callback if present (for streaming support)
 	outputCallback := toolOutputCallbackFromContext(ctx)
 
 	if outputCallback != nil {
 		// Streaming mode: use pipes to capture output as it arrives
-		return executeBashStreaming(cmdCtx, call, cmd, outputCallback, sudoPassword)
+		return executeShellStreaming(cmdCtx, call, cmd, outputCallback, sudoPassword)
 	}
 
 	// Non-streaming mode: collect all output at once (original behavior)
-	return executeBashBuffered(cmdCtx, call, cmd, sudoPassword)
+	return executeShellBuffered(cmdCtx, call, cmd, sudoPassword)
 }
 
 // pipeDrainGrace bounds how long the parent waits for the output readers to
@@ -266,7 +433,7 @@ func executeBash(ctx context.Context, call fantasy.ToolCall, workDir string, def
 // this timer.
 const pipeDrainGrace = 500 * time.Millisecond
 
-// bashPipes holds the parent's read ends of the child's output pipes. They are
+// shellPipes holds the parent's read ends of the child's output pipes. They are
 // created with os.Pipe and assigned to cmd.Stdout/cmd.Stderr rather than
 // obtained from cmd.StdoutPipe, which matters for correctness:
 //
@@ -277,7 +444,7 @@ const pipeDrainGrace = 500 * time.Millisecond
 //
 // The cost is that Cmd.WaitDelay no longer force-closes these descriptors, so
 // the caller must bound the drain itself — see waitForDrain.
-type bashPipes struct {
+type shellPipes struct {
 	stdout *os.File
 	stderr *os.File
 
@@ -290,7 +457,7 @@ type bashPipes struct {
 // close releases the parent's read ends, unblocking any reader still waiting
 // on a pipe that a surviving grandchild holds open. Safe to call more than
 // once.
-func (p *bashPipes) close() {
+func (p *shellPipes) close() {
 	if p == nil {
 		return
 	}
@@ -307,7 +474,7 @@ func (p *bashPipes) close() {
 // after pipeDrainGrace so a grandchild holding the write end cannot hang the
 // call. Either way it does not return until the readers have stopped, so the
 // caller can read the collected output without a race.
-func (p *bashPipes) waitForDrain(readersDone <-chan struct{}) {
+func (p *shellPipes) waitForDrain(readersDone <-chan struct{}) {
 	select {
 	case <-readersDone:
 		// Normal path: both readers reached EOF and drained everything.
@@ -321,21 +488,21 @@ func (p *bashPipes) waitForDrain(readersDone <-chan struct{}) {
 	}
 }
 
-// setupBashPipes opens stdout/stderr pipes (plus an optional sudo stdin),
+// setupShellPipes opens stdout/stderr pipes (plus an optional sudo stdin),
 // starts the command, and asynchronously writes the sudo password if any.
 // Returns the readers ready for the caller to consume. If setup fails,
 // errResp is non-nil and the readers must not be used; the caller should
 // return the response directly.
 //
 // The caller owns the returned pipes and must drain them via
-// [bashPipes.waitForDrain] after cmd.Wait returns.
-func setupBashPipes(cmd *exec.Cmd, sudoPassword string) (pipes *bashPipes, errResp *fantasy.ToolResponse) {
-	fail := func(msg string) (*bashPipes, *fantasy.ToolResponse) {
+// [shellPipes.waitForDrain] after cmd.Wait returns.
+func setupShellPipes(cmd *exec.Cmd, sudoPassword string) (pipes *shellPipes, errResp *fantasy.ToolResponse) {
+	fail := func(msg string) (*shellPipes, *fantasy.ToolResponse) {
 		r := fantasy.NewTextErrorResponse(msg)
 		return nil, &r
 	}
 
-	// os.Pipe rather than cmd.StdoutPipe: see the bashPipes doc comment. The
+	// os.Pipe rather than cmd.StdoutPipe: see the shellPipes doc comment. The
 	// write ends are handed to the child and closed in the parent right after
 	// Start, so the readers see EOF once every writer has exited.
 	stdoutR, stdoutW, err := os.Pipe()
@@ -384,14 +551,14 @@ func setupBashPipes(cmd *exec.Cmd, sudoPassword string) (pipes *bashPipes, errRe
 		}()
 	}
 
-	return &bashPipes{stdout: stdoutR, stderr: stderrR}, nil
+	return &shellPipes{stdout: stdoutR, stderr: stderrR}, nil
 }
 
-// interpretBashExit decodes cmd.Wait()'s error into an exit code, mapping
+// interpretShellExit decodes cmd.Wait()'s error into an exit code, mapping
 // context-deadline-exceeded to a friendly "command timed out" response.
 // errResp is non-nil only when the caller should short-circuit and return
 // it directly (e.g. timeout).
-func interpretBashExit(waitErr error, cmdCtx context.Context) (exitCode int, errResp *fantasy.ToolResponse) {
+func interpretShellExit(waitErr error, cmdCtx context.Context) (exitCode int, errResp *fantasy.ToolResponse) {
 	if waitErr == nil {
 		return 0, nil
 	}
@@ -405,12 +572,12 @@ func interpretBashExit(waitErr error, cmdCtx context.Context) (exitCode int, err
 	return 0, nil
 }
 
-// executeBashBuffered collects all output before returning (original behavior).
+// executeShellBuffered collects all output before returning (original behavior).
 // It uses explicit pipes (not cmd.Stdout) so that cmd.WaitDelay can forcibly
 // close them when grandchild processes hold pipe handles open after the
 // direct child exits.
-func executeBashBuffered(cmdCtx context.Context, _ fantasy.ToolCall, cmd *exec.Cmd, sudoPassword string) (fantasy.ToolResponse, error) {
-	pipes, errResp := setupBashPipes(cmd, sudoPassword)
+func executeShellBuffered(cmdCtx context.Context, _ fantasy.ToolCall, cmd *exec.Cmd, sudoPassword string) (fantasy.ToolResponse, error) {
+	pipes, errResp := setupShellPipes(cmd, sudoPassword)
 	if errResp != nil {
 		return *errResp, nil
 	}
@@ -446,17 +613,17 @@ func executeBashBuffered(cmdCtx context.Context, _ fantasy.ToolCall, cmd *exec.C
 	// end open cannot hang the call.
 	pipes.waitForDrain(readersDone)
 
-	exitCode, errResp := interpretBashExit(waitErr, cmdCtx)
+	exitCode, errResp := interpretShellExit(waitErr, cmdCtx)
 	if errResp != nil {
 		return *errResp, nil
 	}
 
-	return buildBashResponse(stdout.String(), stderr.String(), exitCode)
+	return buildShellResponse(stdout.String(), stderr.String(), exitCode)
 }
 
-// executeBashStreaming streams output as it arrives via the callback.
-func executeBashStreaming(cmdCtx context.Context, call fantasy.ToolCall, cmd *exec.Cmd, outputCallback ToolOutputCallback, sudoPassword string) (fantasy.ToolResponse, error) {
-	pipes, errResp := setupBashPipes(cmd, sudoPassword)
+// executeShellStreaming streams output as it arrives via the callback.
+func executeShellStreaming(cmdCtx context.Context, call fantasy.ToolCall, cmd *exec.Cmd, outputCallback ToolOutputCallback, sudoPassword string) (fantasy.ToolResponse, error) {
+	pipes, errResp := setupShellPipes(cmd, sudoPassword)
 	if errResp != nil {
 		return *errResp, nil
 	}
@@ -477,7 +644,7 @@ func executeBashStreaming(cmdCtx context.Context, call fantasy.ToolCall, cmd *ex
 		for scanner.Scan() {
 			chunk := scanner.Text()
 			// Send chunk to UI
-			outputCallback(call.ID, "bash", chunk, isStderr)
+			outputCallback(call.ID, ShellToolName, chunk, isStderr)
 			// Collect for final result
 			mu.Lock()
 			if isStderr {
@@ -505,7 +672,7 @@ func executeBashStreaming(cmdCtx context.Context, call fantasy.ToolCall, cmd *ex
 		if err := scanner.Err(); err != nil && !pipes.forced.Load() {
 			discarded, _ := io.Copy(io.Discard, reader)
 			notice := fmt.Sprintf("[output truncated: %v; discarded %d further bytes]", err, discarded)
-			outputCallback(call.ID, "bash", notice, isStderr)
+			outputCallback(call.ID, ShellToolName, notice, isStderr)
 			mu.Lock()
 			if isStderr {
 				stderrChunks = append(stderrChunks, notice)
@@ -538,16 +705,16 @@ func executeBashStreaming(cmdCtx context.Context, call fantasy.ToolCall, cmd *ex
 	// end open cannot hang the call.
 	pipes.waitForDrain(readersDone)
 
-	exitCode, errResp := interpretBashExit(waitErr, cmdCtx)
+	exitCode, errResp := interpretShellExit(waitErr, cmdCtx)
 	if errResp != nil {
 		return *errResp, nil
 	}
 
-	return buildBashResponse(strings.Join(stdoutChunks, "\n"), strings.Join(stderrChunks, "\n"), exitCode)
+	return buildShellResponse(strings.Join(stdoutChunks, "\n"), strings.Join(stderrChunks, "\n"), exitCode)
 }
 
-// buildBashResponse constructs the final tool response from stdout/stderr.
-func buildBashResponse(stdout, stderr string, exitCode int) (fantasy.ToolResponse, error) {
+// buildShellResponse constructs the final tool response from stdout/stderr.
+func buildShellResponse(stdout, stderr string, exitCode int) (fantasy.ToolResponse, error) {
 	var result strings.Builder
 	if stdout != "" {
 		result.WriteString(stdout)
@@ -571,7 +738,7 @@ func buildBashResponse(stdout, stderr string, exitCode int) (fantasy.ToolRespons
 		output = "(no output)"
 	}
 
-	// Truncate from tail (keep last N lines, most relevant for bash)
+	// Truncate from tail (keep last N lines, most relevant for command output)
 	tr := TruncateTail(output, defaultMaxLines, defaultMaxBytes)
 
 	if exitCode != 0 {

--- a/internal/core/shell.go
+++ b/internal/core/shell.go
@@ -124,10 +124,8 @@ func normalizeShell(shell []string) []string {
 // A PATH lookup failure is not an error. The unresolved name is returned and
 // the failure surfaces through the ordinary execution error path.
 func resolveShell(shell []string) (shellResolution, error) {
-	for _, a := range shell {
-		if a == "" {
-			return shellResolution{}, errEmptyShellElement
-		}
+	if slices.Contains(shell, "") {
+		return shellResolution{}, errEmptyShellElement
 	}
 	argv := normalizeShell(shell)
 

--- a/internal/core/shell_exec_test.go
+++ b/internal/core/shell_exec_test.go
@@ -9,8 +9,8 @@ import (
 	"charm.land/fantasy"
 )
 
-// helper to create a bash tool call with the given command and optional timeout.
-func bashCall(command string, timeout float64) fantasy.ToolCall {
+// helper to create a shell tool call with the given command and optional timeout.
+func shellCall(command string, timeout float64) fantasy.ToolCall {
 	args := map[string]any{"command": command}
 	if timeout > 0 {
 		args["timeout"] = timeout
@@ -18,13 +18,13 @@ func bashCall(command string, timeout float64) fantasy.ToolCall {
 	input, _ := json.Marshal(args)
 	return fantasy.ToolCall{
 		ID:    "test-call",
-		Name:  "bash",
+		Name:  ShellToolName,
 		Input: string(input),
 	}
 }
 
-func TestBash_SimpleCommand(t *testing.T) {
-	resp, err := executeBash(context.Background(), bashCall("echo hello", 0), "", defaultBashTimeout, maxBashTimeout)
+func TestShell_SimpleCommand(t *testing.T) {
+	resp, err := executeShell(context.Background(), shellCall("echo hello", 0), "", nil, defaultShellTimeout, maxShellTimeout)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -36,9 +36,9 @@ func TestBash_SimpleCommand(t *testing.T) {
 	}
 }
 
-func TestBash_TimeoutKillsProcess(t *testing.T) {
+func TestShell_TimeoutKillsProcess(t *testing.T) {
 	start := time.Now()
-	resp, err := executeBash(context.Background(), bashCall("sleep 60", 2), "", defaultBashTimeout, maxBashTimeout)
+	resp, err := executeShell(context.Background(), shellCall("sleep 60", 2), "", nil, defaultShellTimeout, maxShellTimeout)
 	elapsed := time.Since(start)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -51,11 +51,11 @@ func TestBash_TimeoutKillsProcess(t *testing.T) {
 	}
 }
 
-func TestBash_ConfiguredMaxTimeoutCaps(t *testing.T) {
+func TestShell_ConfiguredMaxTimeoutCaps(t *testing.T) {
 	// A tiny configured max timeout must clamp a large requested timeout so
 	// the command is killed quickly.
 	start := time.Now()
-	resp, err := executeBash(context.Background(), bashCall("sleep 60", 30), "", defaultBashTimeout, 2*time.Second)
+	resp, err := executeShell(context.Background(), shellCall("sleep 60", 30), "", nil, defaultShellTimeout, 2*time.Second)
 	elapsed := time.Since(start)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -68,10 +68,10 @@ func TestBash_ConfiguredMaxTimeoutCaps(t *testing.T) {
 	}
 }
 
-func TestBash_ConfiguredDefaultTimeoutApplies(t *testing.T) {
+func TestShell_ConfiguredDefaultTimeoutApplies(t *testing.T) {
 	// With no per-call timeout, the configured default must apply.
 	start := time.Now()
-	resp, err := executeBash(context.Background(), bashCall("sleep 60", 0), "", 2*time.Second, maxBashTimeout)
+	resp, err := executeShell(context.Background(), shellCall("sleep 60", 0), "", nil, 2*time.Second, maxShellTimeout)
 	elapsed := time.Since(start)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -84,19 +84,19 @@ func TestBash_ConfiguredDefaultTimeoutApplies(t *testing.T) {
 	}
 }
 
-func TestNewBashTool_TimeoutOptionsInDescription(t *testing.T) {
-	tool := NewBashTool(WithBashTimeout(30*time.Second), WithBashMaxTimeout(90*time.Second))
+func TestNewShellTool_TimeoutOptionsInDescription(t *testing.T) {
+	tool := NewShellTool(WithShellTimeout(30*time.Second), WithShellMaxTimeout(90*time.Second))
 	desc, _ := tool.Info().Parameters["timeout"].(map[string]any)["description"].(string)
 	if desc != "Timeout in seconds (optional, default 30s, max 90s)" {
 		t.Errorf("unexpected timeout description: %q", desc)
 	}
 }
 
-func TestBash_BackgroundProcessDoesNotHang(t *testing.T) {
+func TestShell_BackgroundProcessDoesNotHang(t *testing.T) {
 	// This command spawns a background sleep that would hold pipes open
 	// forever if we didn't have process group killing + WaitDelay.
 	start := time.Now()
-	resp, err := executeBash(context.Background(), bashCall("echo done; sleep 3600 &", 5), "", defaultBashTimeout, maxBashTimeout)
+	resp, err := executeShell(context.Background(), shellCall("echo done; sleep 3600 &", 5), "", nil, defaultShellTimeout, maxShellTimeout)
 	elapsed := time.Since(start)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -110,11 +110,11 @@ func TestBash_BackgroundProcessDoesNotHang(t *testing.T) {
 	}
 }
 
-func TestBash_BackgroundProcessDoesNotHang_Streaming(t *testing.T) {
+func TestShell_BackgroundProcessDoesNotHang_Streaming(t *testing.T) {
 	// Same test but in streaming mode (with output callback).
 	ctx := ContextWithToolOutputCallback(context.Background(), func(_, _, _ string, _ bool) {})
 	start := time.Now()
-	resp, err := executeBash(ctx, bashCall("echo streaming; sleep 3600 &", 5), "", defaultBashTimeout, maxBashTimeout)
+	resp, err := executeShell(ctx, shellCall("echo streaming; sleep 3600 &", 5), "", nil, defaultShellTimeout, maxShellTimeout)
 	elapsed := time.Since(start)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -127,13 +127,13 @@ func TestBash_BackgroundProcessDoesNotHang_Streaming(t *testing.T) {
 	}
 }
 
-func TestBash_ContextCancellation(t *testing.T) {
+func TestShell_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		_, _ = executeBash(ctx, bashCall("sleep 60", 0), "", defaultBashTimeout, maxBashTimeout)
+		_, _ = executeShell(ctx, shellCall("sleep 60", 0), "", nil, defaultShellTimeout, maxShellTimeout)
 	}()
 
 	// Cancel after a short delay
@@ -145,12 +145,12 @@ func TestBash_ContextCancellation(t *testing.T) {
 	case <-done:
 		// success
 	case <-time.After(5 * time.Second):
-		t.Fatal("executeBash did not return after context cancellation")
+		t.Fatal("executeShell did not return after context cancellation")
 	}
 }
 
-func TestBash_BannedCommand(t *testing.T) {
-	resp, err := executeBash(context.Background(), bashCall("alias foo=bar", 0), "", defaultBashTimeout, maxBashTimeout)
+func TestShell_BannedCommand(t *testing.T) {
+	resp, err := executeShell(context.Background(), shellCall("alias foo=bar", 0), "", nil, defaultShellTimeout, maxShellTimeout)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -159,8 +159,8 @@ func TestBash_BannedCommand(t *testing.T) {
 	}
 }
 
-func TestBash_EmptyCommand(t *testing.T) {
-	resp, err := executeBash(context.Background(), bashCall("", 0), "", defaultBashTimeout, maxBashTimeout)
+func TestShell_EmptyCommand(t *testing.T) {
+	resp, err := executeShell(context.Background(), shellCall("", 0), "", nil, defaultShellTimeout, maxShellTimeout)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/core/shell_streaming_test.go
+++ b/internal/core/shell_streaming_test.go
@@ -11,7 +11,7 @@ import (
 	"charm.land/fantasy"
 )
 
-// runStreaming drives executeBashStreaming directly for a shell command and
+// runStreaming drives executeShellStreaming directly for a shell command and
 // returns the tool response plus every chunk pushed to the output callback.
 //
 // It fails the test rather than blocking forever if the call does not return,
@@ -30,26 +30,42 @@ func runStreaming(t *testing.T, command string) (fantasy.ToolResponse, []string)
 		ctx := context.Background()
 		cmd := exec.CommandContext(ctx, "bash", "-c", command)
 
-		// executeBashStreaming drains stdout and stderr in two separate
+		// executeShellStreaming drains stdout and stderr in two separate
 		// goroutines, so the callback is invoked concurrently. The production
 		// code guards its own chunk slices with a mutex; the callback we pass
 		// must do the same or the append races.
 		var mu sync.Mutex
 		var chunks []string
-		cb := func(_, _, chunk string, _ bool) {
+		var names []string
+		cb := func(_, toolName, chunk string, _ bool) {
 			mu.Lock()
 			chunks = append(chunks, chunk)
+			names = append(names, toolName)
 			mu.Unlock()
 		}
 
-		resp, err := executeBashStreaming(ctx, bashCall(command, 0), cmd, cb, "")
+		resp, err := executeShellStreaming(ctx, shellCall(command, 0), cmd, cb, "")
 
-		// executeBashStreaming has joined both stream goroutines by the time it
+		// executeShellStreaming has joined both stream goroutines by the time it
 		// returns, so no further callback can fire. Take the lock anyway to
 		// publish the final slice under the same mutex that guarded the writes.
 		mu.Lock()
 		snapshot := append([]string(nil), chunks...)
+		gotNames := append([]string(nil), names...)
 		mu.Unlock()
+
+		// Streamed output is attributed to the name the tool advertises. Every
+		// chunk is checked, and the check fails when no chunk arrived, so it
+		// cannot pass by producing nothing.
+		if len(gotNames) == 0 {
+			t.Errorf("no chunk was attributed to any tool name")
+		}
+		for _, n := range gotNames {
+			if n != ShellToolName {
+				t.Errorf("streamed output attributed to %q, want %q", n, ShellToolName)
+				break
+			}
+		}
 
 		done <- result{resp, snapshot, err}
 	}()
@@ -57,11 +73,11 @@ func runStreaming(t *testing.T, command string) (fantasy.ToolResponse, []string)
 	select {
 	case r := <-done:
 		if r.err != nil {
-			t.Fatalf("executeBashStreaming: %v", r.err)
+			t.Fatalf("executeShellStreaming: %v", r.err)
 		}
 		return r.resp, r.chunks
 	case <-time.After(30 * time.Second):
-		t.Fatal("executeBashStreaming did not return within 30s (deadlocked on an undrained pipe?)")
+		t.Fatal("executeShellStreaming did not return within 30s (deadlocked on an undrained pipe?)")
 		return fantasy.ToolResponse{}, nil
 	}
 }
@@ -75,7 +91,7 @@ func runStreaming(t *testing.T, command string) (fantasy.ToolResponse, []string)
 //
 // A single line over the limit is not exotic — minified JSON, a packed bundle
 // or `cat` of a binary all produce one.
-func TestBashStreaming_ReportsOversizedLine(t *testing.T) {
+func TestShellStreaming_ReportsOversizedLine(t *testing.T) {
 	// One line of 2 MB, comfortably over the 1 MB scanner limit.
 	resp, chunks := runStreaming(t, `head -c 2000000 /dev/zero | tr '\0' 'a'`)
 
@@ -98,7 +114,7 @@ func TestBashStreaming_ReportsOversizedLine(t *testing.T) {
 
 // TestBashStreaming_NormalOutputUnaffected is the control: ordinary output
 // must stream through unchanged, with no truncation notice.
-func TestBashStreaming_NormalOutputUnaffected(t *testing.T) {
+func TestShellStreaming_NormalOutputUnaffected(t *testing.T) {
 	resp, chunks := runStreaming(t, "printf 'alpha\\nbeta\\ngamma\\n'")
 
 	if strings.Contains(resp.Content, "output truncated") {
@@ -119,10 +135,10 @@ func TestBashStreaming_NormalOutputUnaffected(t *testing.T) {
 // fix does not over-report.
 //
 // The response content is still shorter than the 500 KB produced, because
-// buildBashResponse applies its own deliberate display truncation
+// buildShellResponse applies its own deliberate display truncation
 // (defaultMaxLineLen caps a line at 2000 characters). That is a separate,
 // intended mechanism; what matters here is that the scanner did not error.
-func TestBashStreaming_LongButUnderLimit(t *testing.T) {
+func TestShellStreaming_LongButUnderLimit(t *testing.T) {
 	resp, chunks := runStreaming(t, `head -c 500000 /dev/zero | tr '\0' 'b'`)
 
 	if strings.Contains(resp.Content, "output truncated") {
@@ -151,7 +167,7 @@ func TestBashStreaming_LongButUnderLimit(t *testing.T) {
 // and it is scheduling-dependent, so this runs many iterations. On the
 // unfixed code it reported a spurious "output truncated" notice on the first
 // iteration under -cpu=1,2,4.
-func TestBashStreaming_NoTruncationOnFastExit(t *testing.T) {
+func TestShellStreaming_NoTruncationOnFastExit(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping repeated-iteration race check in short mode")
 	}
@@ -183,7 +199,7 @@ func TestBashStreaming_NoTruncationOnFastExit(t *testing.T) {
 // already completed and nothing it wrote was lost. Reporting it would put a
 // bogus "[output truncated: file already closed]" line on the output of every
 // `cmd &` invocation.
-func TestBashStreaming_BackgroundProcessNoSpuriousNotice(t *testing.T) {
+func TestShellStreaming_BackgroundProcessNoSpuriousNotice(t *testing.T) {
 	// The background process only has to outlive pipeDrainGrace. It is kept
 	// short so the test does not leave a long-lived orphan on the runner: the
 	// foreground shell exits immediately, so nothing reaps this process.

--- a/internal/core/shell_test.go
+++ b/internal/core/shell_test.go
@@ -1,0 +1,254 @@
+package core
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// These tests cover the pure part of the shell tool: argument-vector
+// construction, the name and descriptions derived from the configured shell,
+// and the tool-name mapping. Nothing here starts a process; the tests that do
+// live in shell_exec_test.go and shell_streaming_test.go.
+
+func TestNormalizeShell(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"unset uses the default", nil, []string{"bash"}},
+		{"empty uses the default", []string{}, []string{"bash"}},
+		{"a shell is kept as written", []string{"/bin/dash"}, []string{"/bin/dash"}},
+		{"leading arguments are kept as written", []string{"busybox", "ash"}, []string{"busybox", "ash"}},
+	}
+	for _, c := range cases {
+		if got := normalizeShell(c.in); !reflect.DeepEqual(got, c.want) {
+			t.Errorf("%s: normalizeShell(%#v) = %#v, want %#v", c.name, c.in, got, c.want)
+		}
+	}
+}
+
+func TestResolveShell_DefaultIsUnchangedBehaviour(t *testing.T) {
+	r, err := resolveShell(nil)
+	if err != nil {
+		t.Fatalf("resolveShell(nil): %v", err)
+	}
+	if !reflect.DeepEqual(r.argv, []string{"bash"}) {
+		t.Errorf("argv = %#v, want [bash]", r.argv)
+	}
+	if r.shellPath == "" {
+		t.Error("shellPath is empty")
+	}
+	if got := r.commandArgs("echo hello"); !reflect.DeepEqual(got, []string{"bash", "-c", "echo hello"}) {
+		t.Errorf("commandArgs = %#v, want [bash -c echo hello]", got)
+	}
+}
+
+func TestCommandArgs(t *testing.T) {
+	r, err := resolveShell([]string{"busybox", "ash"})
+	if err != nil {
+		t.Fatalf("resolveShell: %v", err)
+	}
+	got := r.commandArgs("make all")
+	if !reflect.DeepEqual(got, []string{"busybox", "ash", "-c", "make all"}) {
+		t.Errorf("commandArgs = %#v, want [busybox ash -c make all]", got)
+	}
+}
+
+func TestResolveShell_CommandIsOneArgument(t *testing.T) {
+	r, err := resolveShell([]string{"/bin/dash"})
+	if err != nil {
+		t.Fatalf("resolveShell: %v", err)
+	}
+	// A command with spaces, quotes and a semicolon must arrive as a single
+	// argument. Splitting or re-quoting it would change what the shell runs.
+	command := `echo "a b"; echo 'c d'`
+	got := r.commandArgs(command)
+	if len(got) != 3 {
+		t.Fatalf("commandArgs produced %d arguments, want 3: %#v", len(got), got)
+	}
+	if got[2] != command {
+		t.Errorf("command argument = %q, want %q", got[2], command)
+	}
+}
+
+func TestResolveShell_UnresolvableNameIsNotAnError(t *testing.T) {
+	r, err := resolveShell([]string{"no-such-shell-9d3f"})
+	if err != nil {
+		t.Fatalf("a PATH failure must not be an error, got %v", err)
+	}
+	if r.shellPath != "no-such-shell-9d3f" {
+		t.Errorf("shellPath = %q, want the unresolved name", r.shellPath)
+	}
+}
+
+func TestResolveShell_EmptyElementRejected(t *testing.T) {
+	if _, err := resolveShell([]string{"bash", ""}); err != errEmptyShellElement {
+		t.Errorf("resolveShell([bash, \"\"]) error = %v, want errEmptyShellElement", err)
+	}
+	if _, err := resolveShell([]string{""}); err != errEmptyShellElement {
+		t.Errorf("resolveShell([\"\"]) error = %v, want errEmptyShellElement", err)
+	}
+}
+
+func TestShellDisplayName(t *testing.T) {
+	cases := []struct {
+		in   []string
+		want string
+	}{
+		{[]string{"bash"}, "bash"},
+		{[]string{"/bin/dash"}, "/bin/dash"},
+		{[]string{"busybox", "ash"}, "busybox ash"},
+		{[]string{"env", "-i", "/bin/dash"}, "env -i /bin/dash"},
+	}
+	for _, c := range cases {
+		if got := shellDisplayName(c.in); got != c.want {
+			t.Errorf("shellDisplayName(%#v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestShellToolDescription_DialectNote(t *testing.T) {
+	// bash: no dialect note at all.
+	d := shellToolDescription(nil)
+	if !strings.Contains(d, "bash") {
+		t.Errorf("default description does not name bash: %q", d)
+	}
+	if strings.Contains(d, "IMPORTANT") {
+		t.Errorf("default description carries a dialect note: %q", d)
+	}
+
+	// A POSIX shell: name it and ask for POSIX syntax.
+	d = shellToolDescription([]string{"/bin/dash"})
+	if !strings.Contains(d, "/bin/dash") {
+		t.Errorf("description does not name the shell: %q", d)
+	}
+	if !strings.Contains(d, "POSIX sh syntax only") {
+		t.Errorf("description of a POSIX shell does not ask for POSIX syntax: %q", d)
+	}
+
+	// A shell that is not POSIX: name it, and claim no dialect for it.
+	d = shellToolDescription([]string{"/usr/bin/fish"})
+	if !strings.Contains(d, "/usr/bin/fish") {
+		t.Errorf("description does not name the shell: %q", d)
+	}
+	if strings.Contains(d, "POSIX") {
+		t.Errorf("description instructs POSIX syntax for a shell that is not POSIX: %q", d)
+	}
+}
+
+func TestShellCommandParamDescription(t *testing.T) {
+	if got := shellCommandParamDescription(nil); got != "Command to execute with bash" {
+		t.Errorf("default = %q", got)
+	}
+	if got := shellCommandParamDescription([]string{"/bin/dash"}); got != "Command to execute with /bin/dash (POSIX sh syntax)" {
+		t.Errorf("dash = %q", got)
+	}
+	if got := shellCommandParamDescription([]string{"/usr/bin/fish"}); got != "Command to execute with /usr/bin/fish" {
+		t.Errorf("fish = %q", got)
+	}
+}
+
+func TestShellDialectClassification(t *testing.T) {
+	if !isBashShell([]string{"/usr/local/bin/bash"}) {
+		t.Error("bash by absolute path should classify as bash")
+	}
+	if !isPosixShell([]string{"busybox", "ash"}) {
+		t.Error("busybox ash should classify as POSIX")
+	}
+	for _, s := range []string{"zsh", "fish", "nu", "elvish", "pwsh"} {
+		if isPosixShell([]string{s}) {
+			t.Errorf("%s should not classify as POSIX", s)
+		}
+	}
+}
+
+func TestShellTool_NameDoesNotVaryWithTheShell(t *testing.T) {
+	for _, shell := range [][]string{nil, {"bash"}, {"/bin/dash"}, {"busybox", "ash"}} {
+		tool := NewShellTool(WithShell(shell))
+		if got := tool.Info().Name; got != ShellToolName {
+			t.Errorf("shell %#v: tool name = %q, want %q", shell, got, ShellToolName)
+		}
+	}
+}
+
+func TestNormalizeCoreToolName(t *testing.T) {
+	if got := NormalizeCoreToolName(LegacyShellToolName); got != ShellToolName {
+		t.Errorf("NormalizeCoreToolName(%q) = %q, want %q", LegacyShellToolName, got, ShellToolName)
+	}
+	for _, n := range []string{ShellToolName, "read", "write", "edit", "grep", "find", "ls", "subagent", "unknown"} {
+		if got := NormalizeCoreToolName(n); got != n {
+			t.Errorf("NormalizeCoreToolName(%q) = %q, want it unchanged", n, got)
+		}
+	}
+}
+
+func TestListedTools_AcceptsTheEarlierName(t *testing.T) {
+	if got := len(ListedTools([]string{LegacyShellToolName})); got != 1 {
+		t.Errorf("ListedTools([bash]) produced %d tools, want 1", got)
+	}
+	if got := ListedTools([]string{LegacyShellToolName}); len(got) == 1 && got[0].Info().Name != ShellToolName {
+		t.Errorf("ListedTools([bash])[0] = %q, want %q", got[0].Info().Name, ShellToolName)
+	}
+	// An unknown name is skipped rather than dereferenced.
+	if got := len(ListedTools([]string{"no-such-tool"})); got != 0 {
+		t.Errorf("ListedTools([no-such-tool]) produced %d tools, want 0", got)
+	}
+}
+
+func TestApplyOptions_ShellIsPerConfiguration(t *testing.T) {
+	// Two configurations in one process must not observe each other. The
+	// resolution path reads no package-level state, which is what makes this
+	// hold for two Kit instances in one process.
+	a := ApplyOptions([]ToolOption{WithShell([]string{"sh"})})
+	b := ApplyOptions(nil)
+	if !reflect.DeepEqual(a.Shell, []string{"sh"}) {
+		t.Errorf("configured shell = %#v", a.Shell)
+	}
+	if b.Shell != nil {
+		t.Errorf("unconfigured shell = %#v, want nil", b.Shell)
+	}
+	ra, _ := resolveShell(a.Shell)
+	rb, _ := resolveShell(b.Shell)
+	if ra.argv[0] != "sh" || rb.argv[0] != "bash" {
+		t.Errorf("argv0 = %q and %q, want sh and bash", ra.argv[0], rb.argv[0])
+	}
+}
+
+func TestWithShell_EmptyLeavesTheDefault(t *testing.T) {
+	cfg := ApplyOptions([]ToolOption{WithShell(nil), WithShell([]string{})})
+	if cfg.Shell != nil {
+		t.Errorf("Shell = %#v, want nil so that the default applies", cfg.Shell)
+	}
+}
+
+func TestResolveShell_LauncherVectorLeavesSHELLAlone(t *testing.T) {
+	// For ["busybox", "ash"] KIT cannot know which element is the shell;
+	// advertising the busybox binary as SHELL would hand child programs a
+	// dispatcher, not a shell. The resolution reports no path, and the
+	// execution paths then leave SHELL inherited.
+	r, err := resolveShell([]string{"busybox", "ash"})
+	if err != nil {
+		t.Fatalf("resolveShell: %v", err)
+	}
+	if r.shellPath != "" {
+		t.Errorf("shellPath = %q, want empty for a launcher vector", r.shellPath)
+	}
+}
+
+func TestShellCommandArgs_MatchesTheToolConstruction(t *testing.T) {
+	args, shellPath, err := ShellCommandArgs([]string{"busybox", "ash"}, "make all")
+	if err != nil {
+		t.Fatalf("ShellCommandArgs: %v", err)
+	}
+	if !reflect.DeepEqual(args, []string{"busybox", "ash", "-c", "make all"}) {
+		t.Errorf("args = %#v", args)
+	}
+	if shellPath != "" {
+		t.Errorf("shellPath = %q, want empty for a launcher vector", shellPath)
+	}
+	if _, _, err := ShellCommandArgs([]string{""}, "true"); err == nil {
+		t.Error("an empty element must be rejected")
+	}
+}

--- a/internal/core/tools.go
+++ b/internal/core/tools.go
@@ -1,6 +1,6 @@
 // Package core provides the built-in core tools for KIT's coding agent.
 // These tools are direct fantasy.AgentTool implementations — no MCP layer,
-// no JSON-RPC, no serialization overhead. Core tool set: bash, read, write,
+// no JSON-RPC, no serialization overhead. Core tool set: shell, read, write,
 // edit, grep, find, ls.
 package core
 
@@ -24,13 +24,19 @@ type ToolConfig struct {
 	// NamedAgents lists discovered named agent definitions advertised in
 	// the subagent tool description. Only the subagent tool consumes this.
 	NamedAgents []NamedAgentSpec
-	// BashTimeout overrides the default per-call timeout for the bash tool.
-	// Zero uses the built-in default (120s). Only the bash tool consumes this.
-	BashTimeout time.Duration
-	// BashMaxTimeout overrides the ceiling a bash tool call may request via
+	// ShellTimeout overrides the default per-call timeout for the shell tool.
+	// Zero uses the built-in default (120s). Only the shell tool consumes this.
+	ShellTimeout time.Duration
+	// ShellMaxTimeout overrides the ceiling a shell tool call may request via
 	// its timeout argument. Zero uses the built-in default (600s). Only the
-	// bash tool consumes this.
-	BashMaxTimeout time.Duration
+	// shell tool consumes this.
+	ShellMaxTimeout time.Duration
+	// Shell is the shell the shell tool runs a command string through, plus
+	// its own leading arguments, e.g. ["bash"] or ["busybox", "ash"]. Nil or
+	// empty uses the built-in default ["bash"]. This exists so KIT can run
+	// on images that do not ship bash (Alpine, distroless and similar). Only
+	// the shell tool consumes this.
+	Shell []string
 }
 
 // WithWorkDir sets the working directory for file-based tools.
@@ -49,22 +55,34 @@ func WithNamedAgents(agents ...NamedAgentSpec) ToolOption {
 	}
 }
 
-// WithBashTimeout sets the default per-call timeout for the bash tool.
+// WithShellTimeout sets the default per-call timeout for the shell tool.
 // A non-positive duration leaves the built-in default (120s) in place.
-func WithBashTimeout(d time.Duration) ToolOption {
+func WithShellTimeout(d time.Duration) ToolOption {
 	return func(c *ToolConfig) {
 		if d > 0 {
-			c.BashTimeout = d
+			c.ShellTimeout = d
 		}
 	}
 }
 
-// WithBashMaxTimeout sets the maximum timeout a bash tool call may request.
+// WithShellMaxTimeout sets the maximum timeout a shell tool call may request.
 // A non-positive duration leaves the built-in default (600s) in place.
-func WithBashMaxTimeout(d time.Duration) ToolOption {
+func WithShellMaxTimeout(d time.Duration) ToolOption {
 	return func(c *ToolConfig) {
 		if d > 0 {
-			c.BashMaxTimeout = d
+			c.ShellMaxTimeout = d
+		}
+	}
+}
+
+// WithShell sets the shell the shell tool runs command strings through: the
+// shell plus its own leading arguments, e.g. ["bash"] or ["busybox", "ash"].
+// A nil or empty vector leaves the built-in default ["bash"] in place, so an
+// installation that sets nothing executes exactly what it did before.
+func WithShell(argv []string) ToolOption {
+	return func(c *ToolConfig) {
+		if len(argv) > 0 {
+			c.Shell = argv
 		}
 	}
 }
@@ -107,15 +125,39 @@ func parseArgs(input string, target any) error {
 
 type initTool func(...ToolOption) fantasy.AgentTool
 
+// The command-execution tool is a shell tool, and ShellToolName is its name:
+// in the registry, in the tool definition sent to the model, and in a session
+// transcript. It does not vary with the configured shell.
+//
+// LegacyShellToolName is the name the tool had before the shell became
+// configurable. It appears in existing user configuration and in existing
+// sessions, so it is accepted wherever a user names the tool; see
+// NormalizeCoreToolName.
+const (
+	ShellToolName       = "shell"
+	LegacyShellToolName = "bash"
+)
+
+// NormalizeCoreToolName maps a user-supplied core tool name onto its registry
+// key, so that the earlier name for the shell tool keeps selecting it. An
+// unrecognised name in include-core-tools or exclude-core-tools produces a
+// warning and no effect, which is what this avoids.
+func NormalizeCoreToolName(name string) string {
+	if name == LegacyShellToolName {
+		return ShellToolName
+	}
+	return name
+}
+
 var coreTools = map[string]initTool{
-	"bash":     NewBashTool,
-	"read":     NewReadTool,
-	"write":    NewWriteTool,
-	"edit":     NewEditTool,
-	"grep":     NewGrepTool,
-	"find":     NewFindTool,
-	"ls":       NewLsTool,
-	"subagent": NewSubagentTool,
+	ShellToolName: NewShellTool,
+	"read":        NewReadTool,
+	"write":       NewWriteTool,
+	"edit":        NewEditTool,
+	"grep":        NewGrepTool,
+	"find":        NewFindTool,
+	"ls":          NewLsTool,
+	"subagent":    NewSubagentTool,
 }
 
 // ListAllCoreToolNames always returns the full list of available core
@@ -125,10 +167,10 @@ func ListAllCoreToolNames() []string {
 }
 
 // CodingTools returns the default set of core tools for a coding agent:
-// bash, read, write, edit.
+// shell, read, write, edit.
 func CodingTools(opts ...ToolOption) []fantasy.AgentTool {
 	return []fantasy.AgentTool{
-		NewBashTool(opts...),
+		NewShellTool(opts...),
 		NewReadTool(opts...),
 		NewWriteTool(opts...),
 		NewEditTool(opts...),
@@ -150,7 +192,7 @@ func ReadOnlyTools(opts ...ToolOption) []fantasy.AgentTool {
 // infinite recursion when a subagent is itself a Kit instance.
 func SubagentTools(opts ...ToolOption) []fantasy.AgentTool {
 	return []fantasy.AgentTool{
-		NewBashTool(opts...),
+		NewShellTool(opts...),
 		NewReadTool(opts...),
 		NewWriteTool(opts...),
 		NewEditTool(opts...),
@@ -160,10 +202,17 @@ func SubagentTools(opts ...ToolOption) []fantasy.AgentTool {
 	}
 }
 
+// ListedTools builds the named core tools. Names are normalized first, so a
+// list carrying the shell tool's earlier name still selects it, and a name
+// that matches no core tool is skipped rather than dereferenced.
 func ListedTools(toolList []string, opts ...ToolOption) []fantasy.AgentTool {
 	var result = []fantasy.AgentTool{}
 	for _, t := range toolList {
-		result = append(result, coreTools[t](opts...))
+		init, ok := coreTools[NormalizeCoreToolName(t)]
+		if !ok {
+			continue
+		}
+		result = append(result, init(opts...))
 	}
 	return result
 }

--- a/internal/extensions/api.go
+++ b/internal/extensions/api.go
@@ -550,7 +550,7 @@ type Context struct {
 	EmitCustomEvent func(name string, data string)
 
 	// GetAllTools returns information about all tools available to the agent,
-	// including core tools (bash, read, write, etc.), MCP server tools, and
+	// including core tools (shell, read, write, etc.), MCP server tools, and
 	// extension-registered tools. Each entry includes the tool's enabled status.
 	//
 	// Example — list read-only tools:
@@ -1329,6 +1329,15 @@ type API struct {
 
 // OnToolCall registers a handler that fires before a tool executes.
 // Return a non-nil ToolCallResult with Block=true to prevent execution.
+//
+// The event's ToolName is the tool's registered name. The command-execution
+// tool is registered as "shell"; before its shell became configurable it was
+// registered as "bash", so a handler that should run on either version of
+// KIT matches both:
+//
+//	if tc.ToolName != "shell" && tc.ToolName != "bash" { return nil }
+//
+// The bundled extension examples match both names for that reason.
 func (a *API) OnToolCall(handler func(ToolCallEvent, Context) *ToolCallResult) {
 	a.onToolCall(handler)
 }
@@ -1364,7 +1373,7 @@ func (a *API) OnToolExecutionEnd(handler func(ToolExecutionEndEvent, Context)) {
 }
 
 // OnToolOutput registers a handler for streaming tool output chunks.
-// This fires for each output line as it arrives from tools like bash,
+// This fires for each output line as it arrives from tools like the shell tool,
 // allowing extensions to observe or process output in real-time.
 func (a *API) OnToolOutput(handler func(ToolOutputEvent, Context)) {
 	a.onToolOutput(handler)
@@ -2183,7 +2192,11 @@ type OptionDef struct {
 //	})
 type ToolRenderConfig struct {
 	// ToolName is the name of the tool this renderer applies to. Must match
-	// the tool's registered name exactly (e.g. "bash", "read", "my-tool").
+	// the tool's registered name exactly (e.g. "shell", "read", "my-tool").
+	// The one exception is the core shell tool, which is also found under
+	// the name it had before its shell became configurable, "bash". A
+	// renderer naming a tool exactly always wins over that fallback, so a
+	// custom tool of your own named "bash" keeps its own renderer.
 	ToolName string
 
 	// DisplayName, if non-empty, replaces the auto-capitalized tool name
@@ -2391,7 +2404,7 @@ type ToolExecutionEndEvent struct {
 func (e ToolExecutionEndEvent) Type() EventType { return ToolExecutionEnd }
 
 // ToolOutputEvent fires when a tool produces streaming output chunks.
-// This is primarily used for long-running tools like bash to show output
+// This is primarily used for long-running tools like the shell tool to show output
 // in real-time as it arrives, before the tool completes.
 type ToolOutputEvent struct {
 	ToolCallID string
@@ -2477,7 +2490,7 @@ type AgentEndEvent struct {
 	ToolCallCount int
 
 	// ToolNames lists the tool names invoked during this turn, in call order.
-	// Duplicates are preserved (e.g. two bash calls produce ["bash", "bash"]).
+	// Duplicates are preserved (e.g. two shell calls produce ["shell", "shell"]).
 	ToolNames []string
 
 	// LLMCallCount is the number of LLM round-trips (tool-loop iterations)

--- a/internal/extensions/runner.go
+++ b/internal/extensions/runner.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/mark3labs/kit/internal/core"
 	"github.com/spf13/viper"
 )
 
@@ -793,11 +794,50 @@ func (r *Runner) GetUIVisibility() *UIVisibility {
 // no extension registered a renderer for it. If multiple extensions register
 // renderers for the same tool, the last one (by load order) wins. Thread-safe
 // (extensions are immutable after loading).
+// hasCustomTool reports whether a loaded extension registered a tool of its
+// own under this name. The earlier-name compatibility stands down when one
+// does, because the name then belongs to that tool rather than to the core
+// shell tool. Extensions are immutable after loading, so no lock is needed.
+func (r *Runner) hasCustomTool(name string) bool {
+	for _, ext := range r.extensions {
+		for _, tool := range ext.Tools {
+			if tool.Name == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (r *Runner) GetToolRenderer(toolName string) *ToolRenderConfig {
-	// Walk extensions in reverse so last-registered wins.
+	// A renderer that names the tool as written wins, so a custom tool that
+	// really is named "bash" keeps its own renderer whatever the load order.
+	if renderer := r.findToolRenderer(func(name string) bool {
+		return name == toolName
+	}); renderer != nil {
+		return renderer
+	}
+	// Failing that, the shell tool answers to the name it had before its
+	// shell became configurable: an extension written before the rename
+	// keeps rendering live calls, and a session recorded before it replays
+	// with its renderer. This applies to the core tool only, so an extension
+	// that registers a tool of its own under the earlier name keeps its
+	// renderer to itself.
+	if r.hasCustomTool(core.LegacyShellToolName) {
+		return nil
+	}
+	normalized := core.NormalizeCoreToolName(toolName)
+	return r.findToolRenderer(func(name string) bool {
+		return core.NormalizeCoreToolName(name) == normalized
+	})
+}
+
+// findToolRenderer returns the first renderer whose tool name satisfies match,
+// walking extensions in reverse so the last registered one wins.
+func (r *Runner) findToolRenderer(match func(string) bool) *ToolRenderConfig {
 	for _, ext := range slices.Backward(r.extensions) {
 		for _, renderer := range slices.Backward(ext.ToolRenderers) {
-			if renderer.ToolName == toolName {
+			if match(renderer.ToolName) {
 				return &renderer
 			}
 		}
@@ -1096,8 +1136,16 @@ func (r *Runner) SetActiveTools(names []string) {
 		return
 	}
 	active := make(map[string]bool, len(names))
+	// A list written for an earlier KIT keeps enabling the shell tool. The
+	// alias applies to the core tool only: when an extension registers a
+	// tool of its own under the earlier name, that name selects that tool
+	// and nothing else, so a restriction never admits more than it names.
+	aliasCoreTool := !r.hasCustomTool(core.LegacyShellToolName)
 	for _, n := range names {
 		active[n] = true
+		if aliasCoreTool {
+			active[core.NormalizeCoreToolName(n)] = true
+		}
 	}
 	r.disabledTools = active // non-nil = only these tools are allowed
 }

--- a/internal/extensions/runner.go
+++ b/internal/extensions/runner.go
@@ -797,7 +797,9 @@ func (r *Runner) GetUIVisibility() *UIVisibility {
 // hasCustomTool reports whether a loaded extension registered a tool of its
 // own under this name. The earlier-name compatibility stands down when one
 // does, because the name then belongs to that tool rather than to the core
-// shell tool. Extensions are immutable after loading, so no lock is needed.
+// shell tool. It takes no lock of its own: SetActiveTools calls it while
+// holding r.mu, and the read of r.extensions follows the convention of the
+// other readers in this file.
 func (r *Runner) hasCustomTool(name string) bool {
 	for _, ext := range r.extensions {
 		for _, tool := range ext.Tools {
@@ -807,6 +809,13 @@ func (r *Runner) hasCustomTool(name string) bool {
 		}
 	}
 	return false
+}
+
+// shadowsShellToolName reports whether an extension registered a tool under
+// either name of the core shell tool. The names are then ambiguous, so the
+// earlier-name fallback stands down rather than guess.
+func (r *Runner) shadowsShellToolName() bool {
+	return r.hasCustomTool(core.LegacyShellToolName) || r.hasCustomTool(core.ShellToolName)
 }
 
 func (r *Runner) GetToolRenderer(toolName string) *ToolRenderConfig {
@@ -821,9 +830,9 @@ func (r *Runner) GetToolRenderer(toolName string) *ToolRenderConfig {
 	// shell became configurable: an extension written before the rename
 	// keeps rendering live calls, and a session recorded before it replays
 	// with its renderer. This applies to the core tool only, so an extension
-	// that registers a tool of its own under the earlier name keeps its
-	// renderer to itself.
-	if r.hasCustomTool(core.LegacyShellToolName) {
+	// that registers a tool of its own under either name keeps its renderer
+	// to itself and leaves the core tool with the default rendering.
+	if r.shadowsShellToolName() {
 		return nil
 	}
 	normalized := core.NormalizeCoreToolName(toolName)
@@ -1140,7 +1149,7 @@ func (r *Runner) SetActiveTools(names []string) {
 	// alias applies to the core tool only: when an extension registers a
 	// tool of its own under the earlier name, that name selects that tool
 	// and nothing else, so a restriction never admits more than it names.
-	aliasCoreTool := !r.hasCustomTool(core.LegacyShellToolName)
+	aliasCoreTool := !r.shadowsShellToolName()
 	for _, n := range names {
 		active[n] = true
 		if aliasCoreTool {

--- a/internal/extensions/runner.go
+++ b/internal/extensions/runner.go
@@ -790,18 +790,13 @@ func (r *Runner) GetUIVisibility() *UIVisibility {
 // Tool renderer management
 // ---------------------------------------------------------------------------
 
-// GetToolRenderer returns the custom renderer for the named tool, or nil if
-// no extension registered a renderer for it. If multiple extensions register
-// renderers for the same tool, the last one (by load order) wins. Thread-safe
-// (extensions are immutable after loading).
-// hasCustomTool reports whether a loaded extension registered a tool of its
-// own under this name. The earlier-name compatibility stands down when one
+// hasCustomToolIn reports whether one of these extensions registered a tool of
+// its own under this name. The earlier-name compatibility stands down when one
 // does, because the name then belongs to that tool rather than to the core
-// shell tool. It takes no lock of its own: SetActiveTools calls it while
-// holding r.mu, and the read of r.extensions follows the convention of the
-// other readers in this file.
-func (r *Runner) hasCustomTool(name string) bool {
-	for _, ext := range r.extensions {
+// shell tool. It operates on a snapshot of r.extensions; the caller takes it
+// under r.mu, as Reload swaps the slice under the write lock.
+func hasCustomToolIn(exts []LoadedExtension, name string) bool {
+	for _, ext := range exts {
 		for _, tool := range ext.Tools {
 			if tool.Name == name {
 				return true
@@ -811,17 +806,27 @@ func (r *Runner) hasCustomTool(name string) bool {
 	return false
 }
 
-// shadowsShellToolName reports whether an extension registered a tool under
-// either name of the core shell tool. The names are then ambiguous, so the
-// earlier-name fallback stands down rather than guess.
-func (r *Runner) shadowsShellToolName() bool {
-	return r.hasCustomTool(core.LegacyShellToolName) || r.hasCustomTool(core.ShellToolName)
+// shadowsShellToolNameIn reports whether one of these extensions registered a
+// tool under either name of the core shell tool. The names are then ambiguous,
+// so the earlier-name fallback stands down rather than guess.
+func shadowsShellToolNameIn(exts []LoadedExtension) bool {
+	return hasCustomToolIn(exts, core.LegacyShellToolName) || hasCustomToolIn(exts, core.ShellToolName)
 }
 
+// GetToolRenderer returns the custom renderer for the named tool, or nil when
+// no extension registered one. If several extensions register renderers for
+// the same tool, the last one by load order wins.
 func (r *Runner) GetToolRenderer(toolName string) *ToolRenderConfig {
+	// Snapshot under the read lock: Reload swaps r.extensions under the
+	// write lock, and this can run on the UI goroutine while the watcher
+	// reloads.
+	r.mu.RLock()
+	exts := r.extensions
+	r.mu.RUnlock()
+
 	// A renderer that names the tool as written wins, so a custom tool that
 	// really is named "bash" keeps its own renderer whatever the load order.
-	if renderer := r.findToolRenderer(func(name string) bool {
+	if renderer := findToolRendererIn(exts, func(name string) bool {
 		return name == toolName
 	}); renderer != nil {
 		return renderer
@@ -832,19 +837,19 @@ func (r *Runner) GetToolRenderer(toolName string) *ToolRenderConfig {
 	// with its renderer. This applies to the core tool only, so an extension
 	// that registers a tool of its own under either name keeps its renderer
 	// to itself and leaves the core tool with the default rendering.
-	if r.shadowsShellToolName() {
+	if shadowsShellToolNameIn(exts) {
 		return nil
 	}
 	normalized := core.NormalizeCoreToolName(toolName)
-	return r.findToolRenderer(func(name string) bool {
+	return findToolRendererIn(exts, func(name string) bool {
 		return core.NormalizeCoreToolName(name) == normalized
 	})
 }
 
-// findToolRenderer returns the first renderer whose tool name satisfies match,
-// walking extensions in reverse so the last registered one wins.
-func (r *Runner) findToolRenderer(match func(string) bool) *ToolRenderConfig {
-	for _, ext := range slices.Backward(r.extensions) {
+// findToolRendererIn returns the first renderer whose tool name satisfies
+// match, walking extensions in reverse so the last registered one wins.
+func findToolRendererIn(exts []LoadedExtension, match func(string) bool) *ToolRenderConfig {
+	for _, ext := range slices.Backward(exts) {
 		for _, renderer := range slices.Backward(ext.ToolRenderers) {
 			if match(renderer.ToolName) {
 				return &renderer
@@ -1149,7 +1154,7 @@ func (r *Runner) SetActiveTools(names []string) {
 	// alias applies to the core tool only: when an extension registers a
 	// tool of its own under the earlier name, that name selects that tool
 	// and nothing else, so a restriction never admits more than it names.
-	aliasCoreTool := !r.shadowsShellToolName()
+	aliasCoreTool := !shadowsShellToolNameIn(r.extensions)
 	for _, n := range names {
 		active[n] = true
 		if aliasCoreTool {

--- a/internal/extensions/runner_test.go
+++ b/internal/extensions/runner_test.go
@@ -824,3 +824,19 @@ func TestLegacyShellNameIsScopedToTheCoreTool(t *testing.T) {
 		t.Errorf("renderer for the core shell tool = %+v, want the legacy one", got)
 	}
 }
+
+func TestRenderer_CustomToolUnderTheCurrentNameGetsNoLegacyFallback(t *testing.T) {
+	// An extension registering a tool called "shell" shadows the core tool's
+	// own name. Both names are then ambiguous, so a renderer registered under
+	// the earlier name must not be handed to that tool.
+	r := NewRunner([]LoadedExtension{{
+		Tools:         []ToolDef{{Name: "shell"}},
+		ToolRenderers: []ToolRenderConfig{{ToolName: "bash", DisplayName: "Legacy"}},
+	}})
+	if got := r.GetToolRenderer("shell"); got != nil {
+		t.Errorf("renderer for a shadowing custom tool = %+v, want none", got)
+	}
+	if got := r.GetToolRenderer("bash"); got == nil || got.DisplayName != "Legacy" {
+		t.Errorf("renderer named as written = %+v, want the legacy one", got)
+	}
+}

--- a/internal/extensions/runner_test.go
+++ b/internal/extensions/runner_test.go
@@ -711,3 +711,116 @@ func TestRunner_ReentrantEmitCustomEvent(t *testing.T) {
 		t.Errorf("expected [session_start, custom:hello], got %v", order)
 	}
 }
+
+func TestGetToolRenderer_AcceptsEitherShellToolName(t *testing.T) {
+	// A renderer registered under the shell tool's earlier name is found for
+	// a live call, which reports the registered name.
+	r := NewRunner([]LoadedExtension{{
+		ToolRenderers: []ToolRenderConfig{{ToolName: "bash", DisplayName: "Terminal"}},
+	}})
+	if got := r.GetToolRenderer("shell"); got == nil || got.DisplayName != "Terminal" {
+		t.Fatalf("renderer registered under the earlier name was not found for the registered name: %#v", got)
+	}
+	// A renderer registered under the current name is found when a session
+	// recorded before the rename replays with the earlier name.
+	r = NewRunner([]LoadedExtension{{
+		ToolRenderers: []ToolRenderConfig{{ToolName: "shell", DisplayName: "Terminal"}},
+	}})
+	if got := r.GetToolRenderer("bash"); got == nil || got.DisplayName != "Terminal" {
+		t.Fatalf("renderer registered under the current name was not found for the earlier name: %#v", got)
+	}
+}
+
+func TestSetActiveTools_AcceptsTheEarlierName(t *testing.T) {
+	r := NewRunner(nil)
+
+	r.SetActiveTools([]string{"bash", "read"})
+	if r.IsToolDisabled("shell") {
+		t.Error("the earlier name must keep the shell tool enabled")
+	}
+	if r.IsToolDisabled("bash") {
+		t.Error("a custom tool named bash must stay enabled")
+	}
+	if r.IsToolDisabled("read") {
+		t.Error("read was named and must stay enabled")
+	}
+	if !r.IsToolDisabled("write") {
+		t.Error("an unnamed tool must be disabled")
+	}
+
+	r.SetActiveTools([]string{"shell"})
+	if r.IsToolDisabled("shell") {
+		t.Error("the current name must enable the shell tool")
+	}
+
+	r.SetActiveTools(nil)
+	if r.IsToolDisabled("write") {
+		t.Error("an empty list must re-enable all tools")
+	}
+}
+
+func TestGetToolRenderer_ExactMatchBeatsTheEarlierName(t *testing.T) {
+	// A custom tool really named "bash" and the core shell tool must each
+	// keep their own renderer, whichever extension loads first.
+	shellRenderer := ToolRenderConfig{ToolName: "shell", DisplayName: "Shell"}
+	bashRenderer := ToolRenderConfig{ToolName: "bash", DisplayName: "Custom bash"}
+
+	for _, order := range [][]ToolRenderConfig{
+		{shellRenderer, bashRenderer},
+		{bashRenderer, shellRenderer},
+	} {
+		r := NewRunner([]LoadedExtension{{ToolRenderers: order}})
+		if got := r.GetToolRenderer("shell"); got == nil || got.DisplayName != "Shell" {
+			t.Errorf("order %v: renderer for shell = %+v, want the shell renderer", order, got)
+		}
+		if got := r.GetToolRenderer("bash"); got == nil || got.DisplayName != "Custom bash" {
+			t.Errorf("order %v: renderer for bash = %+v, want the custom renderer", order, got)
+		}
+	}
+
+	// Without a renderer of its own, the earlier name still reaches the
+	// shell tool's renderer, so sessions recorded before the rename replay.
+	r := NewRunner([]LoadedExtension{{ToolRenderers: []ToolRenderConfig{shellRenderer}}})
+	if got := r.GetToolRenderer("bash"); got == nil || got.DisplayName != "Shell" {
+		t.Errorf("fallback renderer = %+v, want the shell renderer", got)
+	}
+}
+
+func TestLegacyShellNameIsScopedToTheCoreTool(t *testing.T) {
+	customBash := LoadedExtension{
+		Tools:         []ToolDef{{Name: "bash"}},
+		ToolRenderers: []ToolRenderConfig{{ToolName: "bash", DisplayName: "Custom bash"}},
+	}
+
+	// A restriction that names the earlier name selects that extension's own
+	// tool and nothing else: it must not admit the core shell tool as well.
+	r := NewRunner([]LoadedExtension{customBash})
+	r.SetActiveTools([]string{"bash"})
+	if r.IsToolDisabled("bash") {
+		t.Error("the custom tool was named and must stay enabled")
+	}
+	if !r.IsToolDisabled("shell") {
+		t.Error("naming a custom tool must not enable the core shell tool")
+	}
+
+	// The renderer of that tool stays its own, and the core shell tool falls
+	// back to the default rendering rather than borrowing it.
+	if got := r.GetToolRenderer("bash"); got == nil || got.DisplayName != "Custom bash" {
+		t.Errorf("renderer for the custom tool = %+v, want its own", got)
+	}
+	if got := r.GetToolRenderer("shell"); got != nil {
+		t.Errorf("renderer for the core shell tool = %+v, want none", got)
+	}
+
+	// Without such a tool, the earlier name keeps reaching the core tool.
+	r = NewRunner([]LoadedExtension{{
+		ToolRenderers: []ToolRenderConfig{{ToolName: "bash", DisplayName: "Legacy"}},
+	}})
+	r.SetActiveTools([]string{"bash"})
+	if r.IsToolDisabled("shell") {
+		t.Error("without a custom tool of that name, the earlier name must enable the shell tool")
+	}
+	if got := r.GetToolRenderer("shell"); got == nil || got.DisplayName != "Legacy" {
+		t.Errorf("renderer for the core shell tool = %+v, want the legacy one", got)
+	}
+}

--- a/internal/extensions/toolkinds.go
+++ b/internal/extensions/toolkinds.go
@@ -8,7 +8,7 @@ package extensions
 // This is the single source of truth for tool-kind classification; the
 // pkg/kit SDK re-exports these constants.
 const (
-	ToolKindExecute  = "execute" // Shell execution (bash)
+	ToolKindExecute  = "execute" // Shell execution (the shell tool)
 	ToolKindEdit     = "edit"    // File modification (edit, write)
 	ToolKindRead     = "read"    // File reading (read, ls)
 	ToolKindSearch   = "search"  // Content/file search (grep, find)
@@ -18,7 +18,8 @@ const (
 // coreToolKinds maps built-in tool names to their kind classification.
 // MCP and extension tools without an entry default to ToolKindExecute.
 var coreToolKinds = map[string]string{
-	"bash":     ToolKindExecute,
+	"shell":    ToolKindExecute,
+	"bash":     ToolKindExecute, // the shell tool's earlier name
 	"edit":     ToolKindEdit,
 	"write":    ToolKindEdit,
 	"read":     ToolKindRead,

--- a/internal/kitsetup/setup.go
+++ b/internal/kitsetup/setup.go
@@ -45,12 +45,15 @@ type AgentSetupOptions struct {
 	// NamedAgents lists discovered named agent definitions to advertise in
 	// the subagent tool description.
 	NamedAgents []core.NamedAgentSpec
-	// BashTimeout sets the default per-call timeout (seconds) for the bash
+	// ShellTimeout sets the default per-call timeout (seconds) for the shell
 	// tool. Zero uses the built-in default (120s).
-	BashTimeout int
-	// BashMaxTimeout caps the maximum timeout (seconds) a bash tool call may
+	ShellTimeout int
+	// ShellMaxTimeout caps the maximum timeout (seconds) a shell tool call may
 	// request. Zero uses the built-in default (600s).
-	BashMaxTimeout int
+	ShellMaxTimeout int
+	// Shell is the argument vector prefix the shell tool runs a command
+	// string through. Empty uses the built-in default ["bash"].
+	Shell []string
 	// ToolWrapper is an optional function that wraps tools after extension
 	// wrapping. Used by the SDK hook system. Both wrappers compose:
 	// extension wrapper runs first (inner), then this wrapper (outer).
@@ -276,8 +279,9 @@ func SetupAgent(ctx context.Context, opts AgentSetupOptions) (*AgentSetupResult,
 		ToolWrapper:       toolWrapper,
 		ExtraTools:        extraTools,
 		NamedAgents:       opts.NamedAgents,
-		BashTimeout:       opts.BashTimeout,
-		BashMaxTimeout:    opts.BashMaxTimeout,
+		ShellTimeout:      opts.ShellTimeout,
+		ShellMaxTimeout:   opts.ShellMaxTimeout,
+		Shell:             opts.Shell,
 		OnMCPServerLoaded: opts.OnMCPServerLoaded,
 		MCPTaskConfig:     opts.MCPTaskConfig,
 	})

--- a/internal/ui/activity.go
+++ b/internal/ui/activity.go
@@ -46,7 +46,9 @@ func activityVerb(toolName, toolArgs string) string {
 	var verb, target string
 
 	switch strings.ToLower(toolName) {
-	case "bash":
+	// The shell tool answers to its earlier name as well, so that a session
+	// recorded before the rename still renders with a verb.
+	case "shell", "bash":
 		verb, target = "Running", shortenTarget(oneLine(argString(args, "command")))
 	case "read":
 		verb, target = "Reading", shortenActivityPath(argString(args, "path"))

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -402,6 +402,10 @@ type AppModelOptions struct {
 	// If empty, @file features are disabled.
 	Cwd string
 
+	// Shell is the shell the ! and !! commands run through: the shell plus
+	// its own leading arguments. Empty means the built-in default, bash.
+	Shell []string
+
 	// Width is the initial terminal width in columns.
 	Width int
 
@@ -957,7 +961,8 @@ type AppModel struct {
 	navNotice string
 
 	// cwd is the working directory for @file path resolution.
-	cwd string
+	cwd   string
+	shell []string // shell for the ! and !! commands; empty means bash
 
 	// gitBranch is the current git branch name, resolved once when cwd is
 	// set. Empty when the working directory is not a git repository. Shown
@@ -1140,6 +1145,7 @@ func NewAppModel(appCtrl AppController, opts AppModelOptions) *AppModel {
 		getMCPToolCount: opts.GetMCPToolCount,
 		usageTracker:    opts.UsageTracker,
 		cwd:             opts.Cwd,
+		shell:           opts.Shell,
 		width:           width,
 		height:          height,
 	}
@@ -2589,8 +2595,10 @@ func (m *AppModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// rendered when the ToolResultEvent arrives.
 		m.flushStreamContent()
 
-		// For bash commands, extract and store the command for the streaming output header.
-		if msg.ToolName == "bash" {
+		// For shell commands, extract and store the command for the streaming
+		// output header. The earlier tool name is accepted too, so a replayed
+		// session keeps its header.
+		if msg.ToolName == core.ShellToolName || msg.ToolName == core.LegacyShellToolName {
 			var args struct {
 				Command string `json:"command"`
 			}
@@ -6749,29 +6757,41 @@ func (m *AppModel) executeShellCommand(msg uicore.ShellCommandMsg) tea.Cmd {
 	command := msg.Command
 	excludeFromContext := msg.ExcludeFromContext
 	cwd := m.cwd
+	shell := m.shell
 
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), shellCommandTimeout)
 		defer cancel()
 
-		cmd := exec.CommandContext(ctx, "bash", "-c", command)
+		// The same construction the shell tool uses, so ! and !! run through
+		// the configured shell rather than through a hardcoded bash.
+		cmdArgs, shellPath, err := core.ShellCommandArgs(shell, command)
+		if err != nil {
+			return uicore.ShellCommandResultMsg{
+				Command:            command,
+				Output:             fmt.Sprintf("invalid shell configuration: %v", err),
+				ExitCode:           -1,
+				Err:                err,
+				ExcludeFromContext: excludeFromContext,
+			}
+		}
+		cmd := exec.CommandContext(ctx, cmdArgs[0], cmdArgs[1:]...)
 		if cwd != "" {
 			cmd.Dir = cwd
 		}
 
-		// Ensure SHELL is set to bash so child processes (e.g. tmux) use bash
-		// rather than the user's login shell (which may be nushell, fish, etc.).
-		bashPath, _ := exec.LookPath("bash")
-		if bashPath == "" {
-			bashPath = "/bin/bash"
+		// Point SHELL at the configured shell so child processes (e.g. tmux)
+		// use it rather than the user's login shell (which may be nushell,
+		// fish, etc.). A launcher vector leaves SHELL inherited.
+		if shellPath != "" {
+			cmd.Env = append(os.Environ(), "SHELL="+shellPath)
 		}
-		cmd.Env = append(os.Environ(), "SHELL="+bashPath)
 
 		var stdout, stderr bytes.Buffer
 		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr
 
-		err := cmd.Run()
+		err = cmd.Run()
 
 		exitCode := 0
 		if err != nil {

--- a/pkg/kit/README.md
+++ b/pkg/kit/README.md
@@ -99,10 +99,13 @@ host, err := kit.New(ctx, &kit.Options{
     NoSession:    true,                       // Ephemeral mode
 
     // Tool options
-    Tools:            []kit.Tool{kit.NewBashTool()}, // Replace default tool set
+    Tools:            []kit.Tool{kit.NewShellTool(kit.WithShell([]string{"busybox", "ash"}))}, // Replace default tool set; a hand-built tool takes its own options
     ExtraTools:       []kit.Tool{myTool},            // Add alongside defaults
     DisableCoreTools: true,                        // Use no core tools (0 tools)
     CoreToolList      []string,                    // List of core tools to include, if empty (default) use all.
+    Shell:            []string{"busybox", "ash"},  // Shell for the default core tool set: the shell plus its own leading arguments (default bash)
+    ShellTimeout:     120,                         // Default shell-tool timeout in seconds
+    ShellMaxTimeout:  600,                         // Ceiling a single shell call may request in seconds
 
     // Configuration
     SkipConfig:   true,                        // Skip .kit.yml files (viper defaults + env vars still apply)

--- a/pkg/kit/agents.go
+++ b/pkg/kit/agents.go
@@ -177,10 +177,16 @@ func applyAgentDefinition(cfg *SubagentConfig, def *AgentDefinition) {
 // preserving order. Allowlisted names with no matching tool are ignored.
 // The result is never nil so an empty allowlist match still counts as an
 // explicit (empty) tool set rather than "use defaults".
+//
+// Each entry admits the tool-name mapping's result in addition to the entry
+// as written: an agent definition that says "bash" still selects the shell
+// tool, and a custom tool that really is named "bash" still matches its own
+// entry.
 func filterToolsByName(tools []Tool, names []string) []Tool {
-	allowed := make(map[string]struct{}, len(names))
+	allowed := make(map[string]struct{}, len(names)*2)
 	for _, n := range names {
 		allowed[n] = struct{}{}
+		allowed[core.NormalizeCoreToolName(n)] = struct{}{}
 	}
 	filtered := make([]Tool, 0, len(names))
 	for _, t := range tools {

--- a/pkg/kit/config.go
+++ b/pkg/kit/config.go
@@ -22,7 +22,7 @@ Available tools:
 - read: Read file or directory contents (supports pagination via offset/limit)
 - write: Create or overwrite files
 - edit: Make surgical edits to files (find exact text and replace)
-- bash: Execute bash commands with timeout support
+- shell: Execute commands through the configured shell (bash by default), with timeout support
 - grep: Search file contents using regex patterns (respects .gitignore)
 - find: Search for files by glob pattern (respects .gitignore)
 - ls: List directory contents
@@ -30,11 +30,11 @@ Available tools:
 In addition to the tools above, you may have access to other custom tools from MCP servers and extensions.
 
 Guidelines:
-- Prefer grep/find/ls tools over bash for file exploration (faster, respects .gitignore)
+- Prefer grep/find/ls tools over shell for file exploration (faster, respects .gitignore)
 - Use read to examine files before editing
 - Use edit for precise changes (old text must match exactly, including whitespace)
 - Use write only for new files or complete rewrites
-- When summarizing your actions, output plain text directly - do NOT use cat or bash to display what you did
+- When summarizing your actions, output plain text directly - do NOT use cat or the shell tool to display what you did
 - Be concise in your responses
 - Show file paths clearly when working with files`
 

--- a/pkg/kit/events.go
+++ b/pkg/kit/events.go
@@ -109,7 +109,7 @@ type Event interface {
 // These constants re-export the canonical classification used by extension
 // events, so SDK events and extension events always agree.
 const (
-	ToolKindExecute  = extensions.ToolKindExecute  // Shell execution (bash)
+	ToolKindExecute  = extensions.ToolKindExecute  // Shell execution
 	ToolKindEdit     = extensions.ToolKindEdit     // File modification (edit, write)
 	ToolKindRead     = extensions.ToolKindRead     // File reading (read, ls)
 	ToolKindSearch   = extensions.ToolKindSearch   // Content/file search (grep, find)
@@ -219,7 +219,7 @@ type ReasoningCompleteEvent struct{}
 // EventType implements Event.
 func (e ReasoningCompleteEvent) EventType() EventType { return EventReasoningComplete }
 
-// ToolOutputEvent fires when a tool produces streaming output chunks (e.g., bash output).
+// ToolOutputEvent fires when a tool produces streaming output chunks (e.g., shell output).
 type ToolOutputEvent struct {
 	ToolCallID string
 	ToolName   string
@@ -620,7 +620,7 @@ func (m *Kit) OnToolResult(handler func(ToolResultEvent)) func() {
 }
 
 // OnToolOutput registers a handler that fires only for ToolOutputEvent
-// (streaming tool output chunks, e.g., from bash). Returns an unsubscribe function.
+// (streaming tool output chunks, e.g., from the shell tool). Returns an unsubscribe function.
 func (m *Kit) OnToolOutput(handler func(ToolOutputEvent)) func() {
 	return subscribeTyped(m, handler)
 }

--- a/pkg/kit/kit.go
+++ b/pkg/kit/kit.go
@@ -42,9 +42,13 @@ type ContextFile struct {
 // integration of MCP tools and LLM interactions into Go applications. It manages
 // agents, sessions, and model configurations.
 type Kit struct {
-	agent          *agent.Agent
-	session        SessionManager
-	modelString    string
+	agent       *agent.Agent
+	session     SessionManager
+	modelString string
+	// shell is the effective shell of this instance, resolved from the SDK
+	// option and the configuration store at construction. Subagents built
+	// without an explicit tool set inherit it.
+	shell          []string
 	events         *eventBus
 	autoCompact    bool
 	compactionOpts *CompactionOptions
@@ -1209,14 +1213,37 @@ type Options struct {
 	// will have no tools (useful for simple chat completions).
 	DisableCoreTools bool
 
-	// BashTimeout sets the default per-call timeout (in seconds) for the bash
-	// tool, applied when the model does not specify one. Zero falls back to
-	// the "bash-timeout" config value, then the built-in default (120s).
+	// ShellTimeout sets the default per-call timeout (in seconds) for the
+	// shell tool, applied when the model does not specify one. Zero falls back
+	// to BashTimeout, then the "shell-timeout" config value, then
+	// "bash-timeout", then the built-in default (120s).
+	ShellTimeout int
+
+	// ShellMaxTimeout caps the maximum timeout (in seconds) a shell tool call
+	// may request via its timeout argument. Zero falls back to BashMaxTimeout,
+	// then the "shell-max-timeout" config value, then "bash-max-timeout", then
+	// the built-in default (600s).
+	ShellMaxTimeout int
+
+	// Shell is the shell the shell tool runs a command string through, plus
+	// its own leading arguments, e.g. []string{"bash"} or
+	// []string{"busybox", "ash"}. Nil falls back to the "shell" config value,
+	// then the built-in default ["bash"]. Set this to run on images that do
+	// not ship bash.
+	Shell []string
+
+	// BashTimeout is the name ShellTimeout had before the tool's shell became
+	// configurable.
+	//
+	// Deprecated: use ShellTimeout. Both set the same value and ShellTimeout
+	// wins when both are set.
 	BashTimeout int
 
-	// BashMaxTimeout caps the maximum timeout (in seconds) a bash tool call
-	// may request via its timeout argument. Zero falls back to the
-	// "bash-max-timeout" config value, then the built-in default (600s).
+	// BashMaxTimeout is the name ShellMaxTimeout had before the tool's shell
+	// became configurable.
+	//
+	// Deprecated: use ShellMaxTimeout. Both set the same value and
+	// ShellMaxTimeout wins when both are set.
 	BashMaxTimeout int
 
 	// Session configuration
@@ -1526,8 +1553,9 @@ func New(ctx context.Context, opts *Options) (*Kit, error) {
 		toolList              []string
 		maxSteps              int
 		streaming             bool
-		bashTimeout           int
-		bashMaxTimeout        int
+		shellTimeout          int
+		shellMaxTimeout       int
+		shell                 []string
 		hasCustomSystemPrompt bool
 		systemPromptSource    string
 		capturedBasePrompt    string
@@ -1780,13 +1808,13 @@ func New(ctx context.Context, opts *Options) (*Kit, error) {
 		toolList = handleCoreToolList(toolList, opts.DisableCoreTools || v.GetBool("no-core-tools"))
 		maxSteps = v.GetInt("max-steps")
 		streaming = v.GetBool("stream")
-		bashTimeout = opts.BashTimeout
-		if bashTimeout == 0 {
-			bashTimeout = v.GetInt("bash-timeout")
-		}
-		bashMaxTimeout = opts.BashMaxTimeout
-		if bashMaxTimeout == 0 {
-			bashMaxTimeout = v.GetInt("bash-max-timeout")
+		// Each of the two timeouts has a shell-named form and the bash-named
+		// form it had before the tool's shell became configurable; see
+		// resolveShellTimeouts for the precedence.
+		shellTimeout, shellMaxTimeout = resolveShellTimeouts(opts, v)
+		shell = opts.Shell
+		if len(shell) == 0 {
+			shell = v.GetStringSlice("shell")
 		}
 
 		return nil
@@ -1871,8 +1899,9 @@ func New(ctx context.Context, opts *Options) (*Kit, error) {
 		CoreToolList:      toolList,
 		ExtraTools:        extraTools,
 		NamedAgents:       namedAgentSpecs(namedAgents),
-		BashTimeout:       bashTimeout,
-		BashMaxTimeout:    bashMaxTimeout,
+		ShellTimeout:      shellTimeout,
+		ShellMaxTimeout:   shellMaxTimeout,
+		Shell:             shell,
 		ToolWrapper:       hookToolWrapper(beforeToolCall, afterToolResult),
 		ProviderConfig:    providerConfig,
 		Debug:             debug,
@@ -1950,6 +1979,7 @@ func New(ctx context.Context, opts *Options) (*Kit, error) {
 		agent:                 agentResult.Agent,
 		session:               sessionManager,
 		modelString:           modelString,
+		shell:                 append([]string(nil), shell...),
 		events:                newEventBus(),
 		autoCompact:           opts.AutoCompact,
 		compactionOpts:        opts.CompactionOptions,
@@ -2312,7 +2342,8 @@ type SubagentConfig struct {
 
 	// Tools overrides the tool set available to the subagent.
 	// If nil and the subagent is created via the SDK (Kit.Subagent()), the
-	// static SubagentTools() set (all core tools except "subagent") is used.
+	// default set (all core tools except "subagent", built with the
+	// parent's effective shell) is used.
 	// When spawned internally by the agent loop, the parent's active tools
 	// minus "subagent" are used instead (see GetToolsForSubagent()).
 	// Pass m.GetToolsForSubagent() explicitly to opt into inheritance from
@@ -2460,6 +2491,14 @@ func toolsIncludeMCP(tools []Tool, mcpNames []string) bool {
 //
 // This is the recommended way to run subagents in the SDK — no subprocess,
 // no kit binary dependency, native Go types for results.
+// subagentDefaultTools is the tool set a subagent receives when its
+// configuration names none: every core tool except subagent, built with the
+// parent's effective shell, so that a child on an image without bash keeps
+// working.
+func (m *Kit) subagentDefaultTools() []Tool {
+	return SubagentTools(WithShell(m.shell))
+}
+
 func (m *Kit) Subagent(ctx context.Context, cfg SubagentConfig) (*SubagentResult, error) {
 	if cfg.Prompt == "" {
 		return nil, fmt.Errorf("subagent prompt is required")
@@ -2548,10 +2587,11 @@ func (m *Kit) Subagent(ctx context.Context, cfg SubagentConfig) (*SubagentResult
 		systemPrompt = "You are a helpful coding assistant. Complete the task efficiently and thoroughly."
 	}
 
-	// Default tools: everything except subagent.
+	// Default tools: everything except subagent, built with the parent's
+	// effective shell.
 	tools := cfg.Tools
 	if tools == nil {
-		tools = SubagentTools()
+		tools = m.subagentDefaultTools()
 	}
 
 	// Decide whether the child should re-load MCP servers. When the caller

--- a/pkg/kit/kit_test.go
+++ b/pkg/kit/kit_test.go
@@ -580,6 +580,8 @@ exclude-core-tools:
 	})
 	t.Run("Test whether include-core-tools works", func(t *testing.T) {
 		cfgFile := t.TempDir() + "/.kit.yml"
+		// "bash" is the earlier name of the shell tool; the config keeps it
+		// deliberately as the compatibility input.
 		txt := []byte(`include-core-tools:
    - "subagent"
    - "deadbeef"
@@ -599,7 +601,7 @@ exclude-core-tools:
 		defer func() { _ = host.Close() }()
 		tools := host.GetToolNames()
 		for _, tool := range tools {
-			if tool != "bash" && tool != "subagent" {
+			if tool != "shell" && tool != "subagent" {
 				t.Errorf("include-core-tools expected to have only 'bash' and 'subagent' tools but have %s", tool)
 			}
 		}
@@ -625,7 +627,7 @@ exclude-core-tools:
 		defer func() { _ = host.Close() }()
 		var registeredTools []string
 		for _, tool := range kit.ListAllCoreToolNames() {
-			if tool != "bash" && tool != "subagent" {
+			if tool != "shell" && tool != "subagent" {
 				registeredTools = append(registeredTools, tool)
 			}
 		}

--- a/pkg/kit/shell_timeout_test.go
+++ b/pkg/kit/shell_timeout_test.go
@@ -1,0 +1,62 @@
+package kit
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// fileStore returns a configuration store holding only the given YAML, so a
+// test can stand in for a configuration file without touching the disk.
+func fileStore(t *testing.T, yml string) *viper.Viper {
+	t.Helper()
+	v := viper.New()
+	v.SetConfigType("yaml")
+	if err := v.ReadConfig(strings.NewReader(yml)); err != nil {
+		t.Fatalf("ReadConfig: %v", err)
+	}
+	return v
+}
+
+// Precedence follows the source, not the spelling: SDK option, environment,
+// configuration file; within one source the shell-named spelling wins.
+func TestResolveShellTimeouts_SourceBeatsSpelling(t *testing.T) {
+	// Within one source the shell-named spelling wins.
+	if got, _ := resolveShellTimeouts(&Options{}, fileStore(t, "shell-timeout: 30\nbash-timeout: 90\n")); got != 30 {
+		t.Errorf("both spellings in the file: timeout = %d, want 30", got)
+	}
+
+	// The earlier spelling in the environment beats the current spelling in
+	// the file, because the environment is the higher source.
+	t.Setenv("KIT_BASH_TIMEOUT", "90")
+	if got, _ := resolveShellTimeouts(&Options{}, fileStore(t, "shell-timeout: 60\n")); got != 90 {
+		t.Errorf("earlier env over current file: timeout = %d, want 90", got)
+	}
+	t.Setenv("KIT_BASH_TIMEOUT", "")
+
+	// The current spelling in the environment beats the earlier spelling in
+	// the file.
+	t.Setenv("KIT_SHELL_TIMEOUT", "45")
+	if got, _ := resolveShellTimeouts(&Options{}, fileStore(t, "bash-timeout: 90\n")); got != 45 {
+		t.Errorf("current env over earlier file: timeout = %d, want 45", got)
+	}
+	t.Setenv("KIT_SHELL_TIMEOUT", "")
+
+	// The SDK earlier spelling beats every file value.
+	if got, _ := resolveShellTimeouts(&Options{BashTimeout: 15}, fileStore(t, "shell-timeout: 60\nbash-timeout: 90\n")); got != 15 {
+		t.Errorf("SDK earlier over file: timeout = %d, want 15", got)
+	}
+
+	// The SDK current spelling beats the SDK earlier one.
+	if got, _ := resolveShellTimeouts(&Options{ShellTimeout: 10, BashTimeout: 15}, viper.New()); got != 10 {
+		t.Errorf("SDK current over SDK earlier: timeout = %d, want 10", got)
+	}
+
+	// The maximum timeout follows the same rule.
+	t.Setenv("KIT_BASH_MAX_TIMEOUT", "700")
+	if _, got := resolveShellTimeouts(&Options{}, fileStore(t, "shell-max-timeout: 500\n")); got != 700 {
+		t.Errorf("earlier env over current file: max timeout = %d, want 700", got)
+	}
+	t.Setenv("KIT_BASH_MAX_TIMEOUT", "")
+}

--- a/pkg/kit/subagent_shell_test.go
+++ b/pkg/kit/subagent_shell_test.go
@@ -1,0 +1,23 @@
+package kit
+
+import (
+	"strings"
+	"testing"
+)
+
+// A subagent created without an explicit tool set runs its commands through
+// the parent's configured shell; a parent on an image without bash must not
+// spawn children that cannot execute anything.
+func TestSubagentDefaultTools_InheritTheParentShell(t *testing.T) {
+	m := &Kit{shell: []string{"busybox", "ash"}}
+	for _, tool := range m.subagentDefaultTools() {
+		if tool.Info().Name != "shell" {
+			continue
+		}
+		if d := tool.Info().Description; !strings.Contains(d, "busybox ash") {
+			t.Errorf("subagent shell tool does not name the parent's shell: %q", d)
+		}
+		return
+	}
+	t.Fatal("subagent default tools contain no shell tool")
+}

--- a/pkg/kit/tools.go
+++ b/pkg/kit/tools.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -26,13 +28,33 @@ type ToolOption = core.ToolOption
 // If empty, os.Getwd() is used at execution time.
 var WithWorkDir = core.WithWorkDir
 
-// WithBashTimeout sets the default per-call timeout for the bash tool.
+// WithShellTimeout sets the default per-call timeout for the shell tool.
 // A non-positive duration leaves the built-in default (120s) in place.
-var WithBashTimeout = core.WithBashTimeout
+var WithShellTimeout = core.WithShellTimeout
 
-// WithBashMaxTimeout sets the maximum timeout a bash tool call may request.
+// WithShellMaxTimeout sets the maximum timeout a shell tool call may request.
 // A non-positive duration leaves the built-in default (600s) in place.
-var WithBashMaxTimeout = core.WithBashMaxTimeout
+var WithShellMaxTimeout = core.WithShellMaxTimeout
+
+// WithShell sets the shell the shell tool runs command strings through: the
+// shell plus its own leading arguments, e.g. []string{"bash"} or
+// []string{"busybox", "ash"}. Empty leaves the built-in default ["bash"] in
+// place. For images that do not ship bash.
+var WithShell = core.WithShell
+
+// WithBashTimeout is the name WithShellTimeout had before the tool's shell
+// became configurable.
+//
+// Deprecated: use [WithShellTimeout]. The two are interchangeable; when both
+// are given, the later one in the option list wins.
+var WithBashTimeout = core.WithShellTimeout
+
+// WithBashMaxTimeout is the name WithShellMaxTimeout had before the tool's
+// shell became configurable.
+//
+// Deprecated: use [WithShellMaxTimeout]. The two are interchangeable; when
+// both are given, the later one in the option list wins.
+var WithBashMaxTimeout = core.WithShellMaxTimeout
 
 // --- Core Tool Validation ---
 // processes a list of tool names, if disableCoreTools is true, return an
@@ -44,6 +66,10 @@ func handleCoreToolList(coreTools []string, disableCoreTools bool) []string {
 	if disableCoreTools {
 		return result
 	}
+	// A caller may name the shell tool by its earlier name, in an SDK
+	// CoreToolList or in configuration. Map it onto the registry key here, so
+	// that every path into this function accepts both names.
+	coreTools = normalizeCoreToolNames(coreTools)
 	allTools := ListAllCoreToolNames()
 	if len(coreTools) > 0 {
 		for _, tool := range allTools {
@@ -368,8 +394,15 @@ func NewWriteTool(opts ...ToolOption) Tool { return core.NewWriteTool(opts...) }
 // NewEditTool creates a surgical text-editing tool.
 func NewEditTool(opts ...ToolOption) Tool { return core.NewEditTool(opts...) }
 
-// NewBashTool creates a bash command execution tool.
-func NewBashTool(opts ...ToolOption) Tool { return core.NewBashTool(opts...) }
+// NewShellTool creates the shell command execution tool. It runs one command
+// string through the configured shell, which defaults to bash.
+func NewShellTool(opts ...ToolOption) Tool { return core.NewShellTool(opts...) }
+
+// NewBashTool is the name NewShellTool had before the tool's shell became
+// configurable.
+//
+// Deprecated: use [NewShellTool]. Both return the same tool.
+func NewBashTool(opts ...ToolOption) Tool { return core.NewShellTool(opts...) }
 
 // NewGrepTool creates a content search tool (uses ripgrep when available).
 func NewGrepTool(opts ...ToolOption) Tool { return core.NewGrepTool(opts...) }
@@ -387,7 +420,7 @@ func ListAllCoreToolNames() []string { return core.ListAllCoreToolNames() }
 func AllTools(opts ...ToolOption) []Tool { return core.AllTools(opts...) }
 
 // CodingTools returns the default set of core tools for a coding agent:
-// bash, read, write, edit.
+// shell, read, write, edit.
 func CodingTools(opts ...ToolOption) []Tool { return core.CodingTools(opts...) }
 
 // ReadOnlyTools returns tools for read-only exploration:
@@ -407,6 +440,13 @@ func FilterCoreToolNames(includeTools, excludeTools []string) ([]string, error) 
 	if len(includeTools) > 0 && len(excludeTools) > 0 {
 		return nil, fmt.Errorf("cannot use both include-core-tools and exclude-core-tools options")
 	}
+
+	// The shell tool answers to its earlier name as well, so map both lists
+	// onto registry keys before matching. Without this, a configuration that
+	// names the tool the way it was named before this change would produce a
+	// warning about an invalid tool and no tool.
+	includeTools = normalizeCoreToolNames(includeTools)
+	excludeTools = normalizeCoreToolNames(excludeTools)
 
 	var coreToolList []string
 	if len(includeTools) > 0 || len(excludeTools) > 0 {
@@ -443,4 +483,68 @@ func FilterCoreToolNames(includeTools, excludeTools []string) ([]string, error) 
 // exclude lists directly and does not expose the configuration library.
 func CoreToolFilterHelper(v *viper.Viper) ([]string, error) {
 	return FilterCoreToolNames(v.GetStringSlice("include-core-tools"), v.GetStringSlice("exclude-core-tools"))
+}
+
+// normalizeCoreToolNames maps user-supplied core tool names onto registry keys
+// and removes duplicates, so that naming the shell tool both ways selects it
+// once rather than registering it twice.
+func normalizeCoreToolNames(names []string) []string {
+	if len(names) == 0 {
+		return names
+	}
+	out := make([]string, 0, len(names))
+	for _, n := range names {
+		n = core.NormalizeCoreToolName(n)
+		if !slices.Contains(out, n) {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// firstNonZero returns the first non-zero value.
+func firstNonZero(vals ...int) int {
+	for _, v := range vals {
+		if v != 0 {
+			return v
+		}
+	}
+	return 0
+}
+
+// resolveShellTimeouts resolves the two shell-tool timeouts across their two
+// spellings and their sources. Precedence follows the source, not the
+// spelling: SDK option, then environment, then the configuration store, and
+// within one source the shell-named spelling wins. The environment is read
+// directly because the flattened store cannot report which source supplied a
+// value; KIT_BASH_TIMEOUT would otherwise lose to a shell-timeout entry in a
+// configuration file, against the documented source order.
+func resolveShellTimeouts(opts *Options, v *viper.Viper) (timeout, maxTimeout int) {
+	timeout = firstNonZero(
+		opts.ShellTimeout,
+		opts.BashTimeout,
+		envInt("KIT_SHELL_TIMEOUT"),
+		envInt("KIT_BASH_TIMEOUT"),
+		v.GetInt("shell-timeout"),
+		v.GetInt("bash-timeout"),
+	)
+	maxTimeout = firstNonZero(
+		opts.ShellMaxTimeout,
+		opts.BashMaxTimeout,
+		envInt("KIT_SHELL_MAX_TIMEOUT"),
+		envInt("KIT_BASH_MAX_TIMEOUT"),
+		v.GetInt("shell-max-timeout"),
+		v.GetInt("bash-max-timeout"),
+	)
+	return timeout, maxTimeout
+}
+
+// envInt reads an integer environment variable, zero when unset or not an
+// integer.
+func envInt(name string) int {
+	n, err := strconv.Atoi(strings.TrimSpace(os.Getenv(name)))
+	if err != nil {
+		return 0
+	}
+	return n
 }

--- a/pkg/kit/tools_shell_test.go
+++ b/pkg/kit/tools_shell_test.go
@@ -1,0 +1,142 @@
+package kit
+
+import (
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/kit/internal/core"
+)
+
+// The exported surface of the shell tool: the current spelling, the earlier
+// spelling kept as an alias, and the resolution order between them.
+
+func TestFirstNonZero_CurrentSpellingWins(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []int
+		want int
+	}{
+		{"shell only", []int{30, 0, 0, 0}, 30},
+		{"bash only", []int{0, 45, 0, 0}, 45},
+		{"shell beats bash at the SDK layer", []int{30, 45, 0, 0}, 30},
+		{"config shell beats config bash", []int{0, 0, 60, 90}, 60},
+		{"SDK beats config", []int{0, 45, 60, 90}, 45},
+		{"none set", []int{0, 0, 0, 0}, 0},
+	}
+	for _, c := range cases {
+		if got := firstNonZero(c.in...); got != c.want {
+			t.Errorf("%s: firstNonZero(%v) = %d, want %d", c.name, c.in, got, c.want)
+		}
+	}
+}
+
+func TestToolOptionAliases_SetTheSameField(t *testing.T) {
+	cfg := core.ApplyOptions([]core.ToolOption{WithShellTimeout(30 * time.Second)})
+	if cfg.ShellTimeout != 30*time.Second {
+		t.Errorf("WithShellTimeout: got %v, want 30s", cfg.ShellTimeout)
+	}
+	cfg = core.ApplyOptions([]core.ToolOption{WithBashTimeout(30 * time.Second)})
+	if cfg.ShellTimeout != 30*time.Second {
+		t.Errorf("WithBashTimeout: got %v, want 30s", cfg.ShellTimeout)
+	}
+
+	cfg = core.ApplyOptions([]core.ToolOption{WithShellMaxTimeout(90 * time.Second)})
+	if cfg.ShellMaxTimeout != 90*time.Second {
+		t.Errorf("WithShellMaxTimeout: got %v, want 90s", cfg.ShellMaxTimeout)
+	}
+	cfg = core.ApplyOptions([]core.ToolOption{WithBashMaxTimeout(90 * time.Second)})
+	if cfg.ShellMaxTimeout != 90*time.Second {
+		t.Errorf("WithBashMaxTimeout: got %v, want 90s", cfg.ShellMaxTimeout)
+	}
+
+	// Both are functional options, so the later one in the list wins. That is
+	// the existing convention for every option in this package.
+	cfg = core.ApplyOptions([]core.ToolOption{
+		WithBashTimeout(30 * time.Second),
+		WithShellTimeout(45 * time.Second),
+	})
+	if cfg.ShellTimeout != 45*time.Second {
+		t.Errorf("later option should win: got %v, want 45s", cfg.ShellTimeout)
+	}
+}
+
+func TestConstructorAlias_ProducesTheSameTool(t *testing.T) {
+	if got := NewShellTool().Info().Name; got != "shell" {
+		t.Errorf("NewShellTool name = %q, want \"shell\"", got)
+	}
+	if got := NewBashTool().Info().Name; got != "shell" {
+		t.Errorf("NewBashTool name = %q, want \"shell\"", got)
+	}
+}
+
+func TestWithShell_ReachesTheToolConfig(t *testing.T) {
+	cfg := core.ApplyOptions([]core.ToolOption{WithShell([]string{"busybox", "ash"})})
+	if !slices.Equal(cfg.Shell, []string{"busybox", "ash"}) {
+		t.Errorf("Shell = %#v", cfg.Shell)
+	}
+}
+
+func TestNormalizeCoreToolNames_MapsAndDeduplicates(t *testing.T) {
+	got := normalizeCoreToolNames([]string{"bash", "shell", "read", "bash"})
+	if !slices.Equal(got, []string{"shell", "read"}) {
+		t.Errorf("normalizeCoreToolNames = %#v, want [shell read]", got)
+	}
+	if got := normalizeCoreToolNames(nil); got != nil {
+		t.Errorf("nil input = %#v, want nil", got)
+	}
+}
+
+func TestFilterCoreToolNames_AcceptsTheEarlierName(t *testing.T) {
+	got, err := FilterCoreToolNames([]string{"bash"}, nil)
+	if err != nil {
+		t.Fatalf("include [bash]: %v", err)
+	}
+	if !slices.Equal(got, []string{"shell"}) {
+		t.Errorf("include [bash] = %#v, want [shell]", got)
+	}
+
+	got, err = FilterCoreToolNames(nil, []string{"bash"})
+	if err != nil {
+		t.Fatalf("exclude [bash]: %v", err)
+	}
+	if slices.Contains(got, "shell") {
+		t.Errorf("exclude [bash] still contains the shell tool: %#v", got)
+	}
+	if len(got) != len(ListAllCoreToolNames())-1 {
+		t.Errorf("exclude [bash] produced %d tools, want %d", len(got), len(ListAllCoreToolNames())-1)
+	}
+}
+
+func TestHandleCoreToolList_AcceptsTheEarlierName(t *testing.T) {
+	// An SDK caller can pass CoreToolList directly, so this path has to accept
+	// the earlier name too.
+	got := handleCoreToolList([]string{"bash", "read"}, false)
+	if !slices.Contains(got, "shell") {
+		t.Errorf("handleCoreToolList([bash read]) = %#v, want it to contain shell", got)
+	}
+	if slices.Contains(got, "bash") {
+		t.Errorf("handleCoreToolList returned the earlier name: %#v", got)
+	}
+}
+
+func TestFilterToolsByName_AllowlistAcceptsTheEarlierName(t *testing.T) {
+	// A named agent definition written before the rename says "bash". The
+	// allowlist admits the mapped name beside the written one, so the shell
+	// tool is selected; a custom tool genuinely named "bash" would match its
+	// own entry as well.
+	got := filterToolsByName(SubagentTools(), []string{"bash", "read"})
+	names := make([]string, 0, len(got))
+	for _, tool := range got {
+		names = append(names, tool.Info().Name)
+	}
+	if !slices.Contains(names, "shell") {
+		t.Errorf("allowlist [bash read] selected %v, want it to contain shell", names)
+	}
+	if !slices.Contains(names, "read") {
+		t.Errorf("allowlist [bash read] selected %v, want it to contain read", names)
+	}
+	if len(got) != 2 {
+		t.Errorf("allowlist [bash read] selected %d tools, want 2", len(got))
+	}
+}

--- a/skills/kit-sdk/SKILL.md
+++ b/skills/kit-sdk/SKILL.md
@@ -105,7 +105,7 @@ host, err := kit.New(ctx, &kit.Options{
     SessionManager: myCustomSession,  // custom SessionManager implementation (advanced)
 
     // Tools
-    Tools:            []kit.Tool{kit.NewBashTool()}, // REPLACES entire default tool set
+    Tools:            []kit.Tool{kit.NewShellTool()}, // REPLACES entire default tool set
     ExtraTools:       []kit.Tool{myTool},            // ADDS alongside core/MCP/extension tools
     DisableCoreTools: true,                        // Use no core tools (0 tools, for chat-only)
     CoreToolList      []string,                    // List of core tools to include, if empty (default) include all
@@ -617,7 +617,7 @@ tool := kit.NewTool("my_tool", "...",
 kit.NewReadTool(opts...)  // file reading
 kit.NewWriteTool(opts...) // file writing
 kit.NewEditTool(opts...)  // surgical text editing
-kit.NewBashTool(opts...)  // bash command execution
+kit.NewShellTool(opts...) // shell command execution (bash by default)
 kit.NewGrepTool(opts...) // content search (uses ripgrep when available)
 kit.NewFindTool(opts...) // file search (uses fd when available)
 kit.NewLsTool(opts...)   // directory listing
@@ -641,9 +641,9 @@ kit.WithWorkDir("/path/to/dir") // override working directory for file-based too
 ### Using tools in Options
 
 ```go
-// Restricted: agent can ONLY run bash
+// Restricted: agent can ONLY run shell commands
 host, _ := kit.New(ctx, &kit.Options{
-    Tools: []kit.Tool{kit.NewBashTool()},
+    Tools: []kit.Tool{kit.NewShellTool()},
 })
 
 // Extended: all defaults PLUS a custom tool
@@ -1294,7 +1294,7 @@ Daemon that performs repeated independent tasks:
 ```go
 host, _ := kit.New(ctx, &kit.Options{
     SystemPrompt: taskPrompt,
-    Tools:        []kit.Tool{kit.NewBashTool()},
+    Tools:        []kit.Tool{kit.NewShellTool()},
     NoSession:    true,
     Quiet:        true,
 })

--- a/www/pages/cli/flags.md
+++ b/www/pages/cli/flags.md
@@ -84,6 +84,15 @@ your last bare conversation from anywhere on the filesystem.
 configuration, so allowing a project config to enable it would be
 self-defeating.
 
+## Tools
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--shell` | — | `bash` | Shell the shell tool and the interactive `!` commands run through: the shell plus its own leading arguments, e.g. `/bin/dash` or `"busybox ash"` |
+| `--no-core-tools` | — | `false` | Disable all built-in core tools |
+| `--include-core-tools` | — | — | Comma-separated list of core tools to include (mutually exclusive with `--exclude-core-tools`) |
+| `--exclude-core-tools` | — | — | Comma-separated list of core tools to exclude (mutually exclusive with `--include-core-tools`) |
+
 ## Extensions
 
 | Flag | Short | Default | Description |


### PR DESCRIPTION
core: make the shell configurable and name the tool after it

What

KIT's command-execution tool ran bash, written into the source:

    cmd := exec.CommandContext(cmdCtx, "bash", "-c", command)

The tool is a shell tool. This change makes its shell configurable and
names the tool after what it is: it is called shell in the registry, in
the tool definition sent to the model, in the configuration keys, in the
SDK surface, in the implementation file and in the internal identifiers.
Bash is the default shell and nothing else, and every name that existed
before this change keeps working.

With nothing configured the executed argument vector is ["bash", "-c",
command] and the SHELL value is the resolved path of bash, both exactly
as before; both timeouts, the sudo handling, the truncation and every
exit code are unchanged. Two things do change for an installation that
configures nothing: the tool advertises the name shell rather than bash,
and its two descriptions are worded for a shell tool. That is the point
of the change, so every place that named the tool was updated with it.

Why

Hardcoding bash prevents KIT from running on images without bash: Alpine
and BusyBox bases, distroless images, some Nix environments, and macOS,
where the system bash is old enough that agents generate syntax it
rejects. The nearest replacement, a POSIX shell such as dash, is no
exotic target: Debian has installed dash as its default /bin/sh since
6.0 (2011) and Ubuntu since 6.10 (2006), so every /bin/sh script on
those systems has run on it for fifteen years and more.

The tool description has to follow the shell, because the model writes
the command. Described as bash while a POSIX shell runs, the model emits
bash-only syntax and cannot diagnose the errors, because it believes it
is talking to bash. Told to write POSIX sh for fish, it would be wrong
the other way. The description therefore has three cases: bash gets no
note; a named POSIX shell gets a POSIX requirement with the bash-only
constructs listed; anything else - zsh, fish, nu, elvish - is named
without a dialect instruction.

Overview of the change

37 files changed, 1375 insertions, 238 deletions. Three files are
renames: bash.go to shell.go, bash_test.go to shell_exec_test.go, and
bash_streaming_test.go to shell_streaming_test.go.

  internal/core/shell.go (from bash.go)     resolution, identity and
                                            execution in one file;
                                            identifiers renamed
  internal/core/tools.go                    name constants, the name
                                            mapping, WithShell, and
                                            ToolConfig.Shell
  internal/core/shell_test.go (new)         pure tests: vector, names,
                                            dialect, mapping
  internal/core/shell_exec_test.go          process tests
  internal/core/shell_streaming_test.go     streaming tests; output
                                            attribution asserted
  internal/config/config.go                 shell key; shell-named
                                            timeout keys beside the
                                            bash-named ones
  cmd/root.go                               --shell flag, empty-flag
                                            refusal, help text
  internal/agent/agent.go, factory.go,
  internal/kitsetup/setup.go                field renames; Shell
                                            pass-through
  internal/acpserver/session.go             ACP sessions receive the
                                            root command's shell
  internal/ui/activity.go, model.go         activity verb and streaming
                                            header accept both names;
                                            the ! and !! executor runs
                                            through the configured shell
  internal/extensions/toolkinds.go          kind map lists both names
  internal/extensions/runner.go (+ test)    renderer lookup and
                                            SetActiveTools accept the
                                            earlier name for the core
                                            tool only
  internal/extensions/api.go                doc comments: events report
                                            the registered name;
                                            migration note
  pkg/kit/kit.go                            Options.Shell and friends;
                                            deprecated fields; source-
                                            aware timeout resolution;
                                            subagents inherit the shell
  pkg/kit/events.go                         doc comments follow the tool
  pkg/kit/tools.go                          WithShell; deprecated
                                            aliases; list normalization
  pkg/kit/agents.go                         agent allowlists admit the
                                            mapped name
  pkg/kit/tools_shell_test.go (new)         exported surface, aliases,
                                            resolution, allowlist
  pkg/kit/shell_timeout_test.go (new),
  pkg/kit/subagent_shell_test.go (new)      timeout-source table;
                                            subagent shell inheritance
  pkg/kit/config.go                         default system prompt names
                                            shell
  cmd/extensions.go, examples/ (5 files)    event matchers and prompt
                                            text use the registered name
  internal/compaction/compaction.go         comment
  README.md, pkg/kit/README.md,
  www/pages/cli/flags.md,
  skills/kit-sdk/SKILL.md                   configuration, flag and SDK
                                            docs

Backward compatibility

No exported symbol is removed. Every earlier name keeps working and is
documented once, as the earlier spelling. Each alias has a Deprecated:
comment that states the current spelling; nothing is scheduled for
removal here.

  Kind            Current spelling         Earlier spelling
  tool list name  shell                    bash
  config key      shell-timeout            bash-timeout
  config key      shell-max-timeout        bash-max-timeout
  SDK field       Options.ShellTimeout     Options.BashTimeout
  SDK field       Options.ShellMaxTimeout  Options.BashMaxTimeout
  tool option     WithShellTimeout         WithBashTimeout
  tool option     WithShellMaxTimeout      WithBashMaxTimeout
  constructor     NewShellTool             NewBashTool

The earlier tool name is accepted through one mapping function,
applied wherever a user names the tool to KIT: include-core-tools and
exclude-core-tools, an SDK CoreToolList, a named agent's tools
allowlist, an extension's SetActiveTools restriction, and tool-renderer
registration and lookup. A list that names the tool both ways selects
it once. The allowlist and the active-tool restriction admit the mapped
name in addition to the written one rather than rewriting it, so a
custom tool that really is named "bash" still matches its own entry.
The alias covers the core tool only: when an extension registers a tool
of its own under the earlier name, that name selects that tool and
nothing else, so a restriction never admits more than it names and a
custom renderer stays with its own tool.
Sessions recorded before the rename replay correctly: three render
sites already accepted both names (the message-navigation switch, the
shell-likeness check in the tool renderer, and the tool-result
formatter), and three were taught both names by this change (the
activity verb, the streaming-output header, and the tool-kind map).

For the two timeouts, precedence follows the source, not the spelling:
SDK option, then environment, then configuration file; within one
source the shell-named spelling wins. The environment is read directly,
because the flattened configuration store cannot report which source
supplied a value, so KIT_BASH_TIMEOUT beats a shell-timeout file entry
as the source order demands. A configuration or caller that uses only
the earlier spelling resolves exactly as it did. The tool options are
functional options, so the later one in the list wins, which is the
existing convention for every option in the package.

One surface is not aliased, because it cannot be: tool-call and
tool-result events report the tool's registered name, and the comparison
against it happens inside extension code that KIT does not interpret. An
extension that matched the earlier name updates its comparison to accept
both, which makes the same source run on KIT before and after this
change:

    if tc.ToolName != "shell" && tc.ToolName != "bash" { return nil }

This is documented on OnToolCall. The bundled extension examples match
the current name only; they target the release they ship with, and the
documentation says so.

A session resumed from a transcript recorded before the rename can lead
the model to call the tool by its earlier name once; the call fails as
unknown, the model reissues it under the current name, and one round
trip is lost. This is accepted deliberately: registering both names
instead would keep the tool describing itself two ways at once, which
is the state this change exists to end.

Two behavior changes are deliberate. ListedTools now normalizes the
names it is given and skips one that matches no core tool, where it
previously indexed the registry map directly and would panic on an
unknown name. handleCoreToolList normalizes too, because an SDK caller
can pass CoreToolList without going through FilterCoreToolNames; with
the normalization, both lists also drop duplicates.

Test coverage

  internal/core/shell_test.go            vector construction, display
                                         name, dialect classification,
                                         tool identity, name mapping,
                                         SHELL rule for launcher
                                         vectors; no process started
  internal/core/shell_exec_test.go       execution, timeouts, banned
                                         commands, sudo rewriting
  internal/core/shell_streaming_test.go  streaming, drain behavior;
                                         attribution asserted against
                                         the advertised name, not a
                                         literal
  pkg/kit/tools_shell_test.go            aliases set the same fields,
                                         list normalization, allowlist
                                         acceptance of the earlier name
  pkg/kit/shell_timeout_test.go          source-before-spelling table
                                         for the two timeouts
  pkg/kit/subagent_shell_test.go         a subagent's default tools
                                         inherit the parent's shell
  internal/extensions/runner_test.go     renderer lookup: an exact
                                         name wins over the earlier-name
                                         fallback, under either load
                                         order; SetActiveTools accepts
                                         the earlier name; the fallback
                                         stands down for a custom tool
                                         of that name

The tree is gofmt-clean. Tested on x86-64 Linux with go build, go vet
and go test over ./cmd/..., ./internal/... and ./pkg/....

Configuration options

The configured value names the shell and its own leading arguments - a
vector, not a single string, so a shell that needs a launcher in front
of it works without a wrapper script:

    --shell /bin/dash
    --shell "busybox ash"
    shell: "/bin/dash"              in .kit.yml or .kit.json
    KIT_SHELL=/bin/dash             in the environment
    kit.Options.Shell               or kit.WithShell(...) from the SDK

  Surface       Setting                     Notes
  CLI flag      --shell                     string, split on whitespace
  environment   KIT_SHELL                   via the existing KIT_ prefix
  config key    shell                       string or list
  SDK           Options.Shell, WithShell    []string

The four sources follow the precedence KIT already applies to every
other setting: SDK option, flag, environment, project config, user
config, built-in default. The command string reaches the shell as
exactly one argument, never split or re-quoted. An empty --shell is
refused at startup, because the user asked for a shell and named none;
an empty value from another source leaves the default in place.

SHELL for child processes is set to the resolved shell when the
configured value is the shell alone. For a launcher vector such as
"busybox ash" KIT cannot know which element is the shell; a wrong SHELL
is worse for programs such as tmux than the inherited one, so SHELL is
then left alone.

The interactive ! and !! commands run through the same construction as
the tool, so a configured shell governs every command KIT runs on the
user's behalf, including on images without bash. kit acp passes the
root command's shell into each session, and a subagent created without
an explicit tool set inherits the parent's shell.

Suggested-by: Egbert Eich <eich@suse.com>
Assisted-by: Claude:claude-opus-5
Assisted-by: Claude:claude-fable-5
Assisted-by: GPT:gpt-5.6-sol            # review of the pre-submission branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable shell selection for command execution, including shell arguments.
  * Added `--shell` CLI configuration.
  * Added shell timeout and maximum-timeout settings.
  * Subagents inherit the configured shell when no custom tools are specified.

* **Compatibility**
  * Existing `bash` tool names and settings remain supported as legacy aliases.
  * Custom tools named `bash` retain their own behavior and renderers.

* **Documentation**
  * Updated CLI, SDK, configuration, extension, and project documentation to describe the shell tool and its settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->