### PR TITLE
refactor: SDK hygiene, dedup clusters, split bridge/generate (#120, #121, #122)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -236,6 +237,48 @@ type GenerateCallbacks struct {
 	OnRetry          RetryHandler
 	OnPrepareStep    PrepareStepHandler
 }
+
+// HasAnyCallback reports whether any callback that can only be observed on
+// the streaming path is set. GenerateWithCallbacks uses it to choose between
+// the streaming call (which exposes per-step and per-tool lifecycle events)
+// and the simpler non-streaming call.
+//
+// Three fields are deliberately excluded because both paths honour them:
+// OnResponse fires after either call completes, and OnToolOutput /
+// OnPasswordPrompt are injected into the context for core tools regardless of
+// how the model is invoked. Every other field must appear below —
+// TestHasAnyCallbackCoversAllFields fails when a new field is added without
+// updating this method.
+func (cb GenerateCallbacks) HasAnyCallback() bool {
+	return cb.OnToolCall != nil ||
+		cb.OnToolExecution != nil ||
+		cb.OnToolResult != nil ||
+		cb.OnToolCallContent != nil ||
+		cb.OnStreamingResponse != nil ||
+		cb.OnReasoningDelta != nil ||
+		cb.OnReasoningComplete != nil ||
+		cb.OnStepMessages != nil ||
+		cb.OnStepUsage != nil ||
+		cb.OnToolCallStart != nil ||
+		cb.OnToolCallDelta != nil ||
+		cb.OnToolCallEnd != nil ||
+		cb.OnStepStart != nil ||
+		cb.OnStepFinish != nil ||
+		cb.OnTextStart != nil ||
+		cb.OnTextEnd != nil ||
+		cb.OnReasoningStart != nil ||
+		cb.OnWarnings != nil ||
+		cb.OnSource != nil ||
+		cb.OnStreamFinish != nil ||
+		cb.OnError != nil ||
+		cb.OnRetry != nil ||
+		cb.OnPrepareStep != nil
+}
+
+// ErrNoMCPServers is returned by the per-server MCP accessors (prompts,
+// resources, subscriptions) when the agent was built without any MCP servers
+// and therefore has no tool manager to route the request through.
+var ErrNoMCPServers = errors.New("no MCP servers configured")
 
 // Agent represents an AI agent with core tool integration using the LLM library.
 // Core tools (shell, read, write, edit, grep, find, ls) are registered as direct
