### PR TITLE
chore: remove dead exported symbols in internal/ (#119)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1638,7 +1638,7 @@ func runNormalMode(ctx context.Context) error {
 // runNonInteractiveModeApp executes a single prompt via the app layer and exits,
 // or transitions to the interactive BubbleTea TUI when --no-exit is set.
 //
-// In quiet mode, RunOnce is used (no intermediate output, final response only).
+// In quiet mode, RunOnceWithFiles is used (no intermediate output, final response only).
 // Otherwise, RunOnceWithDisplay streams tool calls and responses through the
 // shared CLIEventHandler — giving --prompt mode the same rich output as
 // interactive mode.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -317,7 +317,7 @@ type GenerateWithLoopResult struct {
 // Core tools (shell, read, write, edit, grep, find, ls) are always registered.
 // If MCP servers are configured, their tools are loaded in the background —
 // the agent returns immediately and is usable with core tools only. The first
-// LLM call (GenerateWithLoop) automatically waits for MCP tools to finish
+// LLM call (GenerateWithCallbacks) automatically waits for MCP tools to finish
 // loading and rebuilds the agent with the full tool set.
 func NewAgent(ctx context.Context, agentConfig *AgentConfig) (*Agent, error) {
 	// Create the LLM provider
@@ -597,20 +597,6 @@ func buildAgentOptions(agentConfig *AgentConfig, providerResult *models.Provider
 	}
 
 	return agentOpts
-}
-
-// GenerateWithLoop processes messages with a custom loop that displays tool calls in real-time.
-func (a *Agent) GenerateWithLoop(ctx context.Context, messages []fantasy.Message,
-	onToolCall ToolCallHandler, onToolExecution ToolExecutionHandler, onToolResult ToolResultHandler,
-	onResponse ResponseHandler, onToolCallContent ToolCallContentHandler,
-) (*GenerateWithLoopResult, error) {
-	return a.GenerateWithCallbacks(ctx, messages, GenerateCallbacks{
-		OnToolCall:        onToolCall,
-		OnToolExecution:   onToolExecution,
-		OnToolResult:      onToolResult,
-		OnResponse:        onResponse,
-		OnToolCallContent: onToolCallContent,
-	})
 }
 
 // GenerateWithCallbacks processes messages using the agent with streaming and callbacks.
@@ -1450,13 +1436,6 @@ func (a *Agent) SetSystemPrompt(prompt string) {
 	defer a.promptMu.Unlock()
 	a.systemPrompt = prompt
 	a.rebuildFantasyAgent()
-}
-
-// GetSystemPrompt returns the agent's current system prompt.
-func (a *Agent) GetSystemPrompt() string {
-	a.promptMu.Lock()
-	defer a.promptMu.Unlock()
-	return a.systemPrompt
 }
 
 // GetMaxTokens returns the effective max output tokens the agent currently

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -53,8 +53,8 @@ const DefaultNewSessionIdleWait = 10 * time.Minute
 // In interactive mode the caller creates a tea.Program and registers it via
 // SetProgram; App then sends events to it as agent work progresses.
 //
-// In non-interactive mode the caller uses RunOnce, which writes the response
-// directly to an io.Writer.
+// In non-interactive mode the caller uses RunOnceWithFiles or
+// RunOnceWithDisplay, which write the response directly to stdout.
 //
 // App satisfies the ui.AppController interface defined in internal/ui/model.go:
 //
@@ -780,15 +780,10 @@ func (a *App) releaseBusyAfterCompact() {
 // Non-interactive execution
 // --------------------------------------------------------------------------
 
-// RunOnce executes a single agent step synchronously and prints the final
-// response text to stdout. No intermediate events are emitted. Blocks until
-// the step completes or ctx is cancelled.
-func (a *App) RunOnce(ctx context.Context, prompt string) error {
-	return a.RunOnceWithFiles(ctx, prompt, nil)
-}
-
 // RunOnceWithFiles executes a single agent step synchronously with optional
-// multimodal file attachments. Prints the response to stdout and returns.
+// multimodal file attachments. Prints the final response text to stdout and
+// returns. No intermediate events are emitted. Blocks until the step
+// completes or ctx is cancelled.
 func (a *App) RunOnceWithFiles(ctx context.Context, prompt string, files []kit.LLMFilePart) error {
 	stepCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -808,15 +803,10 @@ func (a *App) RunOnceWithFiles(ctx context.Context, prompt string, files []kit.L
 	return nil
 }
 
-// RunOnceResult executes a single agent step synchronously and returns the
-// full TurnResult without printing anything. This is used by --json mode to
-// capture structured output for serialization.
-func (a *App) RunOnceResult(ctx context.Context, prompt string) (*kit.TurnResult, error) {
-	return a.RunOnceResultWithFiles(ctx, prompt, nil)
-}
-
 // RunOnceResultWithFiles executes a single agent step synchronously with
-// optional multimodal file attachments and returns the full TurnResult.
+// optional multimodal file attachments and returns the full TurnResult
+// without printing anything. This is used by --json mode to capture
+// structured output for serialization.
 func (a *App) RunOnceResultWithFiles(ctx context.Context, prompt string, files []kit.LLMFilePart) (*kit.TurnResult, error) {
 	stepCtx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/internal/core/truncate.go
+++ b/internal/core/truncate.go
@@ -15,8 +15,6 @@ const (
 	DefaultMaxLines = defaultMaxLines
 	// DefaultMaxBytes is the exported default byte limit for truncation.
 	DefaultMaxBytes = defaultMaxBytes
-	// DefaultMaxLineLen is the exported default per-line character limit.
-	DefaultMaxLineLen = defaultMaxLineLen
 )
 
 // TruncationResult describes how output was truncated.

--- a/internal/extensions/runner.go
+++ b/internal/extensions/runner.go
@@ -101,7 +101,6 @@ type Runner struct {
 	customEditor    *EditorConfig             // nil = no custom editor interceptor
 	uiVisibility    *UIVisibility             // nil = show everything (default)
 	disabledTools   map[string]bool           // nil = all tools enabled
-	customEventSubs map[string][]func(string) // inter-extension event bus
 	optionOverrides map[string]string         // runtime option overrides
 	configStore     *viper.Viper              // per-instance config store (nil = global)
 	state           map[string]string         // session-scoped extension state (last-write-wins)
@@ -1074,7 +1073,6 @@ func (r *Runner) Reload(exts []LoadedExtension) {
 	r.customEditor = nil
 	r.uiVisibility = nil
 	r.disabledTools = nil
-	r.customEventSubs = nil
 	// optionOverrides and state are intentionally preserved across reloads:
 	// they represent user/session intent (not extension code) and would be
 	// surprising to lose on a hot-reload.
@@ -1084,26 +1082,13 @@ func (r *Runner) Reload(exts []LoadedExtension) {
 // Inter-extension event bus
 // ---------------------------------------------------------------------------
 
-// SubscribeCustomEvent registers a handler for a named custom event. Handlers
-// execute in registration order when EmitCustomEvent is called. Thread-safe.
-func (r *Runner) SubscribeCustomEvent(name string, handler func(string)) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.customEventSubs == nil {
-		r.customEventSubs = make(map[string][]func(string))
-	}
-	r.customEventSubs[name] = append(r.customEventSubs[name], handler)
-}
-
-// EmitCustomEvent dispatches a named event to all subscribed handlers.
-// Handlers run synchronously in extension load order. Panics are recovered
+// EmitCustomEvent dispatches a named event to all handlers registered via
+// api.OnCustomEvent. Handlers run synchronously in extension load order. Panics are recovered
 // and logged. Thread-safe.
 func (r *Runner) EmitCustomEvent(name, data string) {
-	// Collect handlers: extension-registered (Init-time) + dynamic subs.
 	// extensions and extMu are snapshotted together for the same reason as
 	// in Emit — Reload may swap them concurrently.
 	r.mu.RLock()
-	dynamicHandlers := r.customEventSubs[name]
 	exts := r.extensions
 	mus := r.extMu
 	r.mu.RUnlock()
@@ -1128,10 +1113,6 @@ func (r *Runner) EmitCustomEvent(name, data string) {
 			safeInvoke(h)
 		}
 		mus[i].unlock()
-	}
-	// Then dynamic subscriptions (not extension-scoped, no per-ext lock).
-	for _, h := range dynamicHandlers {
-		safeInvoke(h)
 	}
 }
 

--- a/internal/message/content.go
+++ b/internal/message/content.go
@@ -193,27 +193,6 @@ func (m *Message) Reasoning() ReasoningContent {
 	return ReasoningContent{}
 }
 
-// AddPart appends a content part and updates the timestamp.
-func (m *Message) AddPart(part ContentPart) {
-	m.Parts = append(m.Parts, part)
-	m.UpdatedAt = time.Now()
-}
-
-// AddToolCall appends or updates a ToolCall part. If a call with the same
-// ID already exists, it is replaced (supports streaming where partial calls
-// arrive before the final version).
-func (m *Message) AddToolCall(tc ToolCall) {
-	for i, part := range m.Parts {
-		if existing, ok := part.(ToolCall); ok && existing.ID == tc.ID {
-			m.Parts[i] = tc
-			m.UpdatedAt = time.Now()
-			return
-		}
-	}
-	m.Parts = append(m.Parts, tc)
-	m.UpdatedAt = time.Now()
-}
-
 // --- Type-tagged JSON serialization ---
 
 type partType string

--- a/internal/session/tree_manager.go
+++ b/internal/session/tree_manager.go
@@ -997,13 +997,6 @@ func (tm *TreeManager) GetSessionName() string {
 	return tm.sessionName
 }
 
-// GetCwd returns the working directory this session was created in.
-func (tm *TreeManager) GetCwd() string {
-	tm.mu.RLock()
-	defer tm.mu.RUnlock()
-	return tm.header.Cwd
-}
-
 // GetFilePath returns the JSONL file path, or empty for in-memory sessions.
 func (tm *TreeManager) GetFilePath() string {
 	tm.mu.RLock()
@@ -1227,28 +1220,6 @@ func (tm *TreeManager) GetLastCompaction() *CompactionEntry {
 		}
 	}
 	return nil
-}
-
-// --- Legacy bridge ---
-
-// AddLLMMessages appends multiple LLM messages as entries. This is
-// used when syncing from the agent's ConversationMessages after a step.
-// All entries are buffered and flushed to disk in a single batch.
-func (tm *TreeManager) AddLLMMessages(msgs []fantasy.Message) error {
-	tm.mu.Lock()
-	defer tm.mu.Unlock()
-
-	for _, msg := range msgs {
-		entry, err := NewMessageEntry(tm.leafID, message.FromLLMMessage(msg))
-		if err != nil {
-			return err
-		}
-		if err := tm.appendAndPersist(entry); err != nil {
-			return err
-		}
-		tm.leafID = entry.ID
-	}
-	return tm.flushLocked()
 }
 
 // GetLLMMessages builds the context and returns just the messages.

--- a/internal/session/tree_validation.go
+++ b/internal/session/tree_validation.go
@@ -5,48 +5,6 @@ import (
 	"log"
 )
 
-// ValidateParentChain checks that the parent ID points to an existing entry
-// and that appending this entry would not create a cycle. This should be called
-// before appending any entry to the tree.
-// Returns an error if the parent is invalid or would create a cycle.
-func (tm *TreeManager) ValidateParentChain(parentID string, newEntryID string) error {
-	if parentID == "" {
-		// Empty parent is valid (root entry)
-		return nil
-	}
-
-	// Check that parent exists
-	if _, ok := tm.index[parentID]; !ok {
-		return fmt.Errorf("parent entry %q does not exist in index", parentID)
-	}
-
-	// Check that we're not creating a cycle by walking up the parent chain
-	// from parentID and ensuring we don't hit newEntryID (or any node that
-	// has newEntryID as an ancestor, but since newEntryID is new, just check
-	// that parentID isn't newEntryID, which it can't be since we check existence)
-	visited := make(map[string]bool)
-	current := parentID
-	for current != "" {
-		if visited[current] {
-			return fmt.Errorf("existing cycle detected at entry %q", current)
-		}
-		visited[current] = true
-
-		// Safety check: if somehow we reach the new entry ID, that's a cycle
-		if current == newEntryID {
-			return fmt.Errorf("would create cycle: entry %q cannot be its own ancestor", newEntryID)
-		}
-
-		entry, ok := tm.index[current]
-		if !ok {
-			return fmt.Errorf("broken parent chain: entry %q not found", current)
-		}
-		current = tm.entryParentID(entry)
-	}
-
-	return nil
-}
-
 // DetectCycle walks the parent chain from the given entry ID and returns true
 // if a cycle is detected. This is used for diagnostics.
 func (tm *TreeManager) DetectCycle(fromID string) (cycleDetected bool, cycleEntry string) {

--- a/internal/tools/connection_pool.go
+++ b/internal/tools/connection_pool.go
@@ -108,15 +108,6 @@ func (p *MCPConnectionPool) SetDebugLogger(logger DebugLogger) {
 	p.debugLogger = logger
 }
 
-// SetOAuthFlow sets the OAuth flow runner for the connection pool.
-// When set, the pool can trigger OAuth re-authorization when a tool call fails
-// with an OAuth error (e.g. expired token). Thread-safe and can be called at any time.
-func (p *MCPConnectionPool) SetOAuthFlow(flow *OAuthFlowRunner) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.oauthFlow = flow
-}
-
 // GetConnection retrieves or creates a connection for the specified MCP server.
 // If a healthy, non-idle connection exists in the pool, it will be reused.
 // Otherwise, a new connection is created and added to the pool.
@@ -591,29 +582,6 @@ func (p *MCPConnectionPool) HandleConnectionError(serverName string, err error) 
 	}
 }
 
-// GetConnectionStats returns detailed statistics for all connections in the pool.
-// The returned map includes health status, last usage time, error counts, and
-// last error for each connection. Useful for monitoring and debugging connection
-// pool behavior. The returned data is a snapshot and safe for concurrent access.
-func (p *MCPConnectionPool) GetConnectionStats() map[string]any {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-
-	stats := make(map[string]any)
-	for serverName, conn := range p.connections {
-		conn.mu.RLock()
-		stats[serverName] = map[string]any{
-			"is_healthy":  conn.isHealthy,
-			"last_used":   conn.lastUsed,
-			"last_error":  conn.lastError,
-			"error_count": conn.errorCount,
-			"server_name": conn.serverName,
-		}
-		conn.mu.RUnlock()
-	}
-	return stats
-}
-
 // ServerName returns the server name associated with this MCP connection.
 // This is the configured name from the KIT configuration, not necessarily
 // the actual server implementation name.
@@ -672,7 +640,7 @@ func (p *MCPConnectionPool) ServerSupportsToolTasks(serverName string) bool {
 // GetClients returns a map of all MCP clients currently in the pool.
 // The map keys are server names and values are the corresponding MCP client instances.
 // The returned map is a copy and modifications won't affect the pool.
-// Note that clients may be unhealthy; use GetConnectionStats to check health status.
+// Note that clients may be unhealthy.
 func (p *MCPConnectionPool) GetClients() map[string]client.MCPClient {
 	p.mu.RLock()
 	defer p.mu.RUnlock()

--- a/internal/tools/mcp.go
+++ b/internal/tools/mcp.go
@@ -157,10 +157,6 @@ type MCPToolManager struct {
 	// mutates the tool list. The agent layer uses this to trigger a rebuild
 	// so the LLM sees the updated tools.
 	onToolsChanged func()
-
-	// onResourcesChanged, if non-nil, is called when a subscribed resource
-	// is updated by the server.
-	onResourcesChanged func()
 }
 
 // toolMapping stores the mapping between prefixed tool names and their original details
@@ -234,13 +230,6 @@ func (m *MCPToolManager) SetOnToolsChanged(cb func()) {
 // Subsequent calls replace the previous configuration wholesale.
 func (m *MCPToolManager) SetTaskConfig(cfg MCPTaskConfig) {
 	m.taskCfg = cfg
-}
-
-// TaskConfig returns the manager's current task-augmented tools/call
-// configuration. The zero value means: defer to per-server config and
-// auto-detected capability, with no progress callback and default polling.
-func (m *MCPToolManager) TaskConfig() MCPTaskConfig {
-	return m.taskCfg
 }
 
 // AddServer connects to a new MCP server at runtime and loads its tools.
@@ -1101,12 +1090,6 @@ func (m *MCPToolManager) GetResources() []MCPResource {
 	return result
 }
 
-// SetOnResourcesChanged sets the callback invoked when a subscribed resource
-// changes. Used by the UI layer to refresh autocomplete or re-read content.
-func (m *MCPToolManager) SetOnResourcesChanged(cb func()) {
-	m.onResourcesChanged = cb
-}
-
 // ReadResource reads a specific resource from an MCP server by URI.
 // Returns the resource content (text or binary blob).
 func (m *MCPToolManager) ReadResource(ctx context.Context, serverName, uri string) (*MCPResourceContent, error) {
@@ -1183,8 +1166,6 @@ func (m *MCPToolManager) ReadResource(ctx context.Context, serverName, uri strin
 }
 
 // SubscribeResource subscribes to change notifications for a resource.
-// When the resource changes on the server, onResourcesChanged is called
-// and the resource list is refreshed automatically.
 func (m *MCPToolManager) SubscribeResource(ctx context.Context, serverName, uri string) error {
 	if m.connectionPool == nil {
 		return fmt.Errorf("no connection pool available")
@@ -1234,51 +1215,6 @@ func (m *MCPToolManager) UnsubscribeResource(ctx context.Context, serverName, ur
 	m.mu.Unlock()
 
 	return nil
-}
-
-// RefreshServerResources re-fetches resources from a specific server.
-// Called when a resource change notification is received.
-func (m *MCPToolManager) RefreshServerResources(ctx context.Context, serverName string) {
-	if m.connectionPool == nil {
-		return
-	}
-
-	clients := m.connectionPool.GetClients()
-	mcpClient, ok := clients[serverName]
-	if !ok {
-		return
-	}
-
-	listResult, err := mcpClient.ListResources(ctx, mcp.ListResourcesRequest{})
-	if err != nil {
-		return
-	}
-
-	var newResources []MCPResource
-	for _, r := range listResult.Resources {
-		newResources = append(newResources, MCPResource{
-			URI:         r.URI,
-			Name:        r.Name,
-			Description: r.Description,
-			MIMEType:    r.MIMEType,
-			ServerName:  serverName,
-		})
-	}
-
-	m.mu.Lock()
-	// Remove old resources from this server, add new ones.
-	filtered := make([]MCPResource, 0, len(m.resources))
-	for _, r := range m.resources {
-		if r.ServerName != serverName {
-			filtered = append(filtered, r)
-		}
-	}
-	m.resources = append(filtered, newResources...)
-	m.mu.Unlock()
-
-	if m.onResourcesChanged != nil {
-		m.onResourcesChanged()
-	}
 }
 
 // GetLoadedServerNames returns the names of all successfully loaded MCP servers.

--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -1014,11 +1014,6 @@ func (s *InputComponent) ClearPendingImages() ([]core.ImageAttachment, tea.Cmd) 
 	return images, cleanup
 }
 
-// PendingImageCount returns the number of images currently attached.
-func (s *InputComponent) PendingImageCount() int {
-	return len(s.pendingImages)
-}
-
 // Clear clears the textarea content and resets related state. Returns true if
 // there was content to clear, false if the input was already empty.
 func (s *InputComponent) Clear() bool {

--- a/internal/ui/popup_list.go
+++ b/internal/ui/popup_list.go
@@ -506,15 +506,6 @@ func (p *PopupList) IsSearching() bool {
 	return p.search != ""
 }
 
-// SelectedItem returns the item under the cursor, or nil if the list is empty.
-func (p *PopupList) SelectedItem() *PopupItem {
-	if p.cursor < len(p.filtered) {
-		item := p.filtered[p.cursor]
-		return &item
-	}
-	return nil
-}
-
 // --- Internal helpers ---
 
 func (p *PopupList) rebuildFiltered() {

--- a/internal/ui/scrolllist.go
+++ b/internal/ui/scrolllist.go
@@ -193,16 +193,6 @@ func (s *ScrollList) SetWidth(width int) {
 	s.clampOffset()
 }
 
-// SetItemGap sets the number of blank lines between items (0 = no gap).
-func (s *ScrollList) SetItemGap(gap int) {
-	s.itemGap = gap
-}
-
-// ItemGap returns the current gap between items.
-func (s *ScrollList) ItemGap() int {
-	return s.itemGap
-}
-
 // --------------------------------------------------------------------------
 // Mouse event handling — character-level text selection (crush-style)
 // --------------------------------------------------------------------------
@@ -650,11 +640,6 @@ func (s *ScrollList) AtBottom() bool {
 	return true
 }
 
-// AtTop returns true if the viewport is at the top of the list.
-func (s *ScrollList) AtTop() bool {
-	return s.offsetIdx == 0 && s.offsetLine == 0
-}
-
 // --------------------------------------------------------------------------
 // Rendering
 // --------------------------------------------------------------------------
@@ -811,43 +796,6 @@ func (s *ScrollList) VisibleItems() []VisibleItem {
 		}
 	}
 	return out
-}
-
-// ScrollPercent returns the current scroll position as a percentage (0.0-1.0).
-// 0.0 = at top, 1.0 = at bottom. Useful for scroll indicators.
-func (s *ScrollList) ScrollPercent() float64 {
-	if len(s.items) == 0 {
-		return 0.0
-	}
-
-	totalHeight := 0
-	for idx := range s.items {
-		totalHeight += s.itemHeight(idx)
-	}
-
-	if totalHeight <= s.height {
-		return 1.0
-	}
-
-	linesAbove := 0
-	for i := 0; i < s.offsetIdx && i < len(s.items); i++ {
-		linesAbove += s.itemHeight(i)
-	}
-	linesAbove += s.offsetLine
-
-	scrollableHeight := totalHeight - s.height
-	if scrollableHeight <= 0 {
-		return 1.0
-	}
-
-	percent := float64(linesAbove) / float64(scrollableHeight)
-	if percent > 1.0 {
-		percent = 1.0
-	}
-	if percent < 0.0 {
-		percent = 0.0
-	}
-	return percent
 }
 
 // clampOffset ensures the offset values are within valid bounds after

--- a/internal/ui/session_selector.go
+++ b/internal/ui/session_selector.go
@@ -146,12 +146,6 @@ func NewSessionSelector(store SessionStore, cwd string, width, height int) *Sess
 	return ss
 }
 
-// SetCurrentPath sets the currently active session path so the picker can
-// highlight it in the list.
-func (ss *SessionSelectorComponent) SetCurrentPath(path string) {
-	ss.currentPath = path
-}
-
 // Init implements tea.Model.
 func (ss *SessionSelectorComponent) Init() tea.Cmd {
 	return nil


### PR DESCRIPTION
## Description

Removes 18 exported symbols under `internal/` that have no references anywhere in the module — not in non-test code, not in tests, and not reachable from Yaegi extensions (which only see the `kit/ext/ext` namespace). Each symbol was verified with a grep across `internal/`, `pkg/`, and `cmd/` before deletion; the only hits were the declarations and their own doc comments.

Two private fields became write-only once their setters were removed, so they are dropped as well: `MCPToolManager.onResourcesChanged` and `Runner.customEventSubs`. `EmitCustomEvent` now dispatches only to handlers registered via `api.OnCustomEvent`, which is the only path that was ever populated — extension behaviour is unchanged.

Doc comments that referenced the removed names (`NewAgent`, `App`, `GetClients`, `runNonInteractiveModeApp`) now point to the surviving alternatives.

Fixes #119

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Chore / cleanup

## Removed symbols

| Package | Symbols |
|---|---|
| `internal/app` | `RunOnce`, `RunOnceResult` |
| `internal/agent` | `GenerateWithLoop`, `GetSystemPrompt` |
| `internal/ui` | `SetItemGap`, `ItemGap`, `AtTop`, `ScrollPercent`, `SelectedItem`, `PendingImageCount`, `SetCurrentPath` |
| `internal/message` | `AddPart`, `AddToolCall` |
| `internal/session` | `GetCwd`, `AddLLMMessages`, `ValidateParentChain` |
| `internal/tools` | `SetOAuthFlow`, `GetConnectionStats`, `TaskConfig`, `SetOnResourcesChanged`, `RefreshServerResources` |
| `internal/extensions` | `SubscribeCustomEvent` |
| `internal/core` | `DefaultMaxLineLen` (exported alias; private `defaultMaxLineLen` kept) |

Out of scope, per the issue: `daemon/tunnel.go` `StatusCh`/`Exited`, `agent.GetExtraToolCount`, `app.RunOnceWithDisplay`.

## Checklist

- [x] Code follows the project style (`gofmt`, `go vet` clean)
- [x] Self-reviewed the diff
- [x] `go test -race ./...` passes
- [x] `golangci-lint run` reports 0 issues
- [ ] Tests added (none needed — deletion only)
- [ ] Docs updated (no public surface changed; `internal/` only)

## Additional Information

- 14 files changed, +13 / −325
- No changes to `pkg/kit/` or any public SDK surface
- No behaviour change for extensions or the CLI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Quiet, non-interactive runs now correctly include attached files when sending requests to the agent.
  - File-aware execution is now used consistently, whether or not attachments are provided.

- **Documentation**
  - Updated non-interactive execution guidance to reflect the current file-capable workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->