### PR TITLE
fix(docs): compare live ToolName to "shell", not the legacy "bash" name

### DIFF
--- a/internal/core/docs_shell_toolname_test.go
+++ b/internal/core/docs_shell_toolname_test.go
@@ -17,11 +17,39 @@ import (
 var toolNameComparison = regexp.MustCompile(
 	`(?:[\w.]*ToolName\s*(?:==|!=)\s*"([^"]*)")|(?:"([^"]*)"\s*(?:==|!=)\s*[\w.]*ToolName)`)
 
+// stripLineComment removes a trailing // comment so that comment prose cannot
+// satisfy the ShellToolName exception below. A line such as
+//
+//	if h.ToolName == "bash" { // unlike h.ToolName == "shell"
+//
+// would otherwise look like it compares against both names. Quoted strings are
+// tracked so a // inside a literal (a URL, say) is not mistaken for a comment.
+func stripLineComment(line string) string {
+	var inString bool
+	var quote rune
+	prev := rune(0)
+	for i, r := range line {
+		switch {
+		case inString:
+			if r == quote && prev != '\\' {
+				inString = false
+			}
+		case r == '"' || r == '`' || r == '\'':
+			inString = true
+			quote = r
+		case r == '/' && prev == '/':
+			return line[:i-1]
+		}
+		prev = r
+	}
+	return line
+}
+
 // comparedToolNames returns every quoted literal that line compares against a
-// ToolName field, in either operand order.
+// ToolName field, in either operand order. Trailing comments are ignored.
 func comparedToolNames(line string) []string {
 	var out []string
-	for _, m := range toolNameComparison.FindAllStringSubmatch(line, -1) {
+	for _, m := range toolNameComparison.FindAllStringSubmatch(stripLineComment(line), -1) {
 		// Exactly one of the two capture groups is set per match.
 		if m[1] != "" {
 			out = append(out, m[1])
@@ -72,6 +100,14 @@ func TestFlagsLegacyToolNameComparison(t *testing.T) {
 		// A "shell" literal that is not a ToolName comparison must not excuse it.
 		{`if h.ToolName == "bash" || label == "shell" {`, true},
 		{`if h.ToolName == "bash" { log("shell") }`, true},
+
+		// Nor may comment prose: only real code counts toward the exception.
+		{`if h.ToolName == "bash" { // unlike h.ToolName == "shell"`, true},
+		{`// h.ToolName == "shell" is right, this is not:`, false},
+		{`if h.ToolName == "bash" { // TODO: should be "shell"`, true},
+
+		// A // inside a string literal is not a comment.
+		{`if h.ToolName == "bash" && url == "http://x" || h.ToolName == "shell" {`, false},
 
 		// Correct and unrelated lines.
 		{`    if h.ToolName == "shell" {`, false},

--- a/internal/core/docs_shell_toolname_test.go
+++ b/internal/core/docs_shell_toolname_test.go
@@ -1,0 +1,83 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// legacyToolNameEquality matches a doc example that tests a live tool name for
+// equality with the shell tool's earlier name, e.g. `h.ToolName == "bash"`.
+var legacyToolNameEquality = regexp.MustCompile(`ToolName\s*(==|!=)\s*"` + LegacyShellToolName + `"`)
+
+// TestDocsDoNotCompareLiveToolNameToLegacyShellName keeps doc examples honest
+// about the name the shell tool reports at runtime.
+//
+// NormalizeCoreToolName accepts LegacyShellToolName wherever a *user names* the
+// tool — CoreToolList, include/exclude flags, SetActiveTools, tool renderers —
+// so "bash" is correct in those positions. It is not applied to the ToolName
+// carried by events and hooks: hooks read the live fantasy.ToolInfo.Name, which
+// is always ShellToolName. An example comparing that field to "bash" is dead
+// code, and two such examples shipped for months before a reviewer caught them.
+//
+// A comparison is allowed when the same line also names ShellToolName, which is
+// the defensive `!= "shell" && != "bash"` form used by examples that must cope
+// with sessions recorded by older builds.
+func TestDocsDoNotCompareLiveToolNameToLegacyShellName(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+
+	// Directories holding prose and example code that users copy from.
+	roots := []string{
+		filepath.Join(repoRoot, "www", "pages"),
+		filepath.Join(repoRoot, "skills"),
+		filepath.Join(repoRoot, "examples"),
+		filepath.Join(repoRoot, "pkg", "extensions", "test"),
+	}
+
+	var scanned int
+	for _, root := range roots {
+		if _, err := os.Stat(root); err != nil {
+			continue // docs not present in this checkout
+		}
+		err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil //nolint:nilerr // skip unreadable entries, don't abort
+			}
+			ext := strings.ToLower(filepath.Ext(path))
+			if ext != ".md" && ext != ".go" {
+				return nil
+			}
+			body, readErr := os.ReadFile(path)
+			if readErr != nil {
+				return nil
+			}
+			scanned++
+			for i, line := range strings.Split(string(body), "\n") {
+				if !legacyToolNameEquality.MatchString(line) {
+					continue
+				}
+				if strings.Contains(line, `"`+ShellToolName+`"`) {
+					continue // defensive form naming both spellings
+				}
+				rel, relErr := filepath.Rel(repoRoot, path)
+				if relErr != nil {
+					rel = path
+				}
+				t.Errorf("%s:%d compares a live ToolName to %q, which never matches "+
+					"(the shell tool reports %q); use %q or name both spellings:\n\t%s",
+					rel, i+1, LegacyShellToolName, ShellToolName, ShellToolName,
+					strings.TrimSpace(line))
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", root, err)
+		}
+	}
+
+	if scanned == 0 {
+		t.Skip("no documentation or example files found in this checkout")
+	}
+}

--- a/internal/core/docs_shell_toolname_test.go
+++ b/internal/core/docs_shell_toolname_test.go
@@ -8,9 +8,86 @@ import (
 	"testing"
 )
 
-// legacyToolNameEquality matches a doc example that tests a live tool name for
-// equality with the shell tool's earlier name, e.g. `h.ToolName == "bash"`.
-var legacyToolNameEquality = regexp.MustCompile(`ToolName\s*(==|!=)\s*"` + LegacyShellToolName + `"`)
+// toolNameComparison matches a comparison between a *ToolName field and a
+// quoted literal, in either operand order:
+//
+//	h.ToolName == "bash"    tc.ToolName != "shell"    "bash" == h.ToolName
+//
+// The captured literal is whichever side is quoted.
+var toolNameComparison = regexp.MustCompile(
+	`(?:[\w.]*ToolName\s*(?:==|!=)\s*"([^"]*)")|(?:"([^"]*)"\s*(?:==|!=)\s*[\w.]*ToolName)`)
+
+// comparedToolNames returns every quoted literal that line compares against a
+// ToolName field, in either operand order.
+func comparedToolNames(line string) []string {
+	var out []string
+	for _, m := range toolNameComparison.FindAllStringSubmatch(line, -1) {
+		// Exactly one of the two capture groups is set per match.
+		if m[1] != "" {
+			out = append(out, m[1])
+		} else if m[2] != "" {
+			out = append(out, m[2])
+		}
+	}
+	return out
+}
+
+// flagsLegacyToolNameComparison reports whether line compares a live ToolName
+// against the shell tool's earlier name without also comparing it against the
+// current name. The exception is scoped to ToolName comparisons specifically,
+// so an unrelated `|| label == "shell"` on the same line does not excuse it.
+func flagsLegacyToolNameComparison(line string) bool {
+	names := comparedToolNames(line)
+	var sawLegacy, sawCurrent bool
+	for _, n := range names {
+		switch n {
+		case LegacyShellToolName:
+			sawLegacy = true
+		case ShellToolName:
+			sawCurrent = true
+		}
+	}
+	return sawLegacy && !sawCurrent
+}
+
+// TestFlagsLegacyToolNameComparison covers the matcher used by the docs scan
+// below, including both operand orders and the scoped "shell" exception.
+func TestFlagsLegacyToolNameComparison(t *testing.T) {
+	cases := []struct {
+		line string
+		flag bool
+	}{
+		// Plain comparisons against the earlier name — always dead code.
+		{`    if h.ToolName == "bash" {`, true},
+		{`    if h.ToolName != "bash" {`, true},
+		{`    if "bash" == h.ToolName {`, true},
+		{`    if "bash" != tc.ToolName {`, true},
+		{`if e.ToolName=="bash"{`, true},
+
+		// The defensive both-spellings form, in either order.
+		{`if tc.ToolName != "shell" && tc.ToolName != "bash" {`, false},
+		{`if tc.ToolName == "bash" || tc.ToolName == "shell" {`, false},
+		{`if "shell" == h.ToolName || "bash" == h.ToolName {`, false},
+
+		// A "shell" literal that is not a ToolName comparison must not excuse it.
+		{`if h.ToolName == "bash" || label == "shell" {`, true},
+		{`if h.ToolName == "bash" { log("shell") }`, true},
+
+		// Correct and unrelated lines.
+		{`    if h.ToolName == "shell" {`, false},
+		{`    if h.ToolName == "read" {`, false},
+		{`    if e.ToolName == "subagent" {`, false},
+		{`    ToolName:    "bash",`, false}, // renderer registration, normalized
+		{`list, _ := kit.FilterCoreToolNames(nil, []string{"bash", "write"})`, false},
+		{`shell: "bash"`, false}, // the shell binary, not the tool name
+		{``, false},
+	}
+	for _, c := range cases {
+		if got := flagsLegacyToolNameComparison(c.line); got != c.flag {
+			t.Errorf("flagsLegacyToolNameComparison(%q) = %v, want %v", c.line, got, c.flag)
+		}
+	}
+}
 
 // TestDocsDoNotCompareLiveToolNameToLegacyShellName keeps doc examples honest
 // about the name the shell tool reports at runtime.
@@ -22,8 +99,8 @@ var legacyToolNameEquality = regexp.MustCompile(`ToolName\s*(==|!=)\s*"` + Legac
 // is always ShellToolName. An example comparing that field to "bash" is dead
 // code, and two such examples shipped for months before a reviewer caught them.
 //
-// A comparison is allowed when the same line also names ShellToolName, which is
-// the defensive `!= "shell" && != "bash"` form used by examples that must cope
+// A comparison is allowed when the same line also compares ToolName against
+// ShellToolName, which is the defensive form used by examples that must cope
 // with sessions recorded by older builds.
 func TestDocsDoNotCompareLiveToolNameToLegacyShellName(t *testing.T) {
 	repoRoot := filepath.Join("..", "..")
@@ -55,18 +132,15 @@ func TestDocsDoNotCompareLiveToolNameToLegacyShellName(t *testing.T) {
 			}
 			scanned++
 			for i, line := range strings.Split(string(body), "\n") {
-				if !legacyToolNameEquality.MatchString(line) {
+				if !flagsLegacyToolNameComparison(line) {
 					continue
-				}
-				if strings.Contains(line, `"`+ShellToolName+`"`) {
-					continue // defensive form naming both spellings
 				}
 				rel, relErr := filepath.Rel(repoRoot, path)
 				if relErr != nil {
 					rel = path
 				}
 				t.Errorf("%s:%d compares a live ToolName to %q, which never matches "+
-					"(the shell tool reports %q); use %q or name both spellings:\n\t%s",
+					"(the shell tool reports %q); use %q or compare against both names:\n\t%s",
 					rel, i+1, LegacyShellToolName, ShellToolName, ShellToolName,
 					strings.TrimSpace(line))
 			}

--- a/skills/kit-sdk/references/hooks.md
+++ b/skills/kit-sdk/references/hooks.md
@@ -11,8 +11,10 @@ Hooks can **modify or cancel** operations. Events are read-only; hooks are read-
 ```go
 unsub := host.OnBeforeToolCall(kit.HookPriorityNormal, func(h kit.BeforeToolCallHook) *kit.BeforeToolCallResult {
     // h.ToolCallID, h.ToolName, h.ToolArgs
-    if h.ToolName == "bash" {
-        return &kit.BeforeToolCallResult{Block: true, Reason: "bash disabled"}
+    // The command-execution tool reports itself as "shell" (both kit.NewShellTool
+    // and the deprecated kit.NewBashTool register it under that name).
+    if h.ToolName == "shell" {
+        return &kit.BeforeToolCallResult{Block: true, Reason: "shell disabled"}
     }
     return nil // allow
 })

--- a/www/pages/sdk/callbacks.md
+++ b/www/pages/sdk/callbacks.md
@@ -76,12 +76,19 @@ Hooks can **modify or cancel** operations. Unlike events (read-only), hooks are 
 ```go
 host.OnBeforeToolCall(kit.HookPriorityNormal, func(h kit.BeforeToolCallHook) *kit.BeforeToolCallResult {
     // h.ToolCallID, h.ToolName, h.ToolArgs
-    if h.ToolName == "bash" && strings.Contains(h.ToolArgs, "rm -rf") {
+    // The command-execution tool reports itself as "shell" (both kit.NewShellTool
+    // and the deprecated kit.NewBashTool register it under that name).
+    if h.ToolName == "shell" && strings.Contains(h.ToolArgs, "rm -rf") {
         return &kit.BeforeToolCallResult{Block: true, Reason: "dangerous command"}
     }
     return nil // allow
 })
 ```
+
+`h.ToolArgs` is the raw JSON the model produced. A substring match over it is a
+convenience guard, not a security boundary — `rm -r -f`, a shell expansion, or a
+script file all get past it. Parse the arguments and enforce an allowlist when
+you need a real control.
 
 ### AfterToolResult — modify tool output
 


### PR DESCRIPTION
## Description

Follow-up to #133. While reviewing that PR, CodeRabbit caught two guard-rail examples that compared a live `ToolName` against `"bash"`. Those two were fixed in-place, but the same mistake existed in files that PR did not touch. This is the audit result.

`NormalizeCoreToolName` maps `"bash"` → `"shell"` wherever a user **names** the tool — `CoreToolList`, `--include-core-tools` / `--exclude-core-tools`, `SetActiveTools`, and tool renderers (`GetToolRenderer` normalizes both sides). Those doc examples using `"bash"` are correct and are left alone.

It is **not** applied to the `ToolName` carried by events and hooks. `pkg/kit/hooks.go` reads `h.inner.Info().Name`, which for the command-execution tool is always `"shell"` — verified empirically, both `kit.NewShellTool()` and the deprecated `kit.NewBashTool()` report `"shell"`. Two examples compared that field to `"bash"`, so their guard was dead code:

- `www/pages/sdk/callbacks.md` — BeforeToolCall example
- `skills/kit-sdk/references/hooks.md` — BeforeToolCall example

Both now match `"shell"`. The `callbacks.md` example also gains the note that a substring match over the raw `ToolArgs` JSON is a convenience guard rather than a security boundary, matching wording already used in the skill references.

To stop this recurring, `TestDocsDoNotCompareLiveToolNameToLegacyShellName` scans `www/pages`, `skills`, `examples` and `pkg/extensions/test` for a `ToolName` comparison against `"bash"` and fails unless the same line also names `"shell"` — the defensive both-spellings form in `examples/extensions/sudo-handler.go` stays legal. This follows the existing `TestDocumentedEventCountMatchesTable` precedent for doc-linting tests. Verified the test fails on the bug and passes once fixed.

## Type of Change

- [ ] New feature
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`go test -race ./...`, `go vet`, `golangci-lint` clean)
- [x] I have made corresponding changes to the documentation

## Additional Information

**Modified**

- `www/pages/sdk/callbacks.md` — `"bash"` → `"shell"`, plus a not-a-security-boundary note
- `skills/kit-sdk/references/hooks.md` — `"bash"` → `"shell"`

**Added**

- `internal/core/docs_shell_toolname_test.go` — regression guard

**Audited and deliberately left unchanged** (all normalized, so `"bash"` works):

- `www/pages/sdk/overview.md`, `www/pages/sdk/options.md` — `CoreToolList` / `FilterCoreToolNames`
- `skills/kit-sdk/references/extension-api-auth-skills.md` — `SetActiveTools`
- `www/pages/extensions/capabilities.md`, `skills/kit-extensions/references/renderers.md` — tool renderers
- `examples/extensions/sudo-handler.go` — checks both spellings on purpose
- `README.md` `shell: "bash"` — the shell binary, unrelated to the tool name

Docs-only change plus one test; no runtime behavior is affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated tool-calling examples to use the current `"shell"` tool name, including compatibility with existing registrations.
  * Clarified that simple command-argument matching is a convenience safeguard and recommended allowlist-based parsing for enforcement.
  * Updated the example block reason to `"shell disabled"`.
* **Tests**
  * Added automated checks to detect legacy tool-name comparisons in documentation and examples, including comparisons in either operand order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->