@@ -631,6 +674,25 @@ func (a *Agent) GenerateWithCallbacks(ctx context.Context, messages []fantasy.Me
 	// This avoids type conflicts with provider-level options.
 	history = applyCacheControlToMessages(history)
 
+	// Use the streaming path when streaming is enabled OR when any
+	// streaming-only callbacks are provided. The agent only exposes tool/step
+	// callbacks on AgentStreamCall, so Stream is required to observe tool
+	// execution in real time. The non-streaming Generate path is reserved for
+	// the simple case with no such callbacks at all.
+	if a.streamingEnabled || cb.HasAnyCallback() {
+		return a.generateStreaming(ctx, cb, messages, prompt, files, history)
+	}
+	return a.generateSimple(ctx, cb, messages, prompt, files, history)
+}
+
+// generateStreaming runs the agent loop through the streaming call so every
+// GenerateCallbacks field can be observed as the model produces output and
+// executes tools. messages is the full original conversation (used to build
+// the returned result); prompt, files and history are its split form as
+// produced by splitPromptAndHistory.
+func (a *Agent) generateStreaming(ctx context.Context, cb GenerateCallbacks, messages []fantasy.Message,
+	prompt string, files []fantasy.FilePart, history []fantasy.Message,
+) (*GenerateWithLoopResult, error) {
 	// Track tool call args per-ToolCallID so parallel tool calls in a single
 	// step don't clobber each other. Without this, OnToolResult callbacks would
 	// all see the args of the last OnToolCall in the step. The mutex guards
@@ -639,385 +701,378 @@ func (a *Agent) GenerateWithCallbacks(ctx context.Context, messages []fantasy.Me
 	toolCallArgs := make(map[string]string)
 	var toolCallArgsMu sync.Mutex
 
-	// Use the streaming path when streaming is enabled OR when any callbacks are
-	// provided. The agent only exposes tool/step callbacks on AgentStreamCall, so
-	// Stream is required to observe tool execution in real time. The non-streaming
-	// Generate path is reserved for the simple case with no callbacks at all.
-	hasCallbacks := cb.OnToolCall != nil || cb.OnToolExecution != nil || cb.OnToolResult != nil ||
-		cb.OnToolCallContent != nil || cb.OnStreamingResponse != nil || cb.OnReasoningDelta != nil ||
-		cb.OnToolCallStart != nil || cb.OnToolCallDelta != nil || cb.OnToolCallEnd != nil ||
-		cb.OnStepStart != nil || cb.OnStepFinish != nil || cb.OnTextStart != nil ||
-		cb.OnTextEnd != nil || cb.OnReasoningStart != nil || cb.OnWarnings != nil ||
-		cb.OnSource != nil || cb.OnStreamFinish != nil || cb.OnError != nil ||
-		cb.OnRetry != nil || cb.OnPrepareStep != nil
+	// Track completed step messages so we can return partial results
+	// on cancellation. The agent's Stream() discards accumulated steps
+	// when it returns an error, but the OnStepFinish callback fires
+	// for every step that completed before the error occurred.
+	var completedStepMessages []fantasy.Message
+	// persistedCount tracks how many new messages (beyond the original
+	// input) were persisted incrementally via cb.OnStepMessages, so the
+	// caller can skip them during post-generation persistence.
+	var persistedCount int
+	// stepCounter tracks the current step number for StepStart/StepFinish events.
+	var stepCounter int
 
-	if a.streamingEnabled || hasCallbacks {
-		// Track completed step messages so we can return partial results
-		// on cancellation. The agent's Stream() discards accumulated steps
-		// when it returns an error, but the OnStepFinish callback fires
-		// for every step that completed before the error occurred.
-		var completedStepMessages []fantasy.Message
-		// persistedCount tracks how many new messages (beyond the original
-		// input) were persisted incrementally via cb.OnStepMessages, so the
-		// caller can skip them during post-generation persistence.
-		var persistedCount int
-		// stepCounter tracks the current step number for StepStart/StepFinish events.
-		var stepCounter int
+	// Use the streaming agent
+	streamCall := fantasy.AgentStreamCall{
+		Prompt:   prompt,
+		Files:    files,
+		Messages: history,
 
-		// Use the streaming agent
-		streamCall := fantasy.AgentStreamCall{
-			Prompt:   prompt,
-			Files:    files,
-			Messages: history,
+		// Tool input streaming callbacks — fire during tool argument generation
+		OnToolInputStart: func(id, toolName string) error {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if cb.OnToolCallStart != nil {
+				cb.OnToolCallStart(id, toolName)
+			}
+			return nil
+		},
+		OnToolInputDelta: func(id, delta string) error {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if cb.OnToolCallDelta != nil {
+				cb.OnToolCallDelta(id, delta)
+			}
+			return nil
+		},
+		OnToolInputEnd: func(id string) error {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if cb.OnToolCallEnd != nil {
+				cb.OnToolCallEnd(id)
+			}
+			return nil
+		},
 
-			// Tool input streaming callbacks — fire during tool argument generation
-			OnToolInputStart: func(id, toolName string) error {
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-				if cb.OnToolCallStart != nil {
-					cb.OnToolCallStart(id, toolName)
-				}
-				return nil
-			},
-			OnToolInputDelta: func(id, delta string) error {
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-				if cb.OnToolCallDelta != nil {
-					cb.OnToolCallDelta(id, delta)
-				}
-				return nil
-			},
-			OnToolInputEnd: func(id string) error {
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-				if cb.OnToolCallEnd != nil {
-					cb.OnToolCallEnd(id)
-				}
-				return nil
-			},
+		// Text start/end callbacks
+		OnTextStart: func(id string) error {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if cb.OnTextStart != nil {
+				cb.OnTextStart(id)
+			}
+			return nil
+		},
+		OnTextEnd: func(id string) error {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if cb.OnTextEnd != nil {
+				cb.OnTextEnd(id)
+			}
+			return nil
+		},
 
-			// Text start/end callbacks
-			OnTextStart: func(id string) error {
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-				if cb.OnTextStart != nil {
-					cb.OnTextStart(id)
-				}
-				return nil
-			},
-			OnTextEnd: func(id string) error {
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-				if cb.OnTextEnd != nil {
-					cb.OnTextEnd(id)
-				}
-				return nil
-			},
+		// Reasoning start callback
+		OnReasoningStart: func(id string, _ fantasy.ReasoningContent) error {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if cb.OnReasoningStart != nil {
+				cb.OnReasoningStart(id)
+			}
+			return nil
+		},
 
-			// Reasoning start callback
-			OnReasoningStart: func(id string, _ fantasy.ReasoningContent) error {
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-				if cb.OnReasoningStart != nil {
-					cb.OnReasoningStart(id)
-				}
-				return nil
-			},
+		// Reasoning/thinking streaming callback
+		OnReasoningDelta: func(id, delta string) error {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if cb.OnReasoningDelta != nil {
+				cb.OnReasoningDelta(delta)
+			}
+			return nil
+		},
 
-			// Reasoning/thinking streaming callback
-			OnReasoningDelta: func(id, delta string) error {
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-				if cb.OnReasoningDelta != nil {
-					cb.OnReasoningDelta(delta)
-				}
-				return nil
-			},
+		// Reasoning/thinking complete callback
+		OnReasoningEnd: func(id string, _ fantasy.ReasoningContent) error {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if cb.OnReasoningComplete != nil {
+				cb.OnReasoningComplete()
+			}
+			return nil
+		},
 
-			// Reasoning/thinking complete callback
-			OnReasoningEnd: func(id string, _ fantasy.ReasoningContent) error {
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-				if cb.OnReasoningComplete != nil {
-					cb.OnReasoningComplete()
-				}
-				return nil
-			},
+		// Text streaming callback
+		OnTextDelta: func(id, text string) error {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if cb.OnStreamingResponse != nil {
+				cb.OnStreamingResponse(text)
+			}
+			return nil
+		},
 
-			// Text streaming callback
-			OnTextDelta: func(id, text string) error {
-				if ctx.Err() != nil {
-					return ctx.Err()
+		// Warnings callback
+		OnWarnings: func(warnings []fantasy.CallWarning) error {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if cb.OnWarnings != nil {
+				strs := make([]string, len(warnings))
+				for i, w := range warnings {
+					strs[i] = w.Message
 				}
-				if cb.OnStreamingResponse != nil {
-					cb.OnStreamingResponse(text)
-				}
-				return nil
-			},
+				cb.OnWarnings(strs)
+			}
+			return nil
+		},
 
-			// Warnings callback
-			OnWarnings: func(warnings []fantasy.CallWarning) error {
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-				if cb.OnWarnings != nil {
-					strs := make([]string, len(warnings))
-					for i, w := range warnings {
-						strs[i] = w.Message
-					}
-					cb.OnWarnings(strs)
-				}
-				return nil
-			},
+		// Source callback
+		OnSource: func(source fantasy.SourceContent) error {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if cb.OnSource != nil {
+				cb.OnSource(string(source.SourceType), source.ID, source.URL, source.Title)
+			}
+			return nil
+		},
 
-			// Source callback
-			OnSource: func(source fantasy.SourceContent) error {
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-				if cb.OnSource != nil {
-					cb.OnSource(string(source.SourceType), source.ID, source.URL, source.Title)
-				}
-				return nil
-			},
+		// Stream finish callback (per-step stream completion)
+		OnStreamFinish: func(usage fantasy.Usage, finishReason fantasy.FinishReason, _ fantasy.ProviderMetadata) error {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if cb.OnStreamFinish != nil {
+				cb.OnStreamFinish(usage, string(finishReason))
+			}
+			return nil
+		},
 
-			// Stream finish callback (per-step stream completion)
-			OnStreamFinish: func(usage fantasy.Usage, finishReason fantasy.FinishReason, _ fantasy.ProviderMetadata) error {
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-				if cb.OnStreamFinish != nil {
-					cb.OnStreamFinish(usage, string(finishReason))
-				}
-				return nil
-			},
+		// Error callback
+		OnError: func(err error) {
+			if cb.OnError != nil {
+				cb.OnError(err)
+			}
+		},
 
-			// Error callback
-			OnError: func(err error) {
-				if cb.OnError != nil {
-					cb.OnError(err)
-				}
-			},
+		// Step start callback
+		OnStepStart: func(stepNumber int) error {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			stepCounter = stepNumber
+			if cb.OnStepStart != nil {
+				cb.OnStepStart(stepNumber)
+			}
+			return nil
+		},
 
-			// Step start callback
-			OnStepStart: func(stepNumber int) error {
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-				stepCounter = stepNumber
-				if cb.OnStepStart != nil {
-					cb.OnStepStart(stepNumber)
-				}
-				return nil
-			},
+		// Tool call complete - the tool has been parsed and is about to execute
+		OnToolCall: func(tc fantasy.ToolCallContent) error {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			toolCallArgsMu.Lock()
+			toolCallArgs[tc.ToolCallID] = tc.Input
+			toolCallArgsMu.Unlock()
 
-			// Tool call complete - the tool has been parsed and is about to execute
-			OnToolCall: func(tc fantasy.ToolCallContent) error {
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-				toolCallArgsMu.Lock()
-				toolCallArgs[tc.ToolCallID] = tc.Input
-				toolCallArgsMu.Unlock()
-
-				// Notify about the tool call
-				if cb.OnToolCall != nil {
-					cb.OnToolCall(tc.ToolCallID, tc.ToolName, tc.Input)
-				}
-
-				// Notify tool execution starting
-				if cb.OnToolExecution != nil {
-					cb.OnToolExecution(tc.ToolCallID, tc.ToolName, tc.Input, true)
-				}
-
-				return nil
-			},
-
-			// Tool result - tool execution completed
-			OnToolResult: func(tr fantasy.ToolResultContent) error {
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-				// Look up the args recorded for this specific tool call. Delete
-				// the entry so the map doesn't accumulate across steps.
-				toolCallArgsMu.Lock()
-				args := toolCallArgs[tr.ToolCallID]
-				delete(toolCallArgs, tr.ToolCallID)
-				toolCallArgsMu.Unlock()
-
-				// Notify tool execution finished
-				if cb.OnToolExecution != nil {
-					cb.OnToolExecution(tr.ToolCallID, tr.ToolName, args, false)
-				}
-
-				if cb.OnToolResult != nil {
-					// Extract result text and error status
-					resultText, isError := extractToolResultText(tr)
-					cb.OnToolResult(tr.ToolCallID, tr.ToolName, args, resultText, tr.ClientMetadata, isError)
-				}
-
-				return nil
-			},
-
-			// Step callbacks for content that accompanies tool calls
-			OnStepFinish: func(step fantasy.StepResult) error {
-				// Accumulate messages from completed steps so they can be
-				// persisted even if a later step is cancelled.
-				completedStepMessages = append(completedStepMessages, step.Messages...)
-
-				// Persist step messages incrementally so progress is saved
-				// as it happens rather than only at the end of the turn.
-				if cb.OnStepMessages != nil && len(step.Messages) > 0 {
-					cb.OnStepMessages(step.Messages)
-					persistedCount += len(step.Messages)
-				}
-
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-				// Check if step has text content alongside tool calls
-				text := step.Content.Text()
-				toolCalls := step.Content.ToolCalls()
-				if text != "" && len(toolCalls) > 0 && cb.OnToolCallContent != nil {
-					cb.OnToolCallContent(text)
-				}
-				// Emit step usage for real-time cost tracking
-				if cb.OnStepUsage != nil {
-					cb.OnStepUsage(step.Usage.InputTokens, step.Usage.OutputTokens,
-						step.Usage.CacheReadTokens, step.Usage.CacheCreationTokens)
-				}
-				// Emit unified step finish event
-				if cb.OnStepFinish != nil {
-					cb.OnStepFinish(stepCounter, len(toolCalls) > 0, string(step.FinishReason), step.Usage)
-				}
-				return nil
-			},
-		}
-
-		// Always wire up PrepareStep. It serves three purposes:
-		//   1. Re-read the live tool set each step so runtime AddTools/
-		//      RemoveTools (and MCP server changes) take effect at the next
-		//      LLM step of the *current* turn, as documented. The entire
-		//      multi-step loop runs inside a single fantasy Stream call that
-		//      otherwise captures the tool snapshot taken when Stream began;
-		//      populating PrepareStepResult.Tools makes fantasy re-read tools
-		//      per step instead.
-		//   2. Steering: drain queued steer messages.
-		//   3. The OnPrepareStep hook.
-		// Steering drains its channel first, then OnPrepareStep hooks run
-		// against the (possibly already steered) messages.
-		steerCh := steerChFromContext(ctx)
-		onConsumed := steerConsumedFromContext(ctx)
-		hasSteering := steerCh != nil
-		hasPrepareStepHook := cb.OnPrepareStep != nil
-
-		streamCall.PrepareStep = func(
-			stepCtx context.Context,
-			opts fantasy.PrepareStepFunctionOptions,
-		) (context.Context, fantasy.PrepareStepResult, error) {
-			result := fantasy.PrepareStepResult{
-				Model:    opts.Model,
-				Messages: opts.Messages,
-				// Re-read the live tool set so mid-turn tool changes are
-				// honored. composeAllTools matches the composition baked
-				// into the fantasy agent, so in the steady state this is
-				// identical to the snapshot fantasy would have used.
-				Tools: a.composeAllTools(),
+			// Notify about the tool call
+			if cb.OnToolCall != nil {
+				cb.OnToolCall(tc.ToolCallID, tc.ToolName, tc.Input)
 			}
 
-			// Phase 1: Drain steering channel (if present).
-			if hasSteering {
-				var steered []SteerMessage
-				for {
-					select {
-					case msg := <-steerCh:
-						steered = append(steered, msg)
-					default:
-						goto done
-					}
-				}
-			done:
-				if len(steered) > 0 {
-					for _, sm := range steered {
-						result.Messages = append(result.Messages,
-							fantasy.NewUserMessage(sm.Text, sm.Files...))
-					}
-					if onConsumed != nil {
-						onConsumed(len(steered))
-					}
-				}
+			// Notify tool execution starting
+			if cb.OnToolExecution != nil {
+				cb.OnToolExecution(tc.ToolCallID, tc.ToolName, tc.Input, true)
 			}
 
-			// Phase 2: Run OnPrepareStep hook (if registered).
-			if hasPrepareStepHook {
-				if update := cb.OnPrepareStep(opts.StepNumber, result.Messages); update != nil {
-					if update.Messages != nil {
-						result.Messages = update.Messages
-					}
-					if update.ToolChoice != nil {
-						result.ToolChoice = update.ToolChoice
-					}
-				}
+			return nil
+		},
+
+		// Tool result - tool execution completed
+		OnToolResult: func(tr fantasy.ToolResultContent) error {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			// Look up the args recorded for this specific tool call. Delete
+			// the entry so the map doesn't accumulate across steps.
+			toolCallArgsMu.Lock()
+			args := toolCallArgs[tr.ToolCallID]
+			delete(toolCallArgs, tr.ToolCallID)
+			toolCallArgsMu.Unlock()
+
+			// Notify tool execution finished
+			if cb.OnToolExecution != nil {
+				cb.OnToolExecution(tr.ToolCallID, tr.ToolName, args, false)
 			}
 
-			// Apply message-level cache control for Anthropic models.
-			result.Messages = applyCacheControlToMessages(result.Messages)
-
-			return stepCtx, result, nil
-		}
-
-		// Wire OnRetry callback if provided.
-		if cb.OnRetry != nil {
-			streamCall.OnRetry = func(err *fantasy.ProviderError, _ time.Duration) {
-				// Use the retry number from the error if available; Fantasy
-				// doesn't pass a counter directly, so we approximate with a
-				// counter incremented on each call.
-				cb.OnRetry(0, err)
+			if cb.OnToolResult != nil {
+				// Extract result text and error status
+				resultText, isError := extractToolResultText(tr)
+				cb.OnToolResult(tr.ToolCallID, tr.ToolName, args, resultText, tr.ClientMetadata, isError)
 			}
-		}
 
-		result, err := a.fantasyAgent.Stream(ctx, streamCall)
-		if err != nil {
-			// On cancellation (or any error), return a partial result
-			// containing messages from completed steps so the caller can
-			// persist tool calls and results that finished before the
-			// cancellation. The original input messages are included so
-			// the caller sees the full conversation up to the point of
-			// cancellation.
-			if len(completedStepMessages) > 0 {
-				partialMessages := make([]fantasy.Message, 0, len(messages)+len(completedStepMessages))
-				partialMessages = append(partialMessages, messages...)
-				partialMessages = append(partialMessages, completedStepMessages...)
-				return &GenerateWithLoopResult{
-					ConversationMessages:  partialMessages,
-					PersistedMessageCount: persistedCount,
-				}, err
+			return nil
+		},
+
+		// Step callbacks for content that accompanies tool calls
+		OnStepFinish: func(step fantasy.StepResult) error {
+			// Accumulate messages from completed steps so they can be
+			// persisted even if a later step is cancelled.
+			completedStepMessages = append(completedStepMessages, step.Messages...)
+
+			// Persist step messages incrementally so progress is saved
+			// as it happens rather than only at the end of the turn.
+			if cb.OnStepMessages != nil && len(step.Messages) > 0 {
+				cb.OnStepMessages(step.Messages)
+				persistedCount += len(step.Messages)
 			}
-			return nil, err
-		}
 
-		// Fire the response callback so callers (e.g. the TUI) can reset
-		// streaming state. This must fire even when the response text is
-		// empty (e.g. reasoning-only responses) so the UI properly resets
-		// the stream component and avoids duplicate content on the next
-		// flush.
-		if cb.OnResponse != nil {
-			cb.OnResponse(result.Response.Content.Text())
-		}
-
-		r := convertAgentResult(result, messages)
-		r.PersistedMessageCount = persistedCount
-		return r, nil
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			// Check if step has text content alongside tool calls
+			text := step.Content.Text()
+			toolCalls := step.Content.ToolCalls()
+			if text != "" && len(toolCalls) > 0 && cb.OnToolCallContent != nil {
+				cb.OnToolCallContent(text)
+			}
+			// Emit step usage for real-time cost tracking
+			if cb.OnStepUsage != nil {
+				cb.OnStepUsage(step.Usage.InputTokens, step.Usage.OutputTokens,
+					step.Usage.CacheReadTokens, step.Usage.CacheCreationTokens)
+			}
+			// Emit unified step finish event
+			if cb.OnStepFinish != nil {
+				cb.OnStepFinish(stepCounter, len(toolCalls) > 0, string(step.FinishReason), step.Usage)
+			}
+			return nil
+		},
 	}
 
+	// Always wire up PrepareStep. It serves three purposes:
+	//   1. Re-read the live tool set each step so runtime AddTools/
+	//      RemoveTools (and MCP server changes) take effect at the next
+	//      LLM step of the *current* turn, as documented. The entire
+	//      multi-step loop runs inside a single fantasy Stream call that
+	//      otherwise captures the tool snapshot taken when Stream began;
+	//      populating PrepareStepResult.Tools makes fantasy re-read tools
+	//      per step instead.
+	//   2. Steering: drain queued steer messages.
+	//   3. The OnPrepareStep hook.
+	// Steering drains its channel first, then OnPrepareStep hooks run
+	// against the (possibly already steered) messages.
+	steerCh := steerChFromContext(ctx)
+	onConsumed := steerConsumedFromContext(ctx)
+	hasSteering := steerCh != nil
+	hasPrepareStepHook := cb.OnPrepareStep != nil
+
+	streamCall.PrepareStep = func(
+		stepCtx context.Context,
+		opts fantasy.PrepareStepFunctionOptions,
+	) (context.Context, fantasy.PrepareStepResult, error) {
+		result := fantasy.PrepareStepResult{
+			Model:    opts.Model,
+			Messages: opts.Messages,
+			// Re-read the live tool set so mid-turn tool changes are
+			// honored. composeAllTools matches the composition baked
+			// into the fantasy agent, so in the steady state this is
+			// identical to the snapshot fantasy would have used.
+			Tools: a.composeAllTools(),
+		}
+
+		// Phase 1: Drain steering channel (if present).
+		if hasSteering {
+			var steered []SteerMessage
+			for {
+				select {
+				case msg := <-steerCh:
+					steered = append(steered, msg)
+				default:
+					goto done
+				}
+			}
+		done:
+			if len(steered) > 0 {
+				for _, sm := range steered {
+					result.Messages = append(result.Messages,
+						fantasy.NewUserMessage(sm.Text, sm.Files...))
+				}
+				if onConsumed != nil {
+					onConsumed(len(steered))
+				}
+			}
+		}
+
+		// Phase 2: Run OnPrepareStep hook (if registered).
+		if hasPrepareStepHook {
+			if update := cb.OnPrepareStep(opts.StepNumber, result.Messages); update != nil {
+				if update.Messages != nil {
+					result.Messages = update.Messages
+				}
+				if update.ToolChoice != nil {
+					result.ToolChoice = update.ToolChoice
+				}
+			}
+		}
+
+		// Apply message-level cache control for Anthropic models.
+		result.Messages = applyCacheControlToMessages(result.Messages)
+
+		return stepCtx, result, nil
+	}
+
+	// Wire OnRetry callback if provided.
+	if cb.OnRetry != nil {
+		streamCall.OnRetry = func(err *fantasy.ProviderError, _ time.Duration) {
+			// Use the retry number from the error if available; Fantasy
+			// doesn't pass a counter directly, so we approximate with a
+			// counter incremented on each call.
+			cb.OnRetry(0, err)
+		}
+	}
+
+	result, err := a.fantasyAgent.Stream(ctx, streamCall)
+	if err != nil {
+		// On cancellation (or any error), return a partial result
+		// containing messages from completed steps so the caller can
+		// persist tool calls and results that finished before the
+		// cancellation. The original input messages are included so
+		// the caller sees the full conversation up to the point of
+		// cancellation.
+		if len(completedStepMessages) > 0 {
+			partialMessages := make([]fantasy.Message, 0, len(messages)+len(completedStepMessages))
+			partialMessages = append(partialMessages, messages...)
+			partialMessages = append(partialMessages, completedStepMessages...)
+			return &GenerateWithLoopResult{
+				ConversationMessages:  partialMessages,
+				PersistedMessageCount: persistedCount,
+			}, err
+		}
+		return nil, err
+	}
+
+	// Fire the response callback so callers (e.g. the TUI) can reset
+	// streaming state. This must fire even when the response text is
+	// empty (e.g. reasoning-only responses) so the UI properly resets
+	// the stream component and avoids duplicate content on the next
+	// flush.
+	if cb.OnResponse != nil {
+		cb.OnResponse(result.Response.Content.Text())
+	}
+
+	r := convertAgentResult(result, messages)
+	r.PersistedMessageCount = persistedCount
+	return r, nil
+}
+
+// generateSimple runs the agent loop through the non-streaming call. It is
+// used only when streaming is disabled and no streaming-only callbacks are
+// set; OnResponse is still honoured so callers can reset UI state.
+func (a *Agent) generateSimple(ctx context.Context, cb GenerateCallbacks, messages []fantasy.Message,
+	prompt string, files []fantasy.FilePart, history []fantasy.Message,
+) (*GenerateWithLoopResult, error) {
 	// Non-streaming path with no callbacks — use the simpler Generate call.
 	result, err := a.fantasyAgent.Generate(ctx, fantasy.AgentCall{
 		Prompt:   prompt,
@@ -1339,7 +1394,7 @@ func (a *Agent) GetMCPPrompts() []tools.MCPPrompt {
 // This is a lazy call — the server is contacted each time.
 func (a *Agent) GetMCPPrompt(ctx context.Context, serverName, promptName string, args map[string]string) (*tools.MCPPromptResult, error) {
 	if a.toolManager == nil {
-		return nil, fmt.Errorf("no MCP servers configured")
+		return nil, ErrNoMCPServers
 	}
 	return a.toolManager.GetPrompt(ctx, serverName, promptName, args)
 }
@@ -1355,7 +1410,7 @@ func (a *Agent) GetMCPResources() []tools.MCPResource {
 // ReadMCPResource reads a specific resource from an MCP server by URI.
 func (a *Agent) ReadMCPResource(ctx context.Context, serverName, uri string) (*tools.MCPResourceContent, error) {
 	if a.toolManager == nil {
-		return nil, fmt.Errorf("no MCP servers configured")
+		return nil, ErrNoMCPServers
 	}
 	return a.toolManager.ReadResource(ctx, serverName, uri)
 }
@@ -1363,7 +1418,7 @@ func (a *Agent) ReadMCPResource(ctx context.Context, serverName, uri string) (*t
 // SubscribeMCPResource subscribes to change notifications for a resource.
 func (a *Agent) SubscribeMCPResource(ctx context.Context, serverName, uri string) error {
 	if a.toolManager == nil {
-		return fmt.Errorf("no MCP servers configured")
+		return ErrNoMCPServers
 	}
 	return a.toolManager.SubscribeResource(ctx, serverName, uri)
 }
@@ -1371,7 +1426,7 @@ func (a *Agent) SubscribeMCPResource(ctx context.Context, serverName, uri string
 // UnsubscribeMCPResource cancels change notifications for a resource.
 func (a *Agent) UnsubscribeMCPResource(ctx context.Context, serverName, uri string) error {
 	if a.toolManager == nil {
-		return fmt.Errorf("no MCP servers configured")
+		return ErrNoMCPServers
 	}
 	return a.toolManager.UnsubscribeResource(ctx, serverName, uri)
 }

--- a/internal/agent/callbacks_test.go
+++ b/internal/agent/callbacks_test.go
@@ -1,0 +1,54 @@
+package agent
+
+import (
+	"reflect"
+	"testing"
+)
+
+// bothPathCallbacks lists the GenerateCallbacks fields that are honoured by
+// both the streaming and non-streaming paths, and therefore must NOT force
+// the streaming path on their own. Every other field must be covered by
+// HasAnyCallback.
+var bothPathCallbacks = map[string]bool{
+	"OnResponse":       true,
+	"OnToolOutput":     true,
+	"OnPasswordPrompt": true,
+}
+
+// TestHasAnyCallbackCoversAllFields sets each GenerateCallbacks field in
+// isolation and checks HasAnyCallback agrees with the allowlist above. It
+// fails when a new callback field is added to the struct without updating
+// HasAnyCallback, which would otherwise silently route callers to the
+// non-streaming path where the new callback never fires.
+func TestHasAnyCallbackCoversAllFields(t *testing.T) {
+	typ := reflect.TypeFor[GenerateCallbacks]()
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if field.Type.Kind() != reflect.Func {
+			t.Fatalf("field %s is %s, expected a func type", field.Name, field.Type.Kind())
+		}
+
+		var cb GenerateCallbacks
+		v := reflect.ValueOf(&cb).Elem()
+		// A non-nil func of the right signature; it is never called.
+		v.Field(i).Set(reflect.MakeFunc(field.Type, func(args []reflect.Value) []reflect.Value {
+			out := make([]reflect.Value, field.Type.NumOut())
+			for j := range out {
+				out[j] = reflect.Zero(field.Type.Out(j))
+			}
+			return out
+		}))
+
+		got := cb.HasAnyCallback()
+		want := !bothPathCallbacks[field.Name]
+		if got != want {
+			t.Errorf("HasAnyCallback with only %s set = %v, want %v (update HasAnyCallback or bothPathCallbacks)", field.Name, got, want)
+		}
+	}
+}
+
+func TestHasAnyCallbackZeroValue(t *testing.T) {
+	if (GenerateCallbacks{}).HasAnyCallback() {
+		t.Fatal("zero GenerateCallbacks must report no callbacks")
+	}
+}

--- a/internal/extensions/toolargs.go
+++ b/internal/extensions/toolargs.go
@@ -1,0 +1,23 @@
+package extensions
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// ParseToolArgs decodes a raw JSON tool-argument payload into a map.
+//
+// It returns nil for empty, whitespace-only, or malformed input. Callers treat
+// nil as "no arguments" rather than as an error: this is non-fatal convenience
+// parsing shared by the extension wrapper, the SDK event bridge, and the TUI
+// activity row, none of which may fail because a payload did not decode.
+func ParseToolArgs(raw string) map[string]any {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return nil
+	}
+	return parsed
+}

--- a/internal/extensions/toolargs_test.go
+++ b/internal/extensions/toolargs_test.go
@@ -1,0 +1,39 @@
+package extensions
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseToolArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want map[string]any
+	}{
+		{name: "empty", raw: "", want: nil},
+		{name: "whitespace only", raw: "  \n\t", want: nil},
+		{name: "malformed json", raw: "{not json", want: nil},
+		{name: "json array is not a map", raw: `[1,2]`, want: nil},
+		{name: "json null yields nil map", raw: `null`, want: nil},
+		{name: "empty object", raw: `{}`, want: map[string]any{}},
+		{
+			name: "object with values",
+			raw:  `{"path":"a.go","count":2}`,
+			want: map[string]any{"path": "a.go", "count": float64(2)},
+		},
+		{
+			name: "leading whitespace is tolerated",
+			raw:  "  {\"k\":\"v\"}",
+			want: map[string]any{"k": "v"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseToolArgs(tt.raw)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("ParseToolArgs(%q) = %#v, want %#v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/extensions/wrapper.go
+++ b/internal/extensions/wrapper.go
@@ -40,16 +40,6 @@ func ExtensionToolsAsLLMTools(defs []ToolDef, runner *Runner) []fantasy.AgentToo
 	return tools
 }
 
-// parseToolArgsJSON attempts to parse JSON-encoded tool args into a map.
-// Returns nil on failure (non-fatal convenience parsing).
-func parseToolArgsJSON(input string) map[string]any {
-	var parsed map[string]any
-	if json.Unmarshal([]byte(input), &parsed) == nil {
-		return parsed
-	}
-	return nil
-}
-
 // ---------------------------------------------------------------------------
 // wrappedTool — intercepts tool calls through the extension runner
 // ---------------------------------------------------------------------------
@@ -81,7 +71,7 @@ func (w *wrappedTool) Run(ctx context.Context, call fantasy.ToolCall) (fantasy.T
 			ToolCallID: call.ID,
 			ToolKind:   kind,
 			Input:      call.Input,
-			ParsedArgs: parseToolArgsJSON(call.Input),
+			ParsedArgs: ParseToolArgs(call.Input),
 			Source:     "llm",
 		})
 		if r, ok := result.(ToolCallResult); ok && r.Block {

--- a/internal/session/tree_manager.go
+++ b/internal/session/tree_manager.go
@@ -183,14 +183,11 @@ func (tm *TreeManager) ForkToNewSession(cwd string, targetID string) (*TreeManag
 		switch e := entry.(type) {
 		case *MessageEntry:
 			newEntry = &MessageEntry{
-				Type:      EntryTypeMessage,
-				ID:        newID,
-				ParentID:  prevNewID, // Chain sequentially in new session
-				Timestamp: e.Timestamp,
-				Role:      e.Role,
-				Parts:     e.Parts,
-				Model:     e.Model,
-				Provider:  e.Provider,
+				Entry:    cloneEntry(e.Entry, newID, prevNewID),
+				Role:     e.Role,
+				Parts:    e.Parts,
+				Model:    e.Model,
+				Provider: e.Provider,
 			}
 			// Copy label if present.
 			if label, ok := tm.labels[oldID]; ok {
@@ -199,12 +196,9 @@ func (tm *TreeManager) ForkToNewSession(cwd string, targetID string) (*TreeManag
 
 		case *ModelChangeEntry:
 			newEntry = &ModelChangeEntry{
-				Type:      EntryTypeModelChange,
-				ID:        newID,
-				ParentID:  prevNewID,
-				Timestamp: e.Timestamp,
-				Provider:  e.Provider,
-				ModelID:   e.ModelID,
+				Entry:    cloneEntry(e.Entry, newID, prevNewID),
+				Provider: e.Provider,
+				ModelID:  e.ModelID,
 			}
 
 		case *LabelEntry:
@@ -214,32 +208,23 @@ func (tm *TreeManager) ForkToNewSession(cwd string, targetID string) (*TreeManag
 				newTargetID = mapped
 			}
 			newEntry = &LabelEntry{
-				Type:      EntryTypeLabel,
-				ID:        newID,
-				ParentID:  prevNewID,
-				Timestamp: e.Timestamp,
-				TargetID:  newTargetID,
-				Label:     e.Label,
+				Entry:    cloneEntry(e.Entry, newID, prevNewID),
+				TargetID: newTargetID,
+				Label:    e.Label,
 			}
 
 		case *SessionInfoEntry:
 			newEntry = &SessionInfoEntry{
-				Type:      EntryTypeSessionInfo,
-				ID:        newID,
-				ParentID:  prevNewID,
-				Timestamp: e.Timestamp,
-				Name:      e.Name,
+				Entry: cloneEntry(e.Entry, newID, prevNewID),
+				Name:  e.Name,
 			}
 			newTm.sessionName = e.Name
 
 		case *ExtensionDataEntry:
 			newEntry = &ExtensionDataEntry{
-				Type:      EntryTypeExtensionData,
-				ID:        newID,
-				ParentID:  prevNewID,
-				Timestamp: e.Timestamp,
-				ExtType:   e.ExtType,
-				Data:      e.Data,
+				Entry:   cloneEntry(e.Entry, newID, prevNewID),
+				ExtType: e.ExtType,
+				Data:    e.Data,
 			}
 
 		case *BranchSummaryEntry:
@@ -249,12 +234,9 @@ func (tm *TreeManager) ForkToNewSession(cwd string, targetID string) (*TreeManag
 				newFromID = mapped
 			}
 			newEntry = &BranchSummaryEntry{
-				Type:      EntryTypeBranchSummary,
-				ID:        newID,
-				ParentID:  prevNewID,
-				Timestamp: e.Timestamp,
-				FromID:    newFromID,
-				Summary:   e.Summary,
+				Entry:   cloneEntry(e.Entry, newID, prevNewID),
+				FromID:  newFromID,
+				Summary: e.Summary,
 			}
 
 		case *CompactionEntry:
@@ -264,10 +246,7 @@ func (tm *TreeManager) ForkToNewSession(cwd string, targetID string) (*TreeManag
 				newFirstKeptID = mapped
 			}
 			newEntry = &CompactionEntry{
-				Type:             EntryTypeCompaction,
-				ID:               newID,
-				ParentID:         prevNewID,
-				Timestamp:        e.Timestamp,
+				Entry:            cloneEntry(e.Entry, newID, prevNewID),
 				Summary:          e.Summary,
 				FirstKeptEntryID: newFirstKeptID,
 				TokensBefore:     e.TokensBefore,
@@ -297,6 +276,20 @@ func (tm *TreeManager) ForkToNewSession(cwd string, targetID string) (*TreeManag
 	newTm.leafID = prevNewID
 
 	return newTm, nil
+}
+
+// cloneEntry builds the base envelope for an entry copied into a forked
+// session: it keeps the original type and timestamp but assigns the fresh ID
+// and the remapped parent so the copy chains sequentially in the new tree.
+// Every per-type case in ForkBranch goes through this helper, so a new base
+// field on Entry needs exactly one edit here.
+func cloneEntry(old Entry, newID, parentID string) Entry {
+	return Entry{
+		Type:      old.Type,
+		ID:        newID,
+		ParentID:  parentID,
+		Timestamp: old.Timestamp,
+	}
 }
 
 // SetParentLink records a parent session reference (and, optionally, the

--- a/internal/tools/mcp.go
+++ b/internal/tools/mcp.go
@@ -827,18 +827,29 @@ func (m *MCPToolManager) CancelServerTask(ctx context.Context, serverName, taskI
 	return taskFromMCP(serverName, res.Task), nil
 }
 
+// serverClient returns the MCP client for a named server. It centralises the
+// two guard conditions every per-server RPC (prompts, resources, tasks,
+// subscriptions) must check: the manager has a connection pool, and the pool
+// currently holds a connection for serverName.
+func (m *MCPToolManager) serverClient(serverName string) (client.MCPClient, error) {
+	if m.connectionPool == nil {
+		return nil, fmt.Errorf("no connection pool available")
+	}
+	mcpClient, ok := m.connectionPool.GetClients()[serverName]
+	if !ok {
+		return nil, fmt.Errorf("MCP server %q not found", serverName)
+	}
+	return mcpClient, nil
+}
+
 // taskClient returns the *client.Client for a server. Tasks endpoints are
 // not part of the upstream MCPClient interface so callers must work with
 // the concrete client. Returns an error when the connection is missing
 // or backed by a non-standard client type.
 func (m *MCPToolManager) taskClient(serverName string) (*client.Client, error) {
-	if m.connectionPool == nil {
-		return nil, fmt.Errorf("no connection pool available")
-	}
-	clients := m.connectionPool.GetClients()
-	raw, ok := clients[serverName]
-	if !ok {
-		return nil, fmt.Errorf("MCP server %q not loaded", serverName)
+	raw, err := m.serverClient(serverName)
+	if err != nil {
+		return nil, err
 	}
 	c, ok := raw.(*client.Client)
 	if !ok {
@@ -867,14 +878,9 @@ func (m *MCPToolManager) GetPrompts() []MCPPrompt {
 // name on that server, and args are the template arguments to substitute.
 // This call is lazy — it contacts the MCP server on each invocation.
 func (m *MCPToolManager) GetPrompt(ctx context.Context, serverName, promptName string, args map[string]string) (*MCPPromptResult, error) {
-	if m.connectionPool == nil {
-		return nil, fmt.Errorf("no connection pool available")
-	}
-
-	clients := m.connectionPool.GetClients()
-	mcpClient, ok := clients[serverName]
-	if !ok {
-		return nil, fmt.Errorf("MCP server %q not found", serverName)
+	mcpClient, err := m.serverClient(serverName)
+	if err != nil {
+		return nil, err
 	}
 
 	req := mcp.GetPromptRequest{}
@@ -1093,14 +1099,9 @@ func (m *MCPToolManager) GetResources() []MCPResource {
 // ReadResource reads a specific resource from an MCP server by URI.
 // Returns the resource content (text or binary blob).
 func (m *MCPToolManager) ReadResource(ctx context.Context, serverName, uri string) (*MCPResourceContent, error) {
-	if m.connectionPool == nil {
-		return nil, fmt.Errorf("no connection pool available")
-	}
-
-	clients := m.connectionPool.GetClients()
-	mcpClient, ok := clients[serverName]
-	if !ok {
-		return nil, fmt.Errorf("MCP server %q not found", serverName)
+	mcpClient, err := m.serverClient(serverName)
+	if err != nil {
+		return nil, err
 	}
 
 	req := mcp.ReadResourceRequest{}
@@ -1167,14 +1168,9 @@ func (m *MCPToolManager) ReadResource(ctx context.Context, serverName, uri strin
 
 // SubscribeResource subscribes to change notifications for a resource.
 func (m *MCPToolManager) SubscribeResource(ctx context.Context, serverName, uri string) error {
-	if m.connectionPool == nil {
-		return fmt.Errorf("no connection pool available")
-	}
-
-	clients := m.connectionPool.GetClients()
-	mcpClient, ok := clients[serverName]
-	if !ok {
-		return fmt.Errorf("MCP server %q not found", serverName)
+	mcpClient, err := m.serverClient(serverName)
+	if err != nil {
+		return err
 	}
 
 	req := mcp.SubscribeRequest{}
@@ -1193,14 +1189,9 @@ func (m *MCPToolManager) SubscribeResource(ctx context.Context, serverName, uri 
 
 // UnsubscribeResource cancels change notifications for a resource.
 func (m *MCPToolManager) UnsubscribeResource(ctx context.Context, serverName, uri string) error {
-	if m.connectionPool == nil {
-		return fmt.Errorf("no connection pool available")
-	}
-
-	clients := m.connectionPool.GetClients()
-	mcpClient, ok := clients[serverName]
-	if !ok {
-		return fmt.Errorf("MCP server %q not found", serverName)
+	mcpClient, err := m.serverClient(serverName)
+	if err != nil {
+		return err
 	}
 
 	req := mcp.UnsubscribeRequest{}

--- a/internal/ui/activity.go
+++ b/internal/ui/activity.go
@@ -1,7 +1,6 @@
 package ui
 
 import (
-	"encoding/json"
 	"fmt"
 	"image/color"
 	"os"
@@ -12,6 +11,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 
+	"github.com/mark3labs/kit/internal/extensions"
 	"github.com/mark3labs/kit/internal/ui/style"
 )
 
@@ -38,7 +38,7 @@ const activityMaxTarget = 56
 // toolArgs is the raw JSON argument payload; malformed JSON degrades to the
 // bare tool name rather than erroring.
 func activityVerb(toolName, toolArgs string) string {
-	args := parseToolArgs(toolArgs)
+	args := extensions.ParseToolArgs(toolArgs)
 
 	// verb is the present-tense action; target is the thing being acted on.
 	// Keeping them separate lets a missing target degrade to a bare verb
@@ -84,20 +84,6 @@ func activityVerb(toolName, toolArgs string) string {
 		return toolDisplayName(toolName)
 	}
 	return verb + " " + target
-}
-
-// parseToolArgs decodes a raw JSON tool-argument payload. A nil map is
-// returned for empty or malformed input; callers treat that as "no arguments"
-// rather than as an error, because the activity row must never fail to render.
-func parseToolArgs(toolArgs string) map[string]any {
-	if strings.TrimSpace(toolArgs) == "" {
-		return nil
-	}
-	var args map[string]any
-	if err := json.Unmarshal([]byte(toolArgs), &args); err != nil {
-		return nil
-	}
-	return args
 }
 
 // argString returns the named argument as a string, or "" when absent or not

--- a/pkg/kit/README.md
+++ b/pkg/kit/README.md
@@ -442,8 +442,7 @@ msg  := kit.ConvertFromLLMMessage(lMsg)  // LLMMessage  → SDK Message
 - `NewRawTool(name, desc, schema, fn)` - Create a schema-driven tool when the
   input shape isn't known at compile time (skill/MCP catalogs)
 - `FilterCoreToolNames(include, exclude)` - Resolve an effective core tool
-  name list from include/exclude filters (nil means "all core tools").
-  Prefer this over the deprecated `CoreToolFilterHelper(*viper.Viper)`
+  name list from include/exclude filters (nil means "all core tools")
 - `LoadSkillsFromFS(fsys, root)` - `fs.FS`-typed skill loader (embed.FS,
   fstest.MapFS, per-tenant virtual filesystems)
 - `ParseTemplate` / `RenderTemplate` / `ParseArguments` - Template and CLI

--- a/pkg/kit/auth.go
+++ b/pkg/kit/auth.go
@@ -102,6 +102,10 @@ func GetValidCopilotAccessToken() (string, error) {
 // GetOpenAIAPIKey resolves the OpenAI API key using the standard
 // resolution order: stored credentials -> OPENAI_API_KEY env var.
 // Returns an empty string if no key is found.
+//
+// Deprecated: Use [HasOpenAICredentials] to check for credentials; the
+// provider layer resolves the key itself. This function has no callers and
+// will be removed in a future release.
 func GetOpenAIAPIKey() string {
 	cm, err := auth.NewCredentialManager()
 	if err == nil {

--- a/pkg/kit/config.go
+++ b/pkg/kit/config.go
@@ -73,7 +73,7 @@ func setSDKDefaults(v *viper.Viper) {
 	v.SetDefault("main-gpu", 0)
 }
 
-// InitConfig initializes the process-global viper configuration system.
+// InitConfig initializes the process-global configuration store.
 // It searches for config files in standard locations and loads them with
 // environment variable substitution.
 //
@@ -81,7 +81,7 @@ func setSDKDefaults(v *viper.Viper) {
 // debug: if true, print warnings about missing configs to stderr.
 //
 // This wraps [initConfig] using the process-global store and is retained for
-// the CLI, which binds its flags to the global viper.
+// the CLI, which binds its flags to that global store.
 func InitConfig(configFile string, debug bool) error {
 	return initConfig(viper.GetViper(), configFile, debug, false)
 }
@@ -104,8 +104,8 @@ type ConfigInitOptions struct {
 	Bare bool
 }
 
-// InitConfigWithOptions initializes the process-global viper configuration
-// system with explicit control over discovery. Use it instead of [InitConfig]
+// InitConfigWithOptions initializes the process-global configuration store
+// with explicit control over discovery. Use it instead of [InitConfig]
 // when project-local configuration must be ignored.
 func InitConfigWithOptions(opts ConfigInitOptions) error {
 	return initConfig(viper.GetViper(), opts.ConfigFile, opts.Debug, opts.Bare)
@@ -175,7 +175,11 @@ func initConfig(v *viper.Viper, configFile string, debug, bare bool) error {
 }
 
 // LoadConfigWithEnvSubstitution loads a config file with ${ENV_VAR} expansion
-// into the process-global viper store.
+// into the process-global configuration store.
+//
+// Deprecated: Use [InitConfig] or [InitConfigWithOptions] with an explicit
+// ConfigFile instead. [New] loads configuration automatically; this function
+// has no callers and will be removed in a future release.
 func LoadConfigWithEnvSubstitution(configPath string) error {
 	return loadConfigWithEnvSubstitution(viper.GetViper(), configPath)
 }

--- a/pkg/kit/events.go
+++ b/pkg/kit/events.go
@@ -1,7 +1,6 @@
 package kit
 
 import (
-	"encoding/json"
 	"sync"
 
 	"github.com/mark3labs/kit/internal/extensions"
@@ -120,16 +119,6 @@ const (
 // ToolKindExecute for unknown tools.
 func toolKindFor(toolName string) string {
 	return extensions.ToolKindFor(toolName)
-}
-
-// parseToolArgs attempts to parse a JSON-encoded tool args string into a map.
-// Returns nil on failure (non-fatal convenience parsing).
-func parseToolArgs(toolArgs string) map[string]any {
-	var parsed map[string]any
-	if json.Unmarshal([]byte(toolArgs), &parsed) == nil {
-		return parsed
-	}
-	return nil
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/kit/extension_api.go
+++ b/pkg/kit/extension_api.go
@@ -1,7 +1,6 @@
 package kit
 
 import (
-	"fmt"
 	"log"
 	"strings"
 
@@ -427,7 +426,7 @@ func (e *extensionAPI) GetSessionMessages() []ExtensionSessionMessage {
 
 func (e *extensionAPI) AppendEntry(extType, data string) (string, error) {
 	if e.kit.session == nil {
-		return "", fmt.Errorf("no session available")
+		return "", ErrNoSession
 	}
 	return e.kit.session.AppendExtensionData(extType, data)
 }

--- a/pkg/kit/extensions_bridge.go
+++ b/pkg/kit/extensions_bridge.go
@@ -22,6 +22,22 @@ import (
 // wrapper (internal/extensions/wrapper.go) which composes underneath the SDK
 // hook wrapper.
 func (m *Kit) bridgeExtensions(runner *extensions.Runner) {
+	// Registration order is preserved from the original monolithic
+	// implementation: the turn aggregator subscribes first so it observes
+	// TurnStart/ToolResult/StepFinish before any forwarding subscriber runs.
+	turnAgg := m.bridgeTurnAggregator()
+	m.bridgeInterceptionHooks(runner)
+	m.bridgeMessageEvents(runner)
+	m.bridgeAgentEnd(runner, turnAgg)
+	m.bridgeSubagentEvents(runner)
+	m.bridgeContextHooks(runner)
+	m.bridgeStepEvents(runner)
+	m.bridgePrepareStepHook(runner)
+}
+
+// bridgeTurnAggregator installs the per-turn aggregator subscription and
+// returns the aggregator so bridgeAgentEnd can consume it.
+func (m *Kit) bridgeTurnAggregator() *turnAggregator {
 	// Per-turn aggregator: collects tool/LLM/usage signals between AgentStart
 	// and AgentEnd so the enriched AgentEndEvent can be populated without
 	// requiring extensions to maintain parallel bookkeeping.
@@ -45,9 +61,12 @@ func (m *Kit) bridgeExtensions(runner *extensions.Runner) {
 			turnAgg.recordStep(ev.Usage)
 		}
 	})
+	return turnAgg
+}
 
-	// --- Interception hooks ---
-
+// bridgeInterceptionHooks wires extension Input and BeforeAgentStart handlers
+// into the SDK BeforeTurn hook chain.
+func (m *Kit) bridgeInterceptionHooks(runner *extensions.Runner) {
 	// Extension Input → BeforeTurn hook (high priority, runs first).
 	// An Input handler with Action="transform" replaces the prompt text.
 	if runner.HasHandlers(extensions.Input) {
@@ -76,8 +95,11 @@ func (m *Kit) bridgeExtensions(runner *extensions.Runner) {
 			return nil
 		})
 	}
+}
 
-	// --- Observation event forwarding ---
+// bridgeMessageEvents forwards turn-start, message streaming, tool output and
+// tool-call-input streaming events to the extension runner (observation only).
+func (m *Kit) bridgeMessageEvents(runner *extensions.Runner) {
 	// Subscribe to SDK events and forward to extension runner so extensions
 	// see lifecycle events from the SDK's runTurn()/generate() path.
 
@@ -126,7 +148,11 @@ func (m *Kit) bridgeExtensions(runner *extensions.Runner) {
 			ToolCallID: ev.ToolCallID,
 		}
 	})
+}
 
+// bridgeAgentEnd emits the enriched AgentEndEvent on TurnEnd, populated from
+// the per-turn aggregator.
+func (m *Kit) bridgeAgentEnd(runner *extensions.Runner, turnAgg *turnAggregator) {
 	if runner.HasHandlers(extensions.AgentEnd) {
 		m.Subscribe(func(e Event) {
 			if ev, ok := e.(TurnEndEvent); ok {
@@ -153,8 +179,11 @@ func (m *Kit) bridgeExtensions(runner *extensions.Runner) {
 			}
 		})
 	}
+}
 
-	// --- Subagent lifecycle events ---
+// bridgeSubagentEvents forwards the SDK's per-subagent event stream to
+// extensions that register SubagentStart/Chunk/End handlers.
+func (m *Kit) bridgeSubagentEvents(runner *extensions.Runner) {
 	// When an extension registers OnSubagentStart/Chunk/End handlers, bridge
 	// the SDK's per-subagent event stream (SubscribeSubagent) into the
 	// extension runner.
@@ -278,8 +307,11 @@ func (m *Kit) bridgeExtensions(runner *extensions.Runner) {
 			})
 		}
 	}
+}
 
-	// --- Context filtering hook ---
+// bridgeContextHooks wires the ContextPrepare and BeforeCompact extension
+// handlers into the matching SDK hook chains.
+func (m *Kit) bridgeContextHooks(runner *extensions.Runner) {
 	// Extension ContextPrepare → SDK ContextPrepare hook.
 	if runner.HasHandlers(extensions.ContextPrepare) {
 		m.OnContextPrepare(HookPriorityNormal, func(h ContextPrepareHook) *ContextPrepareResult {
@@ -293,7 +325,6 @@ func (m *Kit) bridgeExtensions(runner *extensions.Runner) {
 		})
 	}
 
-	// --- Compaction hook ---
 	// Extension BeforeCompact → SDK BeforeCompact hook.
 	if runner.HasHandlers(extensions.BeforeCompact) {
 		m.OnBeforeCompact(HookPriorityNormal, func(h BeforeCompactHook) *BeforeCompactResult {
@@ -320,9 +351,11 @@ func (m *Kit) bridgeExtensions(runner *extensions.Runner) {
 			return nil
 		})
 	}
+}
 
-	// --- Step lifecycle observation events ---
-
+// bridgeStepEvents forwards step lifecycle, LLM usage, reasoning, warnings,
+// source, error and retry events to the extension runner.
+func (m *Kit) bridgeStepEvents(runner *extensions.Runner) {
 	bridgeObserve(m, runner, extensions.StepStart, func(ev StepStartEvent) extensions.Event {
 		return extensions.StepStartEvent{StepNumber: ev.StepNumber}
 	})
@@ -392,8 +425,11 @@ func (m *Kit) bridgeExtensions(runner *extensions.Runner) {
 			Error:   ev.Error.Error(),
 		}
 	})
+}
 
-	// --- PrepareStep hook ---
+// bridgePrepareStepHook wires the PrepareStep extension handler into the SDK
+// PrepareStep hook chain.
+func (m *Kit) bridgePrepareStepHook(runner *extensions.Runner) {
 	// Extension PrepareStep → SDK PrepareStep hook.
 	// Same pattern as ContextPrepare: convert LLMMessage ↔ ContextMessage.
 	if runner.HasHandlers(extensions.PrepareStep) {

--- a/pkg/kit/kit.go
+++ b/pkg/kit/kit.go
@@ -1099,13 +1099,13 @@ func (m *Kit) ExecuteCompletion(ctx context.Context, req CompleteRequest) (Compl
 // and will use CLI defaults if not specified.
 //
 // Config isolation: each [New] / [NewAgent] call constructs its own isolated
-// configuration store (via viper.New internally). Options are applied to that
-// per-instance store, so two Kits constructed in the same process do NOT share
-// or clobber each other's configuration. Runtime mutators ([Kit.SetModel],
-// [Kit.SetThinkingLevel]) and config readers ([Kit.GetThinkingLevel]) operate
-// only on the owning instance. Fields left at their zero value are simply not
-// applied; they fall through to the precedence chain (env → .kit.yml →
-// per-model defaults) resolved within the instance's own store.
+// configuration store. Options are applied to that per-instance store, so two
+// Kits constructed in the same process do NOT share or clobber each other's
+// configuration. Runtime mutators ([Kit.SetModel], [Kit.SetThinkingLevel])
+// and config readers ([Kit.GetThinkingLevel]) operate only on the owning
+// instance. Fields left at their zero value are simply not applied; they fall
+// through to the precedence chain (env → .kit.yml → per-model defaults)
+// resolved within the instance's own store.
 type Options struct {
 	Model        string // Override model (e.g., "anthropic/claude-sonnet-4-5-20250929")
 	SystemPrompt string // Override system prompt
@@ -1512,18 +1512,17 @@ func InitTreeSession(opts *Options) (*TreeManager, error) {
 // It loads configuration, initializes MCP servers, creates the LLM model, and
 // sets up the agent for interaction. Returns an error if initialization fails.
 //
-// Config isolation: New constructs a per-instance configuration store (via
-// viper.New internally) and applies [Options] to it. Two Kits constructed in
-// the same process are therefore fully isolated — neither overwrites the
-// other's model, thinking level, or generation parameters, and runtime
-// mutators ([Kit.SetModel], [Kit.SetThinkingLevel]) only affect the owning
-// instance. This makes subagent spawning and multi-Kit embedding safe without
-// any external synchronization.
+// Config isolation: New constructs a per-instance configuration store and
+// applies [Options] to it. Two Kits constructed in the same process are
+// therefore fully isolated — neither overwrites the other's model, thinking
+// level, or generation parameters, and runtime mutators ([Kit.SetModel],
+// [Kit.SetThinkingLevel]) only affect the owning instance. This makes subagent
+// spawning and multi-Kit embedding safe without any external synchronization.
 //
 // CLI integration: when Options.CLI is non-nil the Kit shares the
-// process-global viper store instead of allocating a fresh one, so cobra flag
-// bindings established by the CLI remain in effect. SDK callers leave
-// Options.CLI nil and always get an isolated store.
+// process-global configuration store instead of allocating a fresh one, so
+// the CLI's flag bindings remain in effect. SDK callers leave Options.CLI nil
+// and always get an isolated store.
 //
 // For an ergonomic functional-options front door, see [NewAgent].
 func New(ctx context.Context, opts *Options) (*Kit, error) {
@@ -2806,7 +2805,7 @@ func (m *Kit) generate(ctx context.Context, messages []fantasy.Message) (*agent.
 		OnToolCall: func(toolCallID, toolName, toolArgs string) {
 			m.events.emit(ToolCallEvent{
 				ToolCallID: toolCallID, ToolName: toolName, ToolKind: toolKindFor(toolName),
-				ToolArgs: toolArgs, ParsedArgs: parseToolArgs(toolArgs),
+				ToolArgs: toolArgs, ParsedArgs: extensions.ParseToolArgs(toolArgs),
 			})
 		},
 		OnToolExecution: func(toolCallID, toolName, toolArgs string, isStarting bool) {
@@ -2819,7 +2818,7 @@ func (m *Kit) generate(ctx context.Context, messages []fantasy.Message) (*agent.
 		OnToolResult: func(toolCallID, toolName, toolArgs, resultText, metadata string, isError bool) {
 			evt := ToolResultEvent{
 				ToolCallID: toolCallID, ToolName: toolName, ToolKind: toolKindFor(toolName),
-				ToolArgs: toolArgs, ParsedArgs: parseToolArgs(toolArgs),
+				ToolArgs: toolArgs, ParsedArgs: extensions.ParseToolArgs(toolArgs),
 				Result: resultText, IsError: isError,
 			}
 			if metadata != "" {

--- a/pkg/kit/models.go
+++ b/pkg/kit/models.go
@@ -47,6 +47,10 @@ func SuggestModels(provider, invalidModel string) []string {
 
 // RefreshModelRegistry reloads the global model database from the current
 // data sources (cache -> embedded). Call after updating the cache.
+//
+// Deprecated: This function has no callers and will be removed in a future
+// release. The registry is loaded once per process; the CLI's model-cache
+// update path reloads it internally.
 func RefreshModelRegistry() {
 	models.ReloadGlobalRegistry()
 }
@@ -54,6 +58,10 @@ func RefreshModelRegistry() {
 // CheckProviderReady validates that a provider is properly configured
 // by checking that it exists in the registry and has required environment
 // variables set.
+//
+// Deprecated: Use [GetProviderInfo] (nil means unknown provider) together
+// with [ValidateEnvironment] instead. This function has no callers and will
+// be removed in a future release.
 func CheckProviderReady(provider string) error {
 	info := models.GetGlobalRegistry().GetProviderInfo(provider)
 	if info == nil {

--- a/pkg/kit/oauth.go
+++ b/pkg/kit/oauth.go
@@ -89,8 +89,9 @@ func NewDefaultMCPAuthHandler() (*DefaultMCPAuthHandler, error) {
 // let the OS pick a free port (equivalent to [NewDefaultMCPAuthHandler]).
 // Call [DefaultMCPAuthHandler.Close] when the handler is no longer needed.
 //
-// Deprecated: Use [NewDefaultMCPAuthHandler] instead. This function has no
-// callers and will be removed in a future release.
+// Use this constructor when the OAuth provider requires a stable, pre-registered
+// redirect URI: [NewDefaultMCPAuthHandler] picks a random port, so its
+// [DefaultMCPAuthHandler.RedirectURI] changes on every run.
 func NewDefaultMCPAuthHandlerWithPort(port int) (*DefaultMCPAuthHandler, error) {
 	addr := fmt.Sprintf("localhost:%d", port)
 	listener, err := net.Listen("tcp", addr)

--- a/pkg/kit/oauth.go
+++ b/pkg/kit/oauth.go
@@ -88,6 +88,9 @@ func NewDefaultMCPAuthHandler() (*DefaultMCPAuthHandler, error) {
 // specified port on localhost. The port is reserved immediately. Pass 0 to
 // let the OS pick a free port (equivalent to [NewDefaultMCPAuthHandler]).
 // Call [DefaultMCPAuthHandler.Close] when the handler is no longer needed.
+//
+// Deprecated: Use [NewDefaultMCPAuthHandler] instead. This function has no
+// callers and will be removed in a future release.
 func NewDefaultMCPAuthHandlerWithPort(port int) (*DefaultMCPAuthHandler, error) {
 	addr := fmt.Sprintf("localhost:%d", port)
 	listener, err := net.Listen("tcp", addr)

--- a/pkg/kit/session.go
+++ b/pkg/kit/session.go
@@ -9,6 +9,12 @@ import (
 // that do not support collapsing a branch range into a summary entry.
 var ErrBranchSummaryNotSupported = errors.New("session manager does not support branch summaries")
 
+// ErrNoSession is returned by session-dependent operations ([Kit.Branch],
+// [Kit.NavigateTo], [Kit.SummarizeBranch], [Kit.CollapseBranch], and the
+// extension session API) when the Kit was created without a session manager.
+// Callers can detect this condition with errors.Is.
+var ErrNoSession = errors.New("no session available")
+
 // SessionManager defines the contract for conversation storage backends.
 // Implementations can use files (default), databases, cloud storage, etc.
 //

--- a/pkg/kit/session.go
+++ b/pkg/kit/session.go
@@ -10,9 +10,10 @@ import (
 var ErrBranchSummaryNotSupported = errors.New("session manager does not support branch summaries")
 
 // ErrNoSession is returned by session-dependent operations ([Kit.Branch],
-// [Kit.NavigateTo], [Kit.SummarizeBranch], [Kit.CollapseBranch], and the
-// extension session API) when the Kit was created without a session manager.
-// Callers can detect this condition with errors.Is.
+// [Kit.NavigateTo], [Kit.SummarizeBranch], [Kit.CollapseBranch],
+// [Kit.SetSessionName], and the extension session API) when the Kit was
+// created without a session manager. Callers can detect this condition with
+// errors.Is.
 var ErrNoSession = errors.New("no session available")
 
 // SessionManager defines the contract for conversation storage backends.

--- a/pkg/kit/sessions.go
+++ b/pkg/kit/sessions.go
@@ -102,7 +102,7 @@ func (m *Kit) GetSessionID() string {
 // a branch point. Subsequent Prompt() calls will extend from the new position.
 func (m *Kit) Branch(entryID string) error {
 	if m.session == nil {
-		return fmt.Errorf("no session available")
+		return ErrNoSession
 	}
 	return m.session.Branch(entryID)
 }
@@ -160,7 +160,7 @@ func (m *Kit) GetChildren(parentID string) []string {
 // Returns an error if the session is unavailable or the entry ID is not found.
 func (m *Kit) NavigateTo(entryID string) error {
 	if m.session == nil {
-		return fmt.Errorf("no session available")
+		return ErrNoSession
 	}
 	return m.session.Branch(entryID)
 }
@@ -170,7 +170,7 @@ func (m *Kit) NavigateTo(entryID string) error {
 // the session is unavailable, or the LLM call fails.
 func (m *Kit) SummarizeBranch(fromID, toID string) (string, error) {
 	if m.session == nil {
-		return "", fmt.Errorf("no session available")
+		return "", ErrNoSession
 	}
 
 	// Get the branch and find the range
@@ -226,7 +226,7 @@ func (m *Kit) SummarizeBranch(fromID, toID string) (string, error) {
 // compatibility.
 func (m *Kit) CollapseBranch(fromID, toID, summary string) error {
 	if m.session == nil {
-		return fmt.Errorf("no session available")
+		return ErrNoSession
 	}
 	_, err := m.session.AppendBranchSummary(fromID, summary)
 	return err

--- a/pkg/kit/sessions.go
+++ b/pkg/kit/sessions.go
@@ -110,7 +110,7 @@ func (m *Kit) Branch(entryID string) error {
 // SetSessionName sets a user-defined display name for the active session.
 func (m *Kit) SetSessionName(name string) error {
 	if m.session == nil {
-		return fmt.Errorf("session naming requires a session")
+		return ErrNoSession
 	}
 	return m.session.SetSessionName(name)
 }

--- a/pkg/kit/sessions_test.go
+++ b/pkg/kit/sessions_test.go
@@ -24,6 +24,9 @@ func TestErrNoSessionSentinel(t *testing.T) {
 	if err := k.CollapseBranch("a", "b", "s"); !errors.Is(err, ErrNoSession) {
 		t.Fatalf("CollapseBranch: got %v, want ErrNoSession", err)
 	}
+	if err := k.SetSessionName("n"); !errors.Is(err, ErrNoSession) {
+		t.Fatalf("SetSessionName: got %v, want ErrNoSession", err)
+	}
 
 	api := &extensionAPI{kit: k}
 	if _, err := api.AppendEntry("ext", "{}"); !errors.Is(err, ErrNoSession) {

--- a/pkg/kit/sessions_test.go
+++ b/pkg/kit/sessions_test.go
@@ -1,0 +1,32 @@
+package kit
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestErrNoSessionSentinel verifies that every session-dependent entry point
+// returns the shared ErrNoSession sentinel when the Kit has no session
+// manager, so callers can classify the failure with errors.Is instead of
+// matching the message text.
+func TestErrNoSessionSentinel(t *testing.T) {
+	k := &Kit{}
+
+	if err := k.Branch("x"); !errors.Is(err, ErrNoSession) {
+		t.Fatalf("Branch: got %v, want ErrNoSession", err)
+	}
+	if err := k.NavigateTo("x"); !errors.Is(err, ErrNoSession) {
+		t.Fatalf("NavigateTo: got %v, want ErrNoSession", err)
+	}
+	if _, err := k.SummarizeBranch("a", "b"); !errors.Is(err, ErrNoSession) {
+		t.Fatalf("SummarizeBranch: got %v, want ErrNoSession", err)
+	}
+	if err := k.CollapseBranch("a", "b", "s"); !errors.Is(err, ErrNoSession) {
+		t.Fatalf("CollapseBranch: got %v, want ErrNoSession", err)
+	}
+
+	api := &extensionAPI{kit: k}
+	if _, err := api.AppendEntry("ext", "{}"); !errors.Is(err, ErrNoSession) {
+		t.Fatalf("extensionAPI.AppendEntry: got %v, want ErrNoSession", err)
+	}
+}

--- a/pkg/kit/skills.go
+++ b/pkg/kit/skills.go
@@ -66,6 +66,10 @@ func LoadSkills(cwd string) ([]*Skill, error) {
 
 // FormatSkillsForPrompt formats skills for inclusion in a system prompt.
 // Each skill is rendered as a named section with its content.
+//
+// Deprecated: [New] composes loaded skills into the system prompt
+// automatically. This function has no callers and will be removed in a future
+// release.
 func FormatSkillsForPrompt(s []*Skill) string {
 	return skills.FormatForPrompt(s)
 }

--- a/pkg/kit/template_bridge.go
+++ b/pkg/kit/template_bridge.go
@@ -399,6 +399,9 @@ func GetCurrentModelID(model string) string {
 }
 
 // JoinModel combines provider and model ID into a model string.
+//
+// Deprecated: This function has no callers and will be removed in a future
+// release. Concatenate provider + "/" + modelID directly.
 func JoinModel(provider, modelID string) string {
 	if provider == "" {
 		return modelID
@@ -408,6 +411,10 @@ func JoinModel(provider, modelID string) string {
 
 // MatchModelGlob matches a model against a glob pattern.
 // Pattern can contain * (match any) and ? (match single).
+//
+// Deprecated: Use [EvaluateModelConditional] instead, which accepts the same
+// glob syntax as part of a model condition. This function has no callers and
+// will be removed in a future release.
 func MatchModelGlob(model, pattern string) bool {
 	return matchModelPattern(model, pattern)
 }
@@ -428,11 +435,17 @@ func ExtractModelFromPath(model string) string {
 }
 
 // IsBareModelID checks if a string is a bare model ID (no provider).
+//
+// Deprecated: Use GetCurrentProvider(model) == "" instead. This function has
+// no callers and will be removed in a future release.
 func IsBareModelID(model string) bool {
 	return !strings.Contains(model, "/")
 }
 
 // AddProviderToModel adds a provider prefix to a bare model ID.
+//
+// Deprecated: This function has no callers and will be removed in a future
+// release. Check [GetCurrentProvider] and concatenate directly.
 func AddProviderToModel(provider, model string) string {
 	if strings.Contains(model, "/") {
 		return model // Already has provider

--- a/pkg/kit/template_bridge.go
+++ b/pkg/kit/template_bridge.go
@@ -401,7 +401,8 @@ func GetCurrentModelID(model string) string {
 // JoinModel combines provider and model ID into a model string.
 //
 // Deprecated: This function has no callers and will be removed in a future
-// release. Concatenate provider + "/" + modelID directly.
+// release. Replace it with the equivalent conditional: return modelID when
+// provider is empty, otherwise provider + "/" + modelID.
 func JoinModel(provider, modelID string) string {
 	if provider == "" {
 		return modelID

--- a/pkg/kit/tools.go
+++ b/pkg/kit/tools.go
@@ -476,15 +476,6 @@ func FilterCoreToolNames(includeTools, excludeTools []string) ([]string, error) 
 	return coreToolList, nil
 }
 
-// CoreToolFilterHelper reads the include-core-tools/exclude-core-tools keys
-// from a configuration store and resolves the effective core tool list.
-//
-// Deprecated: Use FilterCoreToolNames instead, which takes the include and
-// exclude lists directly and does not expose the configuration library.
-func CoreToolFilterHelper(v *viper.Viper) ([]string, error) {
-	return FilterCoreToolNames(v.GetStringSlice("include-core-tools"), v.GetStringSlice("exclude-core-tools"))
-}
-
 // normalizeCoreToolNames maps user-supplied core tool names onto registry keys
 // and removes duplicates, so that naming the shell tool both ways selects it
 // once rather than registering it twice.

--- a/skills/kit-sdk/SKILL.md
+++ b/skills/kit-sdk/SKILL.md
@@ -801,7 +801,6 @@ info := kit.LookupModel("anthropic", "claude-sonnet-4-5-20250929") // *kit.Model
 info := kit.GetProviderInfo("openai")    // *kit.ProviderInfo (env vars, API URL)
 err := kit.ValidateEnvironment("anthropic", "") // check API keys
 suggestions := kit.SuggestModels("anthropic", "claudee") // fuzzy match
-kit.RefreshModelRegistry() // reload model database
 ```
 
 ### Model string format
@@ -1251,7 +1250,6 @@ kit.MCPAuthHandler         // interface: RedirectURI() + HandleAuth(ctx, server,
 kit.DefaultMCPAuthHandler  // SDK-provided transport mechanics (port + callback server); set OnAuthURL hook
 kit.CLIMCPAuthHandler      // CLI wrapper around DefaultMCPAuthHandler: opens browser, prints status
 kit.NewDefaultMCPAuthHandler()         // random port, no UX side effects
-kit.NewDefaultMCPAuthHandlerWithPort() // fixed port (useful when registering a stable redirect URI)
 kit.NewCLIMCPAuthHandler()             // CLI handler: browser + stderr + localhost callback
 kit.MCPTokenStore        // interface for custom OAuth token storage
 kit.MCPToken             // OAuth token struct (access, refresh, expiry)
@@ -1408,7 +1406,8 @@ Config files support `${ENV_VAR}` expansion.
 ```go
 // Initialize config manually (usually not needed — kit.New handles this)
 kit.InitConfig("/path/to/config.yml", false)
-kit.LoadConfigWithEnvSubstitution("/path/to/config.yml")
+// Same, but skip project-local .kit.yml discovery
+kit.InitConfigWithOptions(kit.ConfigInitOptions{ConfigFile: "/path/to/config.yml", Bare: true})
 ```
 
 ---

--- a/skills/kit-sdk/SKILL.md
+++ b/skills/kit-sdk/SKILL.md
@@ -1250,6 +1250,7 @@ kit.MCPAuthHandler         // interface: RedirectURI() + HandleAuth(ctx, server,
 kit.DefaultMCPAuthHandler  // SDK-provided transport mechanics (port + callback server); set OnAuthURL hook
 kit.CLIMCPAuthHandler      // CLI wrapper around DefaultMCPAuthHandler: opens browser, prints status
 kit.NewDefaultMCPAuthHandler()         // random port, no UX side effects
+kit.NewDefaultMCPAuthHandlerWithPort(p) // fixed port (stable, pre-registered redirect URI)
 kit.NewCLIMCPAuthHandler()             // CLI handler: browser + stderr + localhost callback
 kit.MCPTokenStore        // interface for custom OAuth token storage
 kit.MCPToken             // OAuth token struct (access, refresh, expiry)

--- a/www/pages/sdk/options.md
+++ b/www/pages/sdk/options.md
@@ -501,8 +501,6 @@ host, _ := kit.New(ctx, &kit.Options{CoreToolList: list})
 ```
 
 `DisableCoreTools: true` is the chat-only shortcut for an empty core set.
-`CoreToolFilterHelper(*viper.Viper)` is deprecated — prefer
-`FilterCoreToolNames`, which does not expose the configuration library.
 
 Create custom tools with `kit.NewTool` — no external dependencies needed:
 

--- a/www/pages/sdk/overview.md
+++ b/www/pages/sdk/overview.md
@@ -483,8 +483,7 @@ for _, msg := range host.DrainSteer() {
 
 `Options.CoreToolList` accepts an explicit allow-list of core tool names. Build
 it from include/exclude filters with `FilterCoreToolNames` (nil means "all core
-tools"). Prefer this over the deprecated `CoreToolFilterHelper(*viper.Viper)`,
-which leaks the configuration library into the public signature.
+tools").
 
 ```go
 // Keep only read-only tools:

--- a/www/pages/sdk/sessions.md
+++ b/www/pages/sdk/sessions.md
@@ -107,4 +107,8 @@ that don't track branch summaries can return `kit.ErrBranchSummaryNotSupported`
 from that method; `host.CollapseBranch` then surfaces the same sentinel so
 callers can detect it with `errors.Is`.
 
+When a Kit has no session manager at all, `host.Branch`, `host.NavigateTo`,
+`host.SummarizeBranch`, `host.CollapseBranch` and the extension session API
+return `kit.ErrNoSession`, which is also detectable with `errors.Is`.
+
 When using a custom `SessionManager`, the `SessionPath`, `Continue`, and `NoSession` options are ignored — your manager handles its own storage and session selection.

--- a/www/pages/sdk/sessions.md
+++ b/www/pages/sdk/sessions.md
@@ -108,7 +108,8 @@ from that method; `host.CollapseBranch` then surfaces the same sentinel so
 callers can detect it with `errors.Is`.
 
 When a Kit has no session manager at all, `host.Branch`, `host.NavigateTo`,
-`host.SummarizeBranch`, `host.CollapseBranch` and the extension session API
-return `kit.ErrNoSession`, which is also detectable with `errors.Is`.
+`host.SummarizeBranch`, `host.CollapseBranch`, `host.SetSessionName` and the
+extension session API return `kit.ErrNoSession`, which is also detectable with
+`errors.Is`.
 
 When using a custom `SessionManager`, the `SessionPath`, `Continue`, and `NoSession` options are ignored — your manager handles its own storage and session selection.


### PR DESCRIPTION
## Description

This PR resolves the three related refactor issues #120, #121 and #122 (items 1 and 3 only for #122). All changes are behaviour-preserving with one deliberate exception, called out below.

**SDK hygiene (#120).** `pkg/kit` is the public SDK surface and `AGENTS.md` forbids dependency-name leakage. The deprecated `CoreToolFilterHelper(*viper.Viper)` — the only exported signature that exposed a dependency type — is removed (it had zero callers). Godoc on `InitConfig`, `InitConfigWithOptions`, `LoadConfigWithEnvSubstitution`, `Options` and `New` is reworded so `viper` and `cobra` no longer appear in `go doc` output. Ten unused, undocumented exported functions receive a `// Deprecated:` annotation per the AGENTS.md pattern; they will be removed one release cycle later.

**Duplication clusters (#121).** Four drifting copies are consolidated:

- `extensions.ParseToolArgs` replaces the three `parseToolArgs*` copies in `internal/ui`, `pkg/kit` and `internal/extensions` (keeping the `TrimSpace` guard). The helper lives in `internal/extensions`, not `pkg/kit` as the issue proposed, because `pkg/kit` imports `internal/extensions` — the reverse would be a cycle. The `acpserver` variant is left alone (different fallback contract).
- `kit.ErrNoSession` sentinel replaces five `fmt.Errorf("no session available")` sites, so callers can use `errors.Is`.
- `MCPToolManager.serverClient(name)` replaces nine pool/server guard blocks in `internal/tools/mcp.go`; `agent.ErrNoMCPServers` replaces four repeated messages.
- `GenerateCallbacks.HasAnyCallback()` replaces the inline 20-term OR chain. **The old chain had already drifted:** it omitted `OnReasoningComplete`, `OnStepMessages` and `OnStepUsage`, so a caller that set only one of those with streaming disabled was silently routed to the non-streaming path where the callback never fired. The new method includes them. A reflection-based test (`TestHasAnyCallbackCoversAllFields`) sets each struct field in isolation and fails if a future field is added without updating the method or the explicit both-paths allowlist.
- Optional item: `session.cloneEntry` so `ForkToNewSession` builds the `Entry` envelope in one place instead of seven.

**Oversized functions (#122, items 1 and 3).** `bridgeExtensions` (390 lines) is split into eight per-concern methods with registration order preserved. `GenerateWithCallbacks` (434 lines) is split into `generateStreaming` / `generateSimple`, dispatched through `HasAnyCallback()`. Items 2, 4 and 5 (`runNormalMode`, `New`, `ui.update`) are intentionally **not** included — the issue requires each to be its own PR. #122 should stay open after merge.

Fixes #120
Fixes #121
Refs #122

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactor (no functional change, code quality improvement)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project (`go fmt`, `go vet`, `golangci-lint run` — 0 issues)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my change works (`callbacks_test.go`, `toolargs_test.go`, `sessions_test.go`)
- [x] New and existing unit tests pass locally (`go test -race ./...`)
- [x] I have updated the documentation where the public surface changed (`pkg/kit/README.md`, `www/pages/sdk/*.md`, `skills/kit-sdk/SKILL.md`)

## Additional Information

**Added**

- `internal/extensions/toolargs.go` + `toolargs_test.go` — shared `ParseToolArgs`
- `internal/agent/callbacks_test.go` — reflection guard for `HasAnyCallback`
- `pkg/kit/sessions_test.go` — `ErrNoSession` sentinel coverage

**Modified**

- `internal/agent/agent.go` — `HasAnyCallback`, `ErrNoMCPServers`, `generateStreaming` / `generateSimple` split
- `pkg/kit/extensions_bridge.go` — `bridgeExtensions` split into per-concern methods
- `internal/tools/mcp.go` — `serverClient` accessor
- `internal/session/tree_manager.go` — `cloneEntry`
- `pkg/kit/{config,kit,tools,session,sessions,extension_api,events,auth,models,oauth,skills,template_bridge}.go` — godoc, deprecations, sentinel
- `internal/ui/activity.go`, `internal/extensions/wrapper.go` — use shared helper
- Docs: `pkg/kit/README.md`, `www/pages/sdk/{options,overview,sessions}.md`, `skills/kit-sdk/SKILL.md`

**Backward compatibility**

- `CoreToolFilterHelper` is removed. It was already marked `Deprecated` and has no in-tree or documented callers.
- All other public-surface changes are additive (`ErrNoSession`) or comment-only (`Deprecated` annotations, godoc rewording).
- `taskClient` now reports a missing server as `MCP server %q not found` instead of `… not loaded`, matching the other per-server RPCs. No test or caller depended on the old wording.
- `internal/ui` now imports `internal/extensions` directly (previously only transitively via `pkg/kit`); no import cycle is introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared tool-argument parsing for consistent tool event and activity displays.
  * Added detectable sentinel errors for missing sessions and unavailable MCP servers.
* **Deprecations**
  * Marked several unused SDK APIs for future removal and documented recommended replacements.
  * Removed the deprecated `CoreToolFilterHelper` API.
* **Documentation**
  * Updated SDK guidance for configuration, sessions, model management, MCP authentication, and tool filtering.
  * Clarified configuration behavior and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->