### PR TITLE
feat(cli): add --mcp flag to load an MCP server without a config file

### DIFF
--- a/cmd/mcp_flag.go
+++ b/cmd/mcp_flag.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mark3labs/kit/internal/config"
+)
+
+// parseMCPFlag turns one --mcp value into a named MCP server config.
+//
+// The value has the form "name=spec". When spec starts with "http://" or
+// "https://" the server is remote (streamable HTTP). Otherwise spec is a
+// command line that starts a local stdio server. The command line is split
+// on whitespace; single quotes, double quotes and backslash escapes keep
+// spaces inside one argument.
+//
+//	--mcp 'browser=lightpanda mcp'
+//	--mcp 'docs=https://mcp.example.com/mcp'
+//	--mcp 'fs=npx -y @modelcontextprotocol/server-filesystem "/my dir"'
+func parseMCPFlag(value string) (string, config.MCPServerConfig, error) {
+	name, spec, found := strings.Cut(value, "=")
+	name = strings.TrimSpace(name)
+	spec = strings.TrimSpace(spec)
+	if !found || name == "" || spec == "" {
+		return "", config.MCPServerConfig{}, fmt.Errorf("invalid --mcp value %q: expected name=command or name=url", value)
+	}
+	if strings.ContainsAny(name, " \t/") {
+		return "", config.MCPServerConfig{}, fmt.Errorf("invalid --mcp server name %q: must not contain spaces or '/'", name)
+	}
+
+	if strings.HasPrefix(spec, "http://") || strings.HasPrefix(spec, "https://") {
+		return name, config.MCPServerConfig{Type: "remote", URL: spec}, nil
+	}
+
+	command, err := splitCommandLine(spec)
+	if err != nil {
+		return "", config.MCPServerConfig{}, fmt.Errorf("invalid --mcp command for %q: %w", name, err)
+	}
+	if len(command) == 0 || command[0] == "" {
+		return "", config.MCPServerConfig{}, fmt.Errorf("invalid --mcp value %q: command is empty", value)
+	}
+	return name, config.MCPServerConfig{Type: "local", Command: command}, nil
+}
+
+// applyMCPFlags adds every --mcp server to cfg. A flag server replaces a
+// config-file server with the same name. The merged config is validated
+// again so a bad flag fails at startup and not at connect time.
+func applyMCPFlags(cfg *config.Config, values []string) error {
+	if len(values) == 0 {
+		return nil
+	}
+	if cfg.MCPServers == nil {
+		cfg.MCPServers = make(map[string]config.MCPServerConfig)
+	}
+	for _, value := range values {
+		name, server, err := parseMCPFlag(value)
+		if err != nil {
+			return err
+		}
+		cfg.MCPServers[name] = server
+	}
+	if err := cfg.Validate(); err != nil {
+		return fmt.Errorf("invalid --mcp config: %w", err)
+	}
+	return nil
+}
+
+// splitCommandLine splits s into arguments the way a POSIX shell splits a
+// simple command: whitespace separates arguments, single quotes keep text
+// literal, double quotes keep text but honour backslash escapes, and a
+// backslash outside quotes escapes the next rune. No variable expansion or
+// globbing is done.
+func splitCommandLine(s string) ([]string, error) {
+	var (
+		args    []string
+		current strings.Builder
+		inArg   bool
+		quote   rune // 0, '\'' or '"'
+		escaped bool
+	)
+
+	for _, r := range s {
+		switch {
+		case escaped:
+			current.WriteRune(r)
+			escaped = false
+		case r == '\\' && quote != '\'':
+			escaped = true
+			inArg = true
+		case quote != 0:
+			if r == quote {
+				quote = 0
+			} else {
+				current.WriteRune(r)
+			}
+		case r == '\'' || r == '"':
+			quote = r
+			inArg = true
+		case r == ' ' || r == '\t' || r == '\n':
+			if inArg {
+				args = append(args, current.String())
+				current.Reset()
+				inArg = false
+			}
+		default:
+			current.WriteRune(r)
+			inArg = true
+		}
+	}
+
+	if escaped {
+		return nil, fmt.Errorf("trailing backslash")
+	}
+	if quote != 0 {
+		return nil, fmt.Errorf("unterminated %c quote", quote)
+	}
+	if inArg {
+		args = append(args, current.String())
+	}
+	return args, nil
+}

