### PR TITLE
build(lint): enable staticcheck and unused linters (#123)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,25 @@ jobs:
           # than the targeted Go version".
           version: v2.13.1
 
+  # Advisory only: staticcheck with ALL checks enabled (default excludes the
+  # stylistic ST* family). Findings here do not block merges; the blocking
+  # staticcheck/unused checks run through golangci-lint in the lint job.
+  # Pinned via go run so it never depends on a stale binary on PATH
+  # (see issue #123).
+  staticcheck-advisory:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.27"
+
+      - run: go run honnef.co/go/tools/cmd/staticcheck@v0.8.1 -checks=all ./...
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
   # (see issue #123).
   staticcheck-advisory:
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -50,7 +49,10 @@ jobs:
         with:
           go-version: "1.27"
 
+      # Only the staticcheck step is advisory; checkout and Go setup
+      # failures must still fail the job.
       - run: go run honnef.co/go/tools/cmd/staticcheck@v0.8.1 -checks=all ./...
+        continue-on-error: true
 
   test:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,16 @@ version: "2"
 linters:
   enable:
     - modernize
+    # staticcheck and unused catch bugs and dead code that went undetected
+    # for months when only modernize was enabled (see issue #123). Both run
+    # through the golangci-lint binary pinned in .github/workflows/ci.yml,
+    # so they do not depend on whatever staticcheck build is on a
+    # developer's PATH.
+    - staticcheck
+    # unused (U1000) flags unexported symbols only. It does NOT flag
+    # exported symbols in internal/ packages — dead exported code there
+    # must be found by periodic manual review or a cross-reference sweep.
+    - unused
 
 formatters:
   enable:


### PR DESCRIPTION
## Description

The dead code batch in #119 went undetected for months because `.golangci.yml` enabled only the `modernize` linter, and the locally installed `staticcheck`/`deadcode` binaries were broken by a go1.26/go1.27 toolchain mismatch — so the checks that would have caught it never ran.

This PR enables `staticcheck` and `unused` in `.golangci.yml`. Both run through the golangci-lint binary already pinned in CI (`v2.13.1`, built with go1.27), so they no longer depend on whatever analysis tools are on a developer's PATH. The current codebase is clean: `golangci-lint run` reports 0 issues with the new config.

It also adds a non-blocking `staticcheck-advisory` CI job (`continue-on-error: true`) that runs `staticcheck -checks=all` via a pinned `go run honnef.co/go/tools/cmd/staticcheck@v0.8.1` invocation. This surfaces the stylistic ST* family (currently only ST1000/ST1020 package-comment nits) without blocking merges. Note: the semver module tag `v0.8.1` is used instead of the year-style release name `2026.1`, because Go module resolution only accepts semver tags.

Fixes #123

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Build / CI
- [ ] Documentation
- [ ] Refactor

## Checklist

- [x] Code follows the repository style guidelines
- [x] Self-review performed
- [x] Lint passes (`golangci-lint run` — 0 issues with the new linters enabled)
- [x] Tests pass (`go test -race ./...` — 32 packages ok)
- [ ] Tests added (config/CI-only change, no Go code touched)
- [ ] Docs updated (not applicable)

## Additional Information

- Modified: `.golangci.yml` — enable `staticcheck` and `unused` with comments that document why and the known `unused` limitation (exported symbols in `internal/` packages are not flagged; those need periodic manual review)
- Modified: `.github/workflows/ci.yml` — new advisory `staticcheck-advisory` job, pinned and non-blocking
- Not included (already resolved on `master`): CI already pins golangci-lint v2.13.1 on Go 1.27; the stray `kit_multi_stderr.log` / `kit_stderr2.log` artifacts mentioned in the issue no longer exist
- No runtime behavior change; CI-only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Quality Improvements**
  - Added advisory static analysis checks to identify potential bugs and unused code.
  - Expanded linting coverage with additional code-quality checks.
  - Reports findings for review while allowing the workflow to continue when these checks identify issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->