### PR TITLE
test(agent): guard reasoning close on null reasoning_content (#124)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,11 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.10.1
+          # Must be built with Go >= the version targeted in go.mod (1.27),
+          # otherwise golangci-lint refuses to load the config with
+          # "the Go language version used to build golangci-lint is lower
+          # than the targeted Go version".
+          version: v2.13.1
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [master]
 
+# Least privilege: every job here only checks out the repo and runs builds,
+# tests or linters. None of them write back, so the default token never needs
+# more than read access. Matches the explicit blocks in release.yml and
+# sandbox-image.yml.
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/examples/extensions/popup-terminal.go
+++ b/examples/extensions/popup-terminal.go
@@ -209,13 +209,46 @@ func attachArgv(backend string, name string, shell string, cwd string) []string 
 	}
 }
 
+// childEnv strips $TMUX when launching tmux so an outer tmux does not refuse
+// to nest. Kit itself may be running inside tmux; the popup then becomes a
+// nested session, which works.
+//
+// Every tmux invocation must use this env, not just the one that creates the
+// session. tmux resolves its server socket from $TMUX when that variable is
+// set, so a probe that inherits $TMUX talks to the *outer* server while the
+// session itself was created on the default socket — the probe then never
+// finds it. Declared above its callers because Yaegi miscompiles forward
+// references to functions declared later in the file.
+func childEnv(backend string) []string {
+	env := os.Environ()
+	if backend != "tmux" {
+		return env
+	}
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "TMUX=") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}
+
+// tmuxCommand builds a tmux invocation that targets the same server the
+// popup session is created on, by stripping $TMUX from the environment.
+func tmuxCommand(args ...string) *exec.Cmd {
+	cmd := exec.Command("tmux", args...)
+	cmd.Env = childEnv("tmux")
+	return cmd
+}
+
 // sessionAlive reports whether a detached background session exists.
 func sessionAlive(backend string, name string) bool {
 	switch backend {
 	case "tmux":
 		// "=" forces an exact match; without it tmux does prefix matching
 		// and "kit-abc" would match "kit-abcdef".
-		return exec.Command("tmux", "has-session", "-t", "="+name).Run() == nil
+		return tmuxCommand("has-session", "-t", "="+name).Run() == nil
 	case "abduco":
 		out, err := exec.Command("abduco").CombinedOutput()
 		if err != nil {
@@ -243,7 +276,7 @@ func killSession(backend string, name string) error {
 		if !sessionAlive("tmux", name) {
 			return fmt.Errorf("no tmux session named %s", name)
 		}
-		out, err := exec.Command("tmux", "kill-session", "-t", "="+name).CombinedOutput()
+		out, err := tmuxCommand("kill-session", "-t", "="+name).CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("tmux kill-session: %v: %s", err, strings.TrimSpace(string(out)))
 		}
@@ -264,24 +297,6 @@ func detachHint(backend string) string {
 	default:
 		return "type exit to return to Kit"
 	}
-}
-
-// childEnv strips $TMUX when launching tmux so an outer tmux does not refuse
-// to nest. Kit itself may be running inside tmux; the popup then becomes a
-// nested session, which works.
-func childEnv(backend string) []string {
-	env := os.Environ()
-	if backend != "tmux" {
-		return env
-	}
-	out := make([]string, 0, len(env))
-	for _, kv := range env {
-		if strings.HasPrefix(kv, "TMUX=") {
-			continue
-		}
-		out = append(out, kv)
-	}
-	return out
 }
 
 func quoteArgv(argv []string) string {

--- a/examples/extensions/popup-terminal_test.go
+++ b/examples/extensions/popup-terminal_test.go
@@ -4,6 +4,7 @@ import (
 	"maps"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -534,32 +535,35 @@ func TestPopupTerminal_TmuxExactNameMatch(t *testing.T) {
 // TestPopupTerminal_TmuxEnvIsUnnested verifies that $TMUX is stripped from
 // the child environment, which is what lets the popup work while Kit itself
 // runs inside tmux.
+//
+// $TMUX must point at a socket that does not exist. tmux resolves its server
+// socket from $TMUX, so this is what proves the extension's status probe and
+// kill path talk to the same server they created the session on rather than
+// to whatever $TMUX names. A hardcoded /tmp/tmux-1000/default made this test
+// pass on any machine where uid 1000 happened to be running tmux, and fail
+// everywhere else (notably CI, whose runner is not uid 1000).
 func TestPopupTerminal_TmuxEnvIsUnnested(t *testing.T) {
 	if !tmuxAvailable(t) {
 		t.Skip("tmux is not available (or -short)")
 	}
-	t.Setenv("TMUX", "/tmp/tmux-1000/default,1234,0")
+	t.Setenv("TMUX", filepath.Join(t.TempDir(), "outer-socket")+",1234,0")
 
 	const sessionID = "itest-nested"
 	const tmuxName = "kit-itest-nested"
-	_ = exec.Command("tmux", "kill-session", "-t", "="+tmuxName).Run()
-	t.Cleanup(func() {
-		_ = exec.Command("tmux", "kill-session", "-t", "="+tmuxName).Run()
-	})
+	killNested := func() {
+		cmd := exec.Command("tmux", "kill-session", "-t", "="+tmuxName)
+		cmd.Env = tmuxCleanEnv()
+		_ = cmd.Run()
+	}
+	killNested()
+	t.Cleanup(killNested)
 
 	// Reproduce exactly what the extension does: the same argv and the same
 	// filtered environment, run detached so no tty is needed. If $TMUX
 	// leaked through, tmux would refuse with "sessions should be nested
 	// with care".
-	env := make([]string, 0)
-	for _, kv := range os.Environ() {
-		if strings.HasPrefix(kv, "TMUX=") {
-			continue
-		}
-		env = append(env, kv)
-	}
 	cmd := exec.Command("tmux", "new-session", "-d", "-s", tmuxName, "sh", "-c", "sleep 300")
-	cmd.Env = env
+	cmd.Env = tmuxCleanEnv()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Skipf("cannot start a tmux session in this environment: %v: %s", err, out)
 	}
@@ -572,4 +576,17 @@ func TestPopupTerminal_TmuxEnvIsUnnested(t *testing.T) {
 	if !strings.Contains(allPrints(h), "running (detached)") {
 		t.Errorf("session did not start with $TMUX stripped:\n%s", allPrints(h))
 	}
+}
+
+// tmuxCleanEnv returns the current environment with $TMUX removed, matching
+// what the extension passes to every tmux invocation.
+func tmuxCleanEnv() []string {
+	env := make([]string, 0, len(os.Environ()))
+	for _, kv := range os.Environ() {
+		if strings.HasPrefix(kv, "TMUX=") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	return env
 }

--- a/internal/agent/reasoning_stream_test.go
+++ b/internal/agent/reasoning_stream_test.go
@@ -1,0 +1,221 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"charm.land/fantasy"
+	"charm.land/fantasy/providers/openaicompat"
+
+	"github.com/mark3labs/kit/internal/message"
+)
+
+// Regression guard for issue #124: some OpenAI-compatible providers (e.g.
+// glm-5.3-flash, DeepSeek, vLLM, SGLang) put "reasoning_content": null on
+// every chunk that carries answer text, a tool call or the finish reason. A
+// provider that reads a present-but-null key as "reasoning is still running"
+// never closes the reasoning block, so:
+//
+//   - OnReasoningComplete (and therefore ReasoningCompleteEvent) never fires,
+//     and
+//   - the assistant message carries no reasoning part, so sessions persist
+//     nothing and the reasoning the user watched stream live disappears on
+//     reload.
+//
+// The stream hook lives in the provider library, so these tests pin the
+// behaviour Kit depends on: they drive Kit's own callback plumbing and message
+// conversion over a replayed SSE stream and fail loudly if a dependency bump
+// reintroduces the leak.
+
+// glmFlashNullReasoningSSE replays the shape reported in issue #124: reasoning
+// deltas, then an answer chunk that repeats the reasoning key with a null
+// value, then a finish chunk that does the same.
+const glmFlashNullReasoningSSE = `{"id":"x","created":1,"model":"glm-flash","choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning_content":"17 times 23"},"finish_reason":null}]}
+{"id":"x","created":1,"model":"glm-flash","choices":[{"index":0,"delta":{"content":null,"reasoning_content":" is 391."},"finish_reason":null}]}
+{"id":"x","created":1,"model":"glm-flash","choices":[{"index":0,"delta":{"content":"391","reasoning_content":null},"finish_reason":null}]}
+{"id":"x","created":1,"model":"glm-flash","choices":[{"index":0,"delta":{"content":"","reasoning_content":null},"finish_reason":"stop"}]}`
+
+// glmOmittedReasoningSSE replays the control shape (glm-5.2 in the issue): the
+// reasoning key is simply absent once the answer starts.
+const glmOmittedReasoningSSE = `{"id":"x","created":1,"model":"glm","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"17 times 23"},"finish_reason":null}]}
+{"id":"x","created":1,"model":"glm","choices":[{"index":0,"delta":{"reasoning_content":" is 391."},"finish_reason":null}]}
+{"id":"x","created":1,"model":"glm","choices":[{"index":0,"delta":{"content":"391"},"finish_reason":null}]}
+{"id":"x","created":1,"model":"glm","choices":[{"index":0,"delta":{"content":""},"finish_reason":"stop"}]}`
+
+// serveReasoningSSE starts a server that answers a streaming chat-completions
+// POST with the given SSE payload, one event per line.
+func serveReasoningSSE(t *testing.T, payload string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		rc := http.NewResponseController(w)
+		for event := range strings.SplitSeq(payload, "\n") {
+			event = strings.TrimSpace(event)
+			if event == "" {
+				continue
+			}
+			_, _ = fmt.Fprintf(w, "data: %s\n\n", event)
+			_ = rc.Flush()
+		}
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+		_ = rc.Flush()
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// newSSEAgent builds an Agent backed by the OpenAI-compatible provider pointed
+// at srv. It bypasses NewAgent (and therefore the model registry and network)
+// while keeping the real provider, the real fantasy agent, and Kit's own
+// callback and message-conversion code in the path.
+func newSSEAgent(t *testing.T, srv *httptest.Server) *Agent {
+	t.Helper()
+	provider, err := openaicompat.New(
+		openaicompat.WithBaseURL(srv.URL),
+		openaicompat.WithAPIKey("test"),
+		openaicompat.WithName("test-compat"),
+	)
+	if err != nil {
+		t.Fatalf("create provider: %v", err)
+	}
+	model, err := provider.LanguageModel(t.Context(), "test-model")
+	if err != nil {
+		t.Fatalf("create model: %v", err)
+	}
+	return &Agent{
+		fantasyAgent:     fantasy.NewAgent(model),
+		model:            model,
+		maxSteps:         1,
+		streamingEnabled: true,
+		providerType:     "test-compat",
+	}
+}
+
+// reasoningRun holds what one generation observed, so both SSE shapes can be
+// asserted the same way.
+type reasoningRun struct {
+	starts    int
+	completes int
+	deltas    string
+	response  string
+	// reasoningParts counts fantasy.ReasoningPart values in assistant
+	// messages — this is what a SessionManager persists.
+	reasoningParts int
+	// blockText is the reasoning text on the converted message blocks.
+	blockText string
+}
+
+func runReasoningStream(t *testing.T, payload string) reasoningRun {
+	t.Helper()
+	a := newSSEAgent(t, serveReasoningSSE(t, payload))
+
+	var run reasoningRun
+	var deltas strings.Builder
+	result, err := a.GenerateWithCallbacks(t.Context(),
+		[]fantasy.Message{fantasy.NewUserMessage("what is 17*23?")},
+		GenerateCallbacks{
+			OnReasoningStart:    func(string) { run.starts++ },
+			OnReasoningDelta:    func(d string) { deltas.WriteString(d) },
+			OnReasoningComplete: func() { run.completes++ },
+		})
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	run.deltas = deltas.String()
+	run.response = result.FinalResponse.Content.Text()
+
+	for _, m := range result.ConversationMessages {
+		if m.Role != fantasy.MessageRoleAssistant {
+			continue
+		}
+		for _, part := range m.Content {
+			if _, ok := part.(fantasy.ReasoningPart); ok {
+				run.reasoningParts++
+			}
+		}
+	}
+	for _, m := range result.Messages {
+		if m.Role != message.RoleAssistant {
+			continue
+		}
+		run.blockText += m.Reasoning().Thinking
+	}
+	return run
+}
+
+// TestReasoningClosesOnNullReasoningField covers the reported failure: a null
+// reasoning field on the answer chunk must not hold the reasoning block open.
+func TestReasoningClosesOnNullReasoningField(t *testing.T) {
+	t.Parallel()
+	assertReasoningComplete(t, runReasoningStream(t, glmFlashNullReasoningSSE))
+}
+
+// TestReasoningClosesOnOmittedReasoningField is the control case: providers
+// that drop the key entirely once the answer starts already worked.
+func TestReasoningClosesOnOmittedReasoningField(t *testing.T) {
+	t.Parallel()
+	assertReasoningComplete(t, runReasoningStream(t, glmOmittedReasoningSSE))
+}
+
+func assertReasoningComplete(t *testing.T, run reasoningRun) {
+	t.Helper()
+	const wantReasoning = "17 times 23 is 391."
+	if run.starts != 1 {
+		t.Errorf("OnReasoningStart fired %d times, want 1", run.starts)
+	}
+	if run.deltas != wantReasoning {
+		t.Errorf("reasoning deltas = %q, want %q", run.deltas, wantReasoning)
+	}
+	if run.completes != 1 {
+		t.Errorf("OnReasoningComplete fired %d times, want 1 "+
+			"(reasoning block never closed — see issue #124)", run.completes)
+	}
+	if run.reasoningParts != 1 {
+		t.Errorf("assistant messages carry %d reasoning parts, want 1 "+
+			"(reasoning would not be persisted — see issue #124)", run.reasoningParts)
+	}
+	if run.blockText != wantReasoning {
+		t.Errorf("converted reasoning block = %q, want %q", run.blockText, wantReasoning)
+	}
+	if run.response != "391" {
+		t.Errorf("response = %q, want %q", run.response, "391")
+	}
+}
+
+// TestHasReasoningFieldNullContract documents the provider-side rule Kit
+// relies on: a null reasoning value means "no reasoning in this delta", while
+// an empty string still counts as reasoning.
+func TestHasReasoningFieldNullContract(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		raw  string
+		want bool
+	}{
+		{`{"content":"391","reasoning_content":null}`, false},
+		{`{"content":"391","reasoning":null}`, false},
+		{`{"content":"391"}`, false},
+		{`{"reasoning_content":""}`, true},
+		{`{"reasoning_content":"thinking"}`, true},
+	} {
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(tc.raw), &fields); err != nil {
+			t.Fatalf("unmarshal %s: %v", tc.raw, err)
+		}
+		got := false
+		for _, key := range []string{"reasoning_content", "reasoning"} {
+			if v, ok := fields[key]; ok && strings.TrimSpace(string(v)) != "null" {
+				got = true
+				break
+			}
+		}
+		if got != tc.want {
+			t.Errorf("reasoning field present for %s = %v, want %v", tc.raw, got, tc.want)
+		}
+	}
+}

--- a/internal/agent/reasoning_stream_test.go
+++ b/internal/agent/reasoning_stream_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -74,7 +75,7 @@ func serveReasoningSSE(t *testing.T, payload string) *httptest.Server {
 // at srv. It bypasses NewAgent (and therefore the model registry and network)
 // while keeping the real provider, the real fantasy agent, and Kit's own
 // callback and message-conversion code in the path.
-func newSSEAgent(t *testing.T, srv *httptest.Server) *Agent {
+func newSSEAgent(ctx context.Context, t *testing.T, srv *httptest.Server) *Agent {
 	t.Helper()
 	provider, err := openaicompat.New(
 		openaicompat.WithBaseURL(srv.URL),
@@ -84,7 +85,7 @@ func newSSEAgent(t *testing.T, srv *httptest.Server) *Agent {
 	if err != nil {
 		t.Fatalf("create provider: %v", err)
 	}
-	model, err := provider.LanguageModel(t.Context(), "test-model")
+	model, err := provider.LanguageModel(ctx, "test-model")
 	if err != nil {
 		t.Fatalf("create model: %v", err)
 	}
@@ -111,13 +112,13 @@ type reasoningRun struct {
 	blockText string
 }
 
-func runReasoningStream(t *testing.T, payload string) reasoningRun {
+func runReasoningStream(ctx context.Context, t *testing.T, payload string) reasoningRun {
 	t.Helper()
-	a := newSSEAgent(t, serveReasoningSSE(t, payload))
+	a := newSSEAgent(ctx, t, serveReasoningSSE(t, payload))
 
 	var run reasoningRun
 	var deltas strings.Builder
-	result, err := a.GenerateWithCallbacks(t.Context(),
+	result, err := a.GenerateWithCallbacks(ctx,
 		[]fantasy.Message{fantasy.NewUserMessage("what is 17*23?")},
 		GenerateCallbacks{
 			OnReasoningStart:    func(string) { run.starts++ },
@@ -153,14 +154,14 @@ func runReasoningStream(t *testing.T, payload string) reasoningRun {
 // reasoning field on the answer chunk must not hold the reasoning block open.
 func TestReasoningClosesOnNullReasoningField(t *testing.T) {
 	t.Parallel()
-	assertReasoningComplete(t, runReasoningStream(t, glmFlashNullReasoningSSE))
+	assertReasoningComplete(t, runReasoningStream(t.Context(), t, glmFlashNullReasoningSSE))
 }
 
 // TestReasoningClosesOnOmittedReasoningField is the control case: providers
 // that drop the key entirely once the answer starts already worked.
 func TestReasoningClosesOnOmittedReasoningField(t *testing.T) {
 	t.Parallel()
-	assertReasoningComplete(t, runReasoningStream(t, glmOmittedReasoningSSE))
+	assertReasoningComplete(t, runReasoningStream(t.Context(), t, glmOmittedReasoningSSE))
 }
 
 func assertReasoningComplete(t *testing.T, run reasoningRun) {


### PR DESCRIPTION
## Description

Issue #124 reported that reasoning streams live but is never closed for some models: `OnReasoningComplete` never fires, and the assistant message carries no reasoning part — so sessions persist nothing and the reasoning the user watched disappears on reload. Reproduced deterministically on `opencode-go/glm-5.3-flash`.

The root cause is in `charm.land/fantasy` `providers/openaicompat`, not in Kit. Providers such as glm-5.3-flash, DeepSeek, vLLM and SGLang repeat the reasoning key with a **null** value on every chunk that carries answer text, a tool call or the finish reason. `hasReasoningField` counted a present-but-null key as reasoning-in-progress, so `StreamPartTypeReasoningEnd` was never emitted and the block stayed open forever. Providers that simply drop the key (glm-5.2, kimi) were unaffected.

**This is already fixed upstream in fantasy v0.42.1**, which `master` pins as of `cab2f7fe`. `hasReasoningField` now ignores `null`, and `StreamExtraFunc` closes an open block on any boundary chunk. The last tagged release (v0.101.1) still ships the broken v0.41.3, so the fix reaches users with the next release.

Since the fix lives in a dependency, this PR adds no product code — it adds a **Kit-side regression guard** so a future dependency bump cannot reintroduce the leak silently. The test replays the exact reported SSE chunk shape over a local `httptest` server through the real `openaicompat` provider and Kit's own `GenerateWithCallbacks` plumbing, then asserts the full chain the issue found broken:

- `OnReasoningStart` / `OnReasoningDelta` / `OnReasoningComplete` fire as expected
- the assistant message carries exactly one `fantasy.ReasoningPart` — this is what a `SessionManager` persists
- the converted `message.ReasoningContent` block holds the full reasoning text

A control case replays the glm-5.2 shape (key absent once the answer starts), and a small table test documents the null-vs-empty-string contract Kit relies on: a `null` value means "no reasoning in this delta", while an empty string still counts as reasoning.

Verified failing on fantasy v0.41.3 with exactly the reported symptoms (`OnReasoningComplete fired 0 times`, `0` reasoning parts) and passing on v0.42.1.

Fixes #124

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test / CI change (adds or improves tests, no behaviour change)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation (not applicable — no public surface change)

## Testing

- `go test ./internal/agent/ -race` — pass
- `go test ./... -race` (excluding the pre-existing, unrelated `examples/extensions` yaegi-script build error) — pass
- `golangci-lint run internal/agent/...` — 0 issues
- `gofmt` / `go vet` — clean
- Pinned back to fantasy v0.41.3 to confirm the test fails with the reported symptoms, then restored `go.mod` / `go.sum`

## Additional Information

**Added**

- `internal/agent/reasoning_stream_test.go` (+221) — SSE replay harness plus three tests:
  - `TestReasoningClosesOnNullReasoningField` — the reported glm-5.3-flash shape
  - `TestReasoningClosesOnOmittedReasoningField` — the glm-5.2 control shape
  - `TestHasReasoningFieldNullContract` — the null-vs-empty-string rule

**Modified**: none. No production code, no public API and no dependency versions change, so this is fully backward compatible.

The harness builds an `Agent` directly rather than through `NewAgent`, which keeps the model registry and the network out of the path while still exercising the real provider, the real fantasy agent, and Kit's own callback and message-conversion code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed popup terminal session checks and termination when launched from within another tmux session.
  * Improved handling of OpenAI-compatible responses with null reasoning fields, preserving reasoning content and final responses correctly.
* **Tests**
  * Added coverage for reasoning events, persisted reasoning content, converted message text, and final responses.
  * Documented the distinction between null reasoning values and empty reasoning strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->