--- a/cmd/mcp_flag_test.go
+++ b/cmd/mcp_flag_test.go
@@ -1,0 +1,184 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/mark3labs/kit/internal/config"
+)
+
+func TestSplitCommandLine(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    []string
+		wantErr bool
+	}{
+		{name: "simple", in: "lightpanda mcp", want: []string{"lightpanda", "mcp"}},
+		{name: "extra whitespace", in: "  npx   -y  pkg\t", want: []string{"npx", "-y", "pkg"}},
+		{name: "double quotes", in: `cmd "a b" c`, want: []string{"cmd", "a b", "c"}},
+		{name: "single quotes", in: `cmd 'a b' c`, want: []string{"cmd", "a b", "c"}},
+		{name: "backslash escape", in: `cmd a\ b`, want: []string{"cmd", "a b"}},
+		{name: "backslash in single quotes is literal", in: `cmd 'a\b'`, want: []string{"cmd", `a\b`}},
+		{name: "escape inside double quotes", in: `cmd "say \"hi\""`, want: []string{"cmd", `say "hi"`}},
+		{name: "empty quoted arg", in: `cmd ""`, want: []string{"cmd", ""}},
+		{name: "adjacent quotes join", in: `cmd a"b c"d`, want: []string{"cmd", "ab cd"}},
+		{name: "empty", in: "", want: nil},
+		{name: "unterminated double quote", in: `cmd "a`, wantErr: true},
+		{name: "unterminated single quote", in: `cmd 'a`, wantErr: true},
+		{name: "trailing backslash", in: `cmd a\`, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := splitCommandLine(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("splitCommandLine(%q) = %v, want error", tt.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("splitCommandLine(%q) unexpected error: %v", tt.in, err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("splitCommandLine(%q) = %#v, want %#v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseMCPFlag(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		wantName string
+		want     config.MCPServerConfig
+		wantErr  bool
+	}{
+		{
+			name:     "stdio command",
+			in:       "browser=lightpanda mcp",
+			wantName: "browser",
+			want:     config.MCPServerConfig{Type: "local", Command: []string{"lightpanda", "mcp"}},
+		},
+		{
+			name:     "stdio command with quoted arg",
+			in:       `fs=npx -y @modelcontextprotocol/server-filesystem "/my dir"`,
+			wantName: "fs",
+			want:     config.MCPServerConfig{Type: "local", Command: []string{"npx", "-y", "@modelcontextprotocol/server-filesystem", "/my dir"}},
+		},
+		{
+			name:     "https url",
+			in:       "docs=https://mcp.example.com/mcp",
+			wantName: "docs",
+			want:     config.MCPServerConfig{Type: "remote", URL: "https://mcp.example.com/mcp"},
+		},
+		{
+			name:     "http url",
+			in:       "local=http://127.0.0.1:8080/mcp",
+			wantName: "local",
+			want:     config.MCPServerConfig{Type: "remote", URL: "http://127.0.0.1:8080/mcp"},
+		},
+		{
+			name:     "url with query keeps extra equals",
+			in:       "docs=https://mcp.example.com/mcp?token=abc=def",
+			wantName: "docs",
+			want:     config.MCPServerConfig{Type: "remote", URL: "https://mcp.example.com/mcp?token=abc=def"},
+		},
+		{
+			name:     "surrounding whitespace trimmed",
+			in:       "  browser = lightpanda mcp ",
+			wantName: "browser",
+			want:     config.MCPServerConfig{Type: "local", Command: []string{"lightpanda", "mcp"}},
+		},
+		{name: "missing equals", in: "lightpanda mcp", wantErr: true},
+		{name: "empty name", in: "=lightpanda mcp", wantErr: true},
+		{name: "empty spec", in: "browser=", wantErr: true},
+		{name: "name with space", in: "my browser=lightpanda mcp", wantErr: true},
+		{name: "name with slash", in: "a/b=lightpanda mcp", wantErr: true},
+		{name: "bad quoting", in: `browser=lightpanda "mcp`, wantErr: true},
+		{name: "only quotes", in: `browser=""`, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, got, err := parseMCPFlag(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseMCPFlag(%q) = %q, %#v, want error", tt.in, gotName, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseMCPFlag(%q) unexpected error: %v", tt.in, err)
+			}
+			if gotName != tt.wantName {
+				t.Errorf("parseMCPFlag(%q) name = %q, want %q", tt.in, gotName, tt.wantName)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseMCPFlag(%q) = %#v, want %#v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyMCPFlags(t *testing.T) {
+	t.Run("no flags is a no-op", func(t *testing.T) {
+		cfg := &config.Config{}
+		if err := applyMCPFlags(cfg, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.MCPServers != nil {
+			t.Errorf("MCPServers = %#v, want nil", cfg.MCPServers)
+		}
+	})
+
+	t.Run("adds servers to nil map", func(t *testing.T) {
+		cfg := &config.Config{}
+		err := applyMCPFlags(cfg, []string{"browser=lightpanda mcp", "docs=https://mcp.example.com/mcp"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(cfg.MCPServers) != 2 {
+			t.Fatalf("got %d servers, want 2", len(cfg.MCPServers))
+		}
+		if got := cfg.MCPServers["browser"].Command; !reflect.DeepEqual(got, []string{"lightpanda", "mcp"}) {
+			t.Errorf("browser command = %#v", got)
+		}
+		if got := cfg.MCPServers["docs"].URL; got != "https://mcp.example.com/mcp" {
+			t.Errorf("docs url = %q", got)
+		}
+	})
+
+	t.Run("flag replaces config file server with same name", func(t *testing.T) {
+		cfg := &config.Config{MCPServers: map[string]config.MCPServerConfig{
+			"browser": {Type: "local", Command: []string{"old", "server"}},
+			"other":   {Type: "remote", URL: "https://other.example.com"},
+		}}
+		if err := applyMCPFlags(cfg, []string{"browser=lightpanda mcp"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := cfg.MCPServers["browser"].Command; !reflect.DeepEqual(got, []string{"lightpanda", "mcp"}) {
+			t.Errorf("browser command = %#v, want flag value", got)
+		}
+		if _, ok := cfg.MCPServers["other"]; !ok {
+			t.Errorf("config-file server 'other' was dropped")
+		}
+	})
+
+	t.Run("last duplicate flag wins", func(t *testing.T) {
+		cfg := &config.Config{}
+		if err := applyMCPFlags(cfg, []string{"b=first", "b=second"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := cfg.MCPServers["b"].Command; !reflect.DeepEqual(got, []string{"second"}) {
+			t.Errorf("command = %#v, want [second]", got)
+		}
+	})
+
+	t.Run("bad flag returns error", func(t *testing.T) {
+		cfg := &config.Config{}
+		if err := applyMCPFlags(cfg, []string{"nope"}); err == nil {
+			t.Fatal("expected error for value without '='")
+		}
+	})
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,6 +73,7 @@ var (
 	includeCoreToolsFlag []string
 	excludeCoreToolsFlag []string
 	extensionPaths       []string
+	mcpFlags             []string
 
 	// Shell tool
 	shellFlag string
@@ -397,6 +398,9 @@ func init() {
 		StringVar(&shellFlag, "shell", "", `shell the shell tool runs commands through, e.g. "/bin/dash" or "busybox ash" (default "bash")`)
 	rootCmd.PersistentFlags().
 		StringSliceVarP(&extensionPaths, "extension", "e", nil, "load additional extension file(s)")
+	// StringArray (not StringSlice) so a command line with commas stays one value.
+	rootCmd.PersistentFlags().
+		StringArrayVar(&mcpFlags, "mcp", nil, `add an MCP server for this run (repeatable): "name=command args..." for stdio or "name=https://..." for remote`)
 
 	// Skills flags
 	rootCmd.PersistentFlags().
@@ -991,6 +995,9 @@ func runNormalMode(ctx context.Context) error {
 	mcpConfig, err := config.LoadAndValidateConfig()
 	if err != nil {
 		return fmt.Errorf("failed to load MCP config: %v", err)
+	}
+	if err := applyMCPFlags(mcpConfig, mcpFlags); err != nil {
+		return err
 	}
 
 	// appInstancePtr is used to break the circular dependency between

--- a/www/pages/cli/flags.md
+++ b/www/pages/cli/flags.md
@@ -92,6 +92,26 @@ self-defeating.
 | `--no-core-tools` | — | `false` | Disable all built-in core tools |
 | `--include-core-tools` | — | — | Comma-separated list of core tools to include (mutually exclusive with `--exclude-core-tools`) |
 | `--exclude-core-tools` | — | — | Comma-separated list of core tools to exclude (mutually exclusive with `--include-core-tools`) |
+| `--mcp` | — | — | Add an MCP server for this run (repeatable). `name=command args...` starts a local stdio server; `name=https://...` connects to a remote server |
+
+### One-off MCP servers
+
+`--mcp` adds a server without a config file. Each value is `name=spec`. When
+`spec` starts with `http://` or `https://` Kit connects to a remote server;
+otherwise `spec` is a command line for a local stdio server. Quotes and
+backslashes group arguments the way a shell does, so an argument can contain
+spaces.
+
+```bash
+kit --mcp 'browser=lightpanda mcp' "open example.com and read the title"
+kit --mcp 'docs=https://mcp.example.com/mcp' "..."
+kit --mcp 'fs=npx -y @modelcontextprotocol/server-filesystem "/my dir"' \
+    --mcp 'browser=lightpanda mcp' "..."
+```
+
+A flag server with the same name as a `mcpServers` entry in `.kit.yml`
+replaces that entry for the run. For `environment`, `allowedTools`, `headers`
+and the other per-server fields, use the [config file](/configuration#mcp-server-configuration).
 
 ## Extensions
 

--- a/www/pages/configuration.md
+++ b/www/pages/configuration.md
@@ -127,6 +127,10 @@ mcpServers:
 
 A legacy format with `transport`, `args`, and `env` fields is also supported; `headers` works in both the current and legacy formats.
 
+For a one-off server without a config file, pass `--mcp 'name=command args...'`
+or `--mcp 'name=https://...'` on the command line. See
+[CLI flags](/cli/flags#one-off-mcp-servers).
+
 ### MCP tasks (long-running tools)
 
 Kit advertises [MCP task support](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks)


### PR DESCRIPTION
## Description

Adds a repeatable `--mcp` flag so a user can load an MCP server for one run without editing `.kit.yml`. Until now the only way to add a server was the `mcpServers` map in a config file (or `--config` pointing at a throwaway file).

Each value has the form `name=spec`. A spec that starts with `http://` or `https://` becomes a `remote` (streamable HTTP) server. Any other spec is a command line for a `local` stdio server; a small POSIX-style splitter honours single quotes, double quotes and backslash escapes so an argument can contain spaces.

```bash
kit --mcp 'browser=lightpanda mcp' "open example.com and read the title"
kit --mcp 'docs=https://mcp.example.com/mcp' "..."
kit --mcp 'fs=npx -y @modelcontextprotocol/server-filesystem "/my dir"' --mcp 'browser=lightpanda mcp' "..."
```

Flag servers are merged into the config returned by `LoadAndValidateConfig` in `runNormalMode`, then the merged config is validated again so a bad value fails at startup with a clear error. A flag server replaces a config-file server with the same name. The flag is a `StringArray` (not `StringSlice`) so a command line that contains commas stays one value.

Verified interactively in tmux with `lightpanda mcp`: the server loads with 32 tools and the model calls `Browser__goto` / `Browser__extract` through it. Also checked `--quiet` mode and the error paths (missing `=`, unterminated quote).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor / code quality
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`go test -race ./cmd`)
- [x] I have updated the documentation accordingly
- [x] `go vet`, `gofmt` and `golangci-lint` are clean on the touched package

## Additional Information

- Added `cmd/mcp_flag.go` — `parseMCPFlag`, `applyMCPFlags`, `splitCommandLine`
- Added `cmd/mcp_flag_test.go` — table tests for the splitter, the parser and the merge/override behaviour
- Modified `cmd/root.go` — registers `--mcp` and applies it after `config.LoadAndValidateConfig()` in `runNormalMode`
- Modified `www/pages/cli/flags.md` — new table row and "One-off MCP servers" section
- Modified `www/pages/configuration.md` — cross-link from the `mcpServers` section
- Backward compatible: no existing flag or config key changes; `--mcp` is not bound to viper because `mcpServers` already covers config-file use
- Only `name`, `command` / `url` and `type` can be set from the flag; per-server fields such as `environment`, `allowedTools` and `headers` still need the config file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added repeatable `--mcp` support for configuring one-off local or remote MCP servers when starting the application.
  * Supports quoted command arguments, HTTP(S) server URLs, and replacement of same-name configured servers for the current run.
  * Invalid MCP values now produce startup errors.
* **Documentation**
  * Added usage guidance, supported formats, examples, and configuration details for the `--mcp` option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->