### PR TITLE
feat(sdk): durability seams for external SessionManager implementations

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -203,6 +203,9 @@ type PrepareStepUpdate struct {
 	Messages []fantasy.Message
 	// ToolChoice, when non-nil, overrides the tool-choice mode for this step.
 	ToolChoice *fantasy.ToolChoice
+	// Tools, when non-nil, replaces the tool set for this step. An empty
+	// non-nil slice is meaningful: it offers the model no tools at all.
+	Tools []fantasy.AgentTool
 }
 
 // PrepareStepHandler is called between steps to allow message modification
@@ -1039,6 +1042,14 @@ func (a *Agent) generateStreaming(ctx context.Context, cb GenerateCallbacks, mes
 				}
 				if update.ToolChoice != nil {
 					result.ToolChoice = update.ToolChoice
+				}
+				if update.Tools != nil {
+					// Overrides the live tool set read above. An empty
+					// non-nil slice disables tools for this step: fantasy
+					// only replaces stepTools when Tools is non-nil, so
+					// the distinction between nil and empty is preserved
+					// all the way down.
+					result.Tools = update.Tools
 				}
 			}
 		}

--- a/internal/agent/prepare_step_tools_test.go
+++ b/internal/agent/prepare_step_tools_test.go
@@ -1,0 +1,116 @@
+package agent
+
+import (
+	"testing"
+
+	"charm.land/fantasy"
+)
+
+// applyPrepareStepUpdate mirrors the Phase-2 application in the PrepareStep
+// closure in GenerateWithCallbacks. Keeping it in a helper lets the semantics
+// be tested without standing up a provider; the closure and this helper must
+// stay in step.
+func applyPrepareStepUpdate(result *fantasy.PrepareStepResult, update *PrepareStepUpdate) {
+	if update == nil {
+		return
+	}
+	if update.Messages != nil {
+		result.Messages = update.Messages
+	}
+	if update.ToolChoice != nil {
+		result.ToolChoice = update.ToolChoice
+	}
+	if update.Tools != nil {
+		result.Tools = update.Tools
+	}
+}
+
+func liveTools() []fantasy.AgentTool {
+	return []fantasy.AgentTool{
+		fantasy.NewAgentTool[struct{}]("alpha", "", nil),
+		fantasy.NewAgentTool[struct{}]("beta", "", nil),
+	}
+}
+
+func toolNames(tools []fantasy.AgentTool) []string {
+	out := make([]string, 0, len(tools))
+	for _, t := range tools {
+		out = append(out, t.Info().Name)
+	}
+	return out
+}
+
+// TestPrepareStepUpdateNilToolsKeepsLiveSet is the default path: a hook that
+// does not set Tools must leave the live tool set alone, so runtime AddTools
+// and RemoveTools still reach the model mid-turn.
+func TestPrepareStepUpdateNilToolsKeepsLiveSet(t *testing.T) {
+	t.Parallel()
+
+	result := fantasy.PrepareStepResult{Tools: liveTools()}
+	applyPrepareStepUpdate(&result, &PrepareStepUpdate{})
+
+	if got := toolNames(result.Tools); len(got) != 2 {
+		t.Fatalf("tools = %v, want the live set untouched", got)
+	}
+}
+
+// TestPrepareStepUpdateReplacesTools covers per-step filtering, the use case
+// the PrepareStepHook godoc advertises.
+func TestPrepareStepUpdateReplacesTools(t *testing.T) {
+	t.Parallel()
+
+	narrowed := []fantasy.AgentTool{fantasy.NewAgentTool[struct{}]("alpha", "", nil)}
+	result := fantasy.PrepareStepResult{Tools: liveTools()}
+	applyPrepareStepUpdate(&result, &PrepareStepUpdate{Tools: narrowed})
+
+	got := toolNames(result.Tools)
+	if len(got) != 1 || got[0] != "alpha" {
+		t.Fatalf("tools = %v, want [alpha]", got)
+	}
+}
+
+// TestPrepareStepUpdateEmptyToolsDisablesTools guards the nil-versus-empty
+// distinction. An empty non-nil slice must reach fantasy as an empty tool set,
+// which forces a text response and lets an embedder end a turn deterministically.
+// Collapsing empty to nil here would silently restore every tool.
+func TestPrepareStepUpdateEmptyToolsDisablesTools(t *testing.T) {
+	t.Parallel()
+
+	result := fantasy.PrepareStepResult{Tools: liveTools()}
+	applyPrepareStepUpdate(&result, &PrepareStepUpdate{Tools: []fantasy.AgentTool{}})
+
+	if result.Tools == nil {
+		t.Fatal("empty Tools collapsed to nil: fantasy would restore the full tool set")
+	}
+	if len(result.Tools) != 0 {
+		t.Fatalf("tools = %v, want an empty set", toolNames(result.Tools))
+	}
+}
+
+// TestPrepareStepUpdateFieldsAreIndependent proves one override does not
+// disturb the others.
+func TestPrepareStepUpdateFieldsAreIndependent(t *testing.T) {
+	t.Parallel()
+
+	choice := fantasy.ToolChoiceNone
+	msgs := []fantasy.Message{fantasy.NewUserMessage("hi")}
+
+	result := fantasy.PrepareStepResult{
+		Tools:    liveTools(),
+		Messages: []fantasy.Message{fantasy.NewUserMessage("original")},
+	}
+	applyPrepareStepUpdate(&result, &PrepareStepUpdate{
+		Messages:   msgs,
+		ToolChoice: &choice,
+	})
+
+	if len(result.Tools) != 2 {
+		t.Fatalf("tools = %v, want untouched by a message-only update", toolNames(result.Tools))
+	}
+	if result.ToolChoice == nil || *result.ToolChoice != fantasy.ToolChoiceNone {
+		t.Fatalf("ToolChoice = %v, want none", result.ToolChoice)
+	}
+	if len(result.Messages) != 1 {
+		t.Fatalf("messages = %d, want the replacement", len(result.Messages))
+	}
+}

--- a/pkg/kit/README.md
+++ b/pkg/kit/README.md
@@ -278,6 +278,114 @@ response, _ := host.Prompt(ctx, "What's my name?")
 host.ClearSession()
 ```
 
+### Custom Session Storage
+
+Pass your own [`SessionManager`](session.go) to persist conversations anywhere:
+a database, object storage, or an append-only log. The interface is **frozen
+for the v0.x line** — new capability arrives through optional interfaces that
+Kit type-asserts for, never by adding methods — so an external implementation
+will not break on a minor upgrade.
+
+#### Atomic step persistence (`StepAppender`)
+
+Kit persists conversation messages as a turn progresses. A tool-calling step
+produces two messages: an assistant message carrying the tool call, and a
+tool-role message carrying its result. By default these arrive as two separate
+`AppendMessage` calls, so a durable backend performs two writes. A process that
+dies between them leaves an orphaned tool call in storage — a conversation that
+providers reject, which makes the session unresumable.
+
+Implement the optional `StepAppender` interface to receive a whole step in one
+call and commit it atomically:
+
+```go
+type StepAppender interface {
+    AppendStep(msgs []kit.LLMMessage) (entryIDs []string, err error)
+}
+```
+
+```go
+func (s *MySession) AppendStep(msgs []kit.LLMMessage) ([]string, error) {
+    tx, err := s.db.Begin()
+    if err != nil {
+        return nil, err
+    }
+    defer func() { _ = tx.Rollback() }()
+
+    ids := make([]string, 0, len(msgs))
+    for _, m := range msgs {
+        id, err := insertMessage(tx, m)
+        if err != nil {
+            return nil, err // nothing is committed
+        }
+        ids = append(ids, id)
+    }
+    return ids, tx.Commit() // one transaction, one step
+}
+```
+
+Kit falls back to per-message `AppendMessage` when the interface is absent, so
+adding it to an existing implementation is not a breaking change. Return one
+entry ID per input message, in order, and never report a partial write as
+success.
+
+### Suspending a Turn (human-in-the-loop)
+
+A tool can stop the agent loop and hand a typed value back to the caller by
+returning `ToolOutput` with `Halt` set. This is a supported suspension
+mechanism, not just an early exit:
+
+```go
+type AskRequest struct{ Question string }
+
+ask := kit.NewTool("ask_human", "Ask the operator a question.",
+    func(ctx context.Context, in struct {
+        Question string `json:"question"`
+    }) (kit.ToolOutput, error) {
+        return kit.ToolOutput{
+            Content:    "Awaiting operator response.",
+            Halt:       true,
+            FinalValue: AskRequest{Question: in.Question},
+        }, nil
+    })
+
+res, _ := host.PromptResult(ctx, "Deploy the app.")
+if req, ok := res.FinalValue.(AskRequest); ok {
+    // The turn is parked. Persist and resume later — possibly in another
+    // process. res.HaltedByTool is "ask_human".
+    answer := askOperator(req.Question)
+    _, _ = host.PromptResult(ctx, answer)
+}
+```
+
+Two guarantees make resumption safe:
+
+1. A halted tool call still produces a well-formed tool result, so the stored
+   conversation is valid input for the next provider request.
+2. `FinalValue` is propagated by dynamic type, unmodified.
+
+### Per-Step Tool Filtering
+
+`OnPrepareStep` fires between steps of a multi-step turn and can replace the
+context window, the tool-choice mode, and the tool set:
+
+```go
+unsub := host.OnPrepareStep(kit.HookPriorityNormal,
+    func(h kit.PrepareStepHook) *kit.PrepareStepResult {
+        if h.StepNumber < 2 {
+            return nil // nil leaves the live tool set alone
+        }
+        // After two steps, withdraw every tool to force a text answer.
+        return &kit.PrepareStepResult{Tools: []kit.Tool{}}
+    })
+defer unsub()
+```
+
+`Tools` is nil-versus-empty sensitive. Nil keeps the Kit's live tool set, so
+runtime `AddTools` and `RemoveTools` still take effect mid-turn. An empty
+non-nil slice offers the model no tools at all, which ends the turn
+deterministically. The override lasts one step.
+
 ### Runtime Skills and Context Files
 
 For multi-tenant chatbots, web services, or any host that needs per-user or

--- a/pkg/kit/README.md
+++ b/pkg/kit/README.md
@@ -300,13 +300,18 @@ call and commit it atomically:
 
 ```go
 type StepAppender interface {
-    AppendStep(msgs []kit.LLMMessage) (entryIDs []string, err error)
+    AppendStep(ctx context.Context, msgs []kit.LLMMessage) (entryIDs []string, err error)
 }
 ```
 
 ```go
-func (s *MySession) AppendStep(msgs []kit.LLMMessage) ([]string, error) {
-    tx, err := s.db.Begin()
+func (s *MySession) AppendStep(ctx context.Context, msgs []kit.LLMMessage) ([]string, error) {
+    // Kit persists a completed step before it checks for cancellation, so ctx
+    // may already be done. Keep the values, drop the cancellation, or a
+    // cancelled turn silently loses the work this call exists to save.
+    ctx = context.WithoutCancel(ctx)
+
+    tx, err := s.db.BeginTx(ctx, nil)
     if err != nil {
         return nil, err
     }
@@ -314,7 +319,7 @@ func (s *MySession) AppendStep(msgs []kit.LLMMessage) ([]string, error) {
 
     ids := make([]string, 0, len(msgs))
     for _, m := range msgs {
-        id, err := insertMessage(tx, m)
+        id, err := insertMessage(ctx, tx, m)
         if err != nil {
             return nil, err // nothing is committed
         }

--- a/pkg/kit/hooks.go
+++ b/pkg/kit/hooks.go
@@ -138,12 +138,23 @@ type PrepareStepHook struct {
 	Messages []LLMMessage
 }
 
-// PrepareStepResult can replace the context window and override the
+// PrepareStepResult can replace the context window, the tool set, and the
 // tool-choice mode between steps.
 type PrepareStepResult struct {
 	// Messages replaces the entire context window for this step. If nil,
 	// the original messages (including any steering) are used unchanged.
 	Messages []LLMMessage
+	// Tools replaces the tool set offered to the model for this step only.
+	// If nil, the Kit's live tool set is used, so runtime AddTools and
+	// RemoveTools calls still take effect.
+	//
+	// An empty non-nil slice is meaningful and distinct from nil: it offers
+	// the model no tools at all for this step, which forces a text response.
+	// Use that to end a turn deterministically once a phase is complete.
+	//
+	// The override lasts one step. Return nil on the next step to restore
+	// the live tool set.
+	Tools []Tool
 	// ToolChoice, when non-nil, overrides the tool-choice mode for this step
 	// only. Use [LLMToolChoiceRequired] or [LLMSpecificToolChoice] to force a
 	// tool call, [LLMToolChoiceNone] to forbid tool calls, or

--- a/pkg/kit/kit.go
+++ b/pkg/kit/kit.go
@@ -2993,7 +2993,7 @@ func (m *Kit) generate(ctx context.Context, messages []fantasy.Message) (*agent.
 		// message and its tool results atomically. Without that, a crash
 		// between the two writes orphans the tool call.
 		OnStepMessages: func(stepMessages []fantasy.Message) {
-			appendMessages(m.session, stepMessages)
+			appendMessages(ctx, m.session, stepMessages)
 		},
 		OnStepUsage: func(inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens int64) {
 			if m.v.GetBool("debug") {
@@ -3124,7 +3124,11 @@ func (m *Kit) generate(ctx context.Context, messages []fantasy.Message) (*agent.
 // were not already persisted incrementally by the onStepMessages callback.
 // sentCount is the number of input messages sent to the LLM (the prefix of
 // result.ConversationMessages to skip). Safe to call with a nil result.
-func (m *Kit) persistGenerationRemainder(result *agent.GenerateWithLoopResult, sentCount int) {
+//
+// ctx is forwarded to [StepAppender] implementations. It is often already
+// cancelled here, because this runs after a turn ends for any reason; see the
+// Cancellation section on [StepAppender].
+func (m *Kit) persistGenerationRemainder(ctx context.Context, result *agent.GenerateWithLoopResult, sentCount int) {
 	if result == nil || len(result.ConversationMessages) <= sentCount {
 		return
 	}
@@ -3134,7 +3138,7 @@ func (m *Kit) persistGenerationRemainder(result *agent.GenerateWithLoopResult, s
 	}
 	// The remainder can span a complete assistant + tool-result pair, so it is
 	// persisted as one group to keep [StepAppender] implementations atomic.
-	appendMessages(m.session, newMessages[result.PersistedMessageCount:])
+	appendMessages(ctx, m.session, newMessages[result.PersistedMessageCount:])
 }
 
 // runTurn is the shared lifecycle for every prompt mode:
@@ -3198,7 +3202,7 @@ func (m *Kit) runTurn(ctx context.Context, promptLabel string, prompt string, pr
 	}
 
 	// Persist pre-generation messages to session.
-	appendMessages(m.session, preMessages)
+	appendMessages(ctx, m.session, preMessages)
 
 	// Auto-compact if enabled and conversation is near the context limit.
 	if m.autoCompact && m.ShouldCompact() {
@@ -3238,7 +3242,7 @@ func (m *Kit) runTurn(ctx context.Context, promptLabel string, prompt string, pr
 		// Persist completed-step messages from the failed attempt first so
 		// compaction and the rebuilt context include them — the replay then
 		// resumes from where the turn overflowed rather than restarting.
-		m.persistGenerationRemainder(result, sentCount)
+		m.persistGenerationRemainder(ctx, result, sentCount)
 		result = nil
 
 		if retryMessages, retryErr := m.prepareOverflowRetry(ctx); retryErr != nil {
@@ -3265,7 +3269,7 @@ func (m *Kit) runTurn(ctx context.Context, promptLabel string, prompt string, pr
 		// layer only includes fully-paired tool_use + tool_result messages
 		// in completedStepMessages, so there are no orphaned entries that
 		// would break subsequent API requests.
-		m.persistGenerationRemainder(result, sentCount)
+		m.persistGenerationRemainder(ctx, result, sentCount)
 		m.events.emit(TurnEndEvent{Error: err})
 		// Run AfterTurn hooks even on error.
 		m.afterTurn.run(AfterTurnHook{Error: err})
@@ -3278,7 +3282,7 @@ func (m *Kit) runTurn(ctx context.Context, promptLabel string, prompt string, pr
 	// by the onStepMessages callback during generation. This handles the
 	// non-streaming path (where onStepMessages is not called) and any edge
 	// cases where the final response messages weren't covered by step callbacks.
-	m.persistGenerationRemainder(result, sentCount)
+	m.persistGenerationRemainder(ctx, result, sentCount)
 
 	// Store the API-reported token count so GetContextStats() matches the
 	// built-in status bar. The context window is filled by all token

--- a/pkg/kit/kit.go
+++ b/pkg/kit/kit.go
@@ -2987,10 +2987,13 @@ func (m *Kit) generate(ctx context.Context, messages []fantasy.Message) (*agent.
 		},
 		// Persist step messages incrementally so that progress survives
 		// crashes and long-running turns don't lose work.
+		//
+		// The whole step goes through appendMessages so that a session
+		// manager implementing [StepAppender] can commit the assistant
+		// message and its tool results atomically. Without that, a crash
+		// between the two writes orphans the tool call.
 		OnStepMessages: func(stepMessages []fantasy.Message) {
-			for _, msg := range stepMessages {
-				_, _ = m.session.AppendMessage(msg)
-			}
+			appendMessages(m.session, stepMessages)
 		},
 		OnStepUsage: func(inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens int64) {
 			if m.v.GetBool("debug") {
@@ -3101,12 +3104,16 @@ func (m *Kit) generate(ctx context.Context, messages []fantasy.Message) (*agent.
 					StepNumber: stepNumber,
 					Messages:   messages,
 				})
-				if hookResult == nil || (hookResult.Messages == nil && hookResult.ToolChoice == nil) {
+				if hookResult == nil ||
+					(hookResult.Messages == nil &&
+						hookResult.ToolChoice == nil &&
+						hookResult.Tools == nil) {
 					return nil
 				}
 				return &agent.PrepareStepUpdate{
 					Messages:   hookResult.Messages,
 					ToolChoice: hookResult.ToolChoice,
+					Tools:      hookResult.Tools,
 				}
 			}
 		}(),
@@ -3125,9 +3132,9 @@ func (m *Kit) persistGenerationRemainder(result *agent.GenerateWithLoopResult, s
 	if result.PersistedMessageCount >= len(newMessages) {
 		return
 	}
-	for _, msg := range newMessages[result.PersistedMessageCount:] {
-		_, _ = m.session.AppendMessage(msg)
-	}
+	// The remainder can span a complete assistant + tool-result pair, so it is
+	// persisted as one group to keep [StepAppender] implementations atomic.
+	appendMessages(m.session, newMessages[result.PersistedMessageCount:])
 }
 
 // runTurn is the shared lifecycle for every prompt mode:
@@ -3191,9 +3198,7 @@ func (m *Kit) runTurn(ctx context.Context, promptLabel string, prompt string, pr
 	}
 
 	// Persist pre-generation messages to session.
-	for _, msg := range preMessages {
-		_, _ = m.session.AppendMessage(msg)
-	}
+	appendMessages(m.session, preMessages)
 
 	// Auto-compact if enabled and conversation is near the context limit.
 	if m.autoCompact && m.ShouldCompact() {

--- a/pkg/kit/session.go
+++ b/pkg/kit/session.go
@@ -23,6 +23,15 @@ var ErrNoSession = errors.New("no session available")
 // AppendMessage is called incrementally from the agent's step-completion
 // callback while read methods (GetMessages, GetCurrentBranch, etc.) may be
 // called concurrently from the UI or extension goroutines.
+//
+// # Stability
+//
+// This interface is frozen for the v0.x line. New capability is added through
+// optional interfaces that Kit type-asserts for — see [StepAppender] — rather
+// than by adding methods here. Go interfaces have no default implementations,
+// so a new method would break every external implementer at compile time with
+// no deprecation window. Implementers can therefore rely on the method set
+// below staying fixed.
 type SessionManager interface {
 	// AppendMessage adds a message to the current branch and returns its entry ID.
 	// The entry ID is used for tree navigation and must be unique within the session.
@@ -33,6 +42,13 @@ type SessionManager interface {
 	// and the tool-role message (containing tool_result parts) are appended
 	// together as a pair. This ensures the session never contains an orphaned
 	// tool call without its result, which would break subsequent LLM requests.
+	//
+	// The pairing guarantee is per-call, not atomic. Kit calls AppendMessage
+	// once per message, so an implementation that writes to durable storage
+	// produces one write per message. A process that dies between the two
+	// writes of a tool-calling step leaves an orphaned tool call in storage.
+	// Implement [StepAppender] to receive a whole step in one call and write
+	// it atomically.
 	AppendMessage(msg LLMMessage) (entryID string, err error)
 
 	// GetMessages returns all messages on the current branch (from root to leaf),
@@ -159,4 +175,57 @@ type ExtensionDataEntry struct {
 	ExtType   string
 	Data      string
 	Timestamp time.Time
+}
+
+// StepAppender is an optional interface a [SessionManager] may implement to
+// receive the messages of one agent step in a single call.
+//
+// Kit type-asserts for it at every site that persists more than one message.
+// When a session manager implements it, Kit calls AppendStep instead of
+// looping over [SessionManager.AppendMessage]; otherwise Kit falls back to the
+// loop, so implementing it is entirely optional and adding it to an existing
+// implementation is not a breaking change.
+//
+// # Why this exists
+//
+// A tool-calling step produces two messages: an assistant message carrying the
+// tool_use parts, and a tool-role message carrying the matching tool_result
+// parts. Kit's per-message persistence writes them separately, so a session
+// manager backed by durable storage performs two independent writes. A process
+// that dies between them leaves storage holding an assistant message whose
+// tool call has no result — a conversation that LLM providers reject, which
+// makes the session unresumable.
+//
+// AppendStep hands the whole step over at once so that an implementation can
+// commit it as a single unit: one fsync, one database transaction, one object
+// write. Implementations that persist durably should do exactly that.
+//
+// # Contract
+//
+// AppendStep returns one entry ID per input message, in the same order. A
+// partial write must not be reported as success: return an error and leave
+// storage unchanged, or commit every message. Implementations must be safe for
+// concurrent use, like the rest of [SessionManager].
+type StepAppender interface {
+	AppendStep(msgs []LLMMessage) (entryIDs []string, err error)
+}
+
+// appendMessages persists a group of messages that belong together, using
+// [StepAppender] when the session manager provides it and falling back to
+// per-message appends when it does not.
+//
+// Errors are deliberately ignored, matching the historical behaviour of the
+// call sites this replaces: a persistence failure must not abort a turn that
+// has already produced model output.
+func appendMessages(sm SessionManager, msgs []LLMMessage) {
+	if sm == nil || len(msgs) == 0 {
+		return
+	}
+	if sa, ok := sm.(StepAppender); ok {
+		_, _ = sa.AppendStep(msgs)
+		return
+	}
+	for _, msg := range msgs {
+		_, _ = sm.AppendMessage(msg)
+	}
 }

--- a/pkg/kit/session.go
+++ b/pkg/kit/session.go
@@ -1,6 +1,7 @@
 package kit
 
 import (
+	"context"
 	"errors"
 	"time"
 )
@@ -38,17 +39,17 @@ type SessionManager interface {
 	//
 	// During generation, AppendMessage is called incrementally after each
 	// completed agent step rather than in a batch at the end of the turn.
-	// For tool-calling steps, the assistant message (containing tool_use parts)
-	// and the tool-role message (containing tool_result parts) are appended
-	// together as a pair. This ensures the session never contains an orphaned
-	// tool call without its result, which would break subsequent LLM requests.
+	// For tool-calling steps, Kit delivers the assistant message (containing
+	// tool_use parts) and the tool-role message (containing tool_result parts)
+	// back to back, in that order, so a session assembled during normal
+	// execution never presents an orphaned tool call to the next LLM request.
 	//
-	// The pairing guarantee is per-call, not atomic. Kit calls AppendMessage
-	// once per message, so an implementation that writes to durable storage
-	// produces one write per message. A process that dies between the two
-	// writes of a tool-calling step leaves an orphaned tool call in storage.
-	// Implement [StepAppender] to receive a whole step in one call and write
-	// it atomically.
+	// That ordering is not atomicity. Kit calls AppendMessage once per
+	// message, so an implementation that writes to durable storage performs
+	// one write per message, and a process that dies between the two writes of
+	// a tool-calling step leaves an orphaned tool call in storage. Implement
+	// [StepAppender] to receive a whole step in one call and commit it
+	// atomically.
 	AppendMessage(msg LLMMessage) (entryID string, err error)
 
 	// GetMessages returns all messages on the current branch (from root to leaf),
@@ -206,23 +207,48 @@ type ExtensionDataEntry struct {
 // partial write must not be reported as success: return an error and leave
 // storage unchanged, or commit every message. Implementations must be safe for
 // concurrent use, like the rest of [SessionManager].
+//
+// # Cancellation
+//
+// ctx carries the cancellation and values of the turn that produced the step.
+// It may already be cancelled: Kit persists a completed step before it checks
+// for cancellation, precisely so that finished work survives an interrupted
+// turn. An implementation that aborts on ctx.Err() therefore discards exactly
+// the progress this callback exists to save, and the loss is silent because
+// Kit ignores the returned error.
+//
+// Implementations that must not lose a completed step should keep the values
+// but drop the cancellation:
+//
+//	func (s *MySession) AppendStep(ctx context.Context, msgs []kit.LLMMessage) ([]string, error) {
+//	    ctx = context.WithoutCancel(ctx) // keep tracing spans, ignore cancellation
+//	    // ... commit atomically
+//	}
+//
+// Use ctx for tracing, request-scoped values, and a write deadline of your own
+// choosing rather than as a reason to skip the write.
 type StepAppender interface {
-	AppendStep(msgs []LLMMessage) (entryIDs []string, err error)
+	AppendStep(ctx context.Context, msgs []LLMMessage) (entryIDs []string, err error)
 }
 
 // appendMessages persists a group of messages that belong together, using
 // [StepAppender] when the session manager provides it and falling back to
 // per-message appends when it does not.
 //
+// ctx is forwarded to [StepAppender.AppendStep] so durable implementations can
+// carry tracing values and pick their own write deadline. See the Cancellation
+// section on [StepAppender]: ctx may already be cancelled, and aborting the
+// write on that basis loses completed work.
+//
 // Errors are deliberately ignored, matching the historical behaviour of the
 // call sites this replaces: a persistence failure must not abort a turn that
 // has already produced model output.
-func appendMessages(sm SessionManager, msgs []LLMMessage) {
+func appendMessages(ctx context.Context, sm SessionManager, msgs []LLMMessage) {
 	if sm == nil || len(msgs) == 0 {
 		return
 	}
 	if sa, ok := sm.(StepAppender); ok {
-		_, _ = sa.AppendStep(msgs)
+		_, _ = sa.AppendStep(ctx, msgs)
 		return
 	}
 	for _, msg := range msgs {

--- a/pkg/kit/step_appender_test.go
+++ b/pkg/kit/step_appender_test.go
@@ -1,6 +1,7 @@
 package kit
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -57,10 +58,13 @@ type batchSessionManager struct {
 	steps     [][]string
 	stepCalls int
 	err       error
+	// gotCtx records the context handed to the most recent AppendStep call.
+	gotCtx context.Context
 }
 
-func (b *batchSessionManager) AppendStep(msgs []LLMMessage) ([]string, error) {
+func (b *batchSessionManager) AppendStep(ctx context.Context, msgs []LLMMessage) ([]string, error) {
 	b.stepCalls++
+	b.gotCtx = ctx
 	if b.err != nil {
 		return nil, b.err
 	}
@@ -92,7 +96,7 @@ func TestAppendMessagesUsesStepAppender(t *testing.T) {
 	t.Parallel()
 
 	sm := &batchSessionManager{}
-	appendMessages(sm, toolStep())
+	appendMessages(context.Background(), sm, toolStep())
 
 	if sm.stepCalls != 1 {
 		t.Fatalf("AppendStep called %d times, want exactly 1", sm.stepCalls)
@@ -115,7 +119,7 @@ func TestAppendMessagesFallsBackToPerMessage(t *testing.T) {
 	t.Parallel()
 
 	sm := &stubSessionManager{}
-	appendMessages(sm, toolStep())
+	appendMessages(context.Background(), sm, toolStep())
 
 	if sm.appends != 2 {
 		t.Fatalf("AppendMessage called %d times, want 2", sm.appends)
@@ -132,7 +136,7 @@ func TestAppendMessagesSwallowsStepAppenderError(t *testing.T) {
 	t.Parallel()
 
 	sm := &batchSessionManager{err: errors.New("disk full")}
-	appendMessages(sm, toolStep()) // must not panic
+	appendMessages(context.Background(), sm, toolStep()) // must not panic
 
 	if sm.stepCalls != 1 {
 		t.Fatalf("AppendStep called %d times, want 1", sm.stepCalls)
@@ -146,15 +150,69 @@ func TestAppendMessagesSwallowsStepAppenderError(t *testing.T) {
 func TestAppendMessagesIgnoresEmptyAndNil(t *testing.T) {
 	t.Parallel()
 
+	ctx := context.Background()
 	sm := &batchSessionManager{}
-	appendMessages(sm, nil)
-	appendMessages(sm, []LLMMessage{})
+	appendMessages(ctx, sm, nil)
+	appendMessages(ctx, sm, []LLMMessage{})
 	if sm.stepCalls != 0 || sm.appends != 0 {
 		t.Fatalf("empty input caused %d step calls and %d appends, want none",
 			sm.stepCalls, sm.appends)
 	}
 
-	appendMessages(nil, toolStep()) // must not panic
+	appendMessages(ctx, nil, toolStep()) // must not panic
+}
+
+// TestAppendMessagesForwardsContext proves the turn's context reaches a
+// StepAppender, so a durable implementation can carry tracing values and pick
+// its own write deadline.
+func TestAppendMessagesForwardsContext(t *testing.T) {
+	t.Parallel()
+
+	type ctxKey struct{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, "trace-42")
+
+	sm := &batchSessionManager{}
+	appendMessages(ctx, sm, toolStep())
+
+	if sm.gotCtx == nil {
+		t.Fatal("AppendStep received a nil context")
+	}
+	if got := sm.gotCtx.Value(ctxKey{}); got != "trace-42" {
+		t.Fatalf("context value = %v, want the caller's value to survive", got)
+	}
+}
+
+// TestAppendMessagesStillWritesWhenContextCancelled pins deliberate behaviour.
+// Kit persists a completed step BEFORE it checks for cancellation (see
+// OnStepFinish in internal/agent), so that finished work survives an
+// interrupted turn. appendMessages must therefore hand the step over even when
+// ctx is already done, and must not short-circuit on ctx.Err() as a
+// well-meaning optimisation: doing so would silently drop exactly the progress
+// this path exists to save.
+func TestAppendMessagesStillWritesWhenContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	sm := &batchSessionManager{}
+	appendMessages(ctx, sm, toolStep())
+
+	if sm.stepCalls != 1 {
+		t.Fatalf("AppendStep called %d times on a cancelled context, want 1: "+
+			"completed work must still be persisted", sm.stepCalls)
+	}
+	if sm.gotCtx == nil || sm.gotCtx.Err() == nil {
+		t.Fatal("the cancelled context must be passed through unchanged, " +
+			"so implementations can decide for themselves")
+	}
+
+	// The fallback path must behave the same way.
+	plain := &stubSessionManager{}
+	appendMessages(ctx, plain, toolStep())
+	if plain.appends != 2 {
+		t.Fatalf("AppendMessage called %d times on a cancelled context, want 2", plain.appends)
+	}
 }
 
 // TestSessionManagerInterfaceIsFrozen guards the stability promise in the

--- a/pkg/kit/step_appender_test.go
+++ b/pkg/kit/step_appender_test.go
@@ -1,0 +1,171 @@
+package kit
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// stubSessionManager is a minimal SessionManager that records how messages
+// arrive. It implements the interface but NOT StepAppender, so it exercises
+// the fallback path.
+type stubSessionManager struct {
+	// groups records one entry per append call group. A StepAppender receives
+	// one group per step; a plain SessionManager receives one group per
+	// message.
+	groups  [][]string
+	appends int
+}
+
+func (s *stubSessionManager) AppendMessage(msg LLMMessage) (string, error) {
+	s.appends++
+	s.groups = append(s.groups, []string{string(msg.Role)})
+	return "e", nil
+}
+
+func (s *stubSessionManager) GetMessages() []LLMMessage                    { return nil }
+func (s *stubSessionManager) BuildContext() ([]LLMMessage, string, string) { return nil, "", "" }
+func (s *stubSessionManager) Branch(string) error                          { return nil }
+func (s *stubSessionManager) GetCurrentBranch() []BranchEntry              { return nil }
+func (s *stubSessionManager) GetChildren(string) []string                  { return nil }
+func (s *stubSessionManager) GetEntry(string) *BranchEntry                 { return nil }
+func (s *stubSessionManager) GetSessionID() string                         { return "stub" }
+func (s *stubSessionManager) GetSessionName() string                       { return "" }
+func (s *stubSessionManager) SetSessionName(string) error                  { return nil }
+func (s *stubSessionManager) GetCreatedAt() time.Time                      { return time.Time{} }
+func (s *stubSessionManager) IsPersisted() bool                            { return false }
+func (s *stubSessionManager) AppendCompaction(string, string, int, int, int, []string, []string) (string, error) {
+	return "", nil
+}
+func (s *stubSessionManager) GetLastCompaction() *CompactionEntry { return nil }
+func (s *stubSessionManager) AppendExtensionData(string, string) (string, error) {
+	return "", nil
+}
+func (s *stubSessionManager) GetExtensionData(string) []ExtensionDataEntry { return nil }
+func (s *stubSessionManager) AppendModelChange(string, string) (string, error) {
+	return "", nil
+}
+func (s *stubSessionManager) GetContextEntryIDs() []string { return nil }
+func (s *stubSessionManager) AppendBranchSummary(string, string) (string, error) {
+	return "", nil
+}
+func (s *stubSessionManager) Close() error { return nil }
+
+// batchSessionManager additionally implements StepAppender.
+type batchSessionManager struct {
+	stubSessionManager
+	steps     [][]string
+	stepCalls int
+	err       error
+}
+
+func (b *batchSessionManager) AppendStep(msgs []LLMMessage) ([]string, error) {
+	b.stepCalls++
+	if b.err != nil {
+		return nil, b.err
+	}
+	roles := make([]string, 0, len(msgs))
+	ids := make([]string, 0, len(msgs))
+	for i, m := range msgs {
+		roles = append(roles, string(m.Role))
+		ids = append(ids, string(rune('a'+i)))
+	}
+	b.steps = append(b.steps, roles)
+	return ids, nil
+}
+
+// Compile-time proof that the optional interface is satisfiable from outside
+// the package's own implementations.
+var _ StepAppender = (*batchSessionManager)(nil)
+
+func toolStep() []LLMMessage {
+	return []LLMMessage{
+		{Role: LLMMessageRole("assistant")},
+		{Role: LLMMessageRole("tool")},
+	}
+}
+
+// TestAppendMessagesUsesStepAppender is the core guarantee behind StepAppender:
+// a session manager that implements it receives a tool-calling step as ONE
+// call, so it can commit the assistant message and its tool result atomically.
+func TestAppendMessagesUsesStepAppender(t *testing.T) {
+	t.Parallel()
+
+	sm := &batchSessionManager{}
+	appendMessages(sm, toolStep())
+
+	if sm.stepCalls != 1 {
+		t.Fatalf("AppendStep called %d times, want exactly 1", sm.stepCalls)
+	}
+	if sm.appends != 0 {
+		t.Fatalf("AppendMessage called %d times, want 0 when StepAppender exists", sm.appends)
+	}
+	if len(sm.steps) != 1 || len(sm.steps[0]) != 2 {
+		t.Fatalf("step groups = %v, want one group of two messages", sm.steps)
+	}
+	if sm.steps[0][0] != "assistant" || sm.steps[0][1] != "tool" {
+		t.Fatalf("step order = %v, want [assistant tool]", sm.steps[0])
+	}
+}
+
+// TestAppendMessagesFallsBackToPerMessage proves the change is not breaking:
+// an existing SessionManager that knows nothing about StepAppender still gets
+// its messages, one per call, exactly as before.
+func TestAppendMessagesFallsBackToPerMessage(t *testing.T) {
+	t.Parallel()
+
+	sm := &stubSessionManager{}
+	appendMessages(sm, toolStep())
+
+	if sm.appends != 2 {
+		t.Fatalf("AppendMessage called %d times, want 2", sm.appends)
+	}
+	if len(sm.groups) != 2 {
+		t.Fatalf("groups = %v, want one per message", sm.groups)
+	}
+}
+
+// TestAppendMessagesSwallowsStepAppenderError documents deliberate behaviour:
+// a persistence failure must not abort a turn that already produced output,
+// matching the historical per-message behaviour.
+func TestAppendMessagesSwallowsStepAppenderError(t *testing.T) {
+	t.Parallel()
+
+	sm := &batchSessionManager{err: errors.New("disk full")}
+	appendMessages(sm, toolStep()) // must not panic
+
+	if sm.stepCalls != 1 {
+		t.Fatalf("AppendStep called %d times, want 1", sm.stepCalls)
+	}
+	if sm.appends != 0 {
+		t.Fatal("a failed AppendStep must not silently fall back to AppendMessage: " +
+			"that would write a partially-committed step twice")
+	}
+}
+
+func TestAppendMessagesIgnoresEmptyAndNil(t *testing.T) {
+	t.Parallel()
+
+	sm := &batchSessionManager{}
+	appendMessages(sm, nil)
+	appendMessages(sm, []LLMMessage{})
+	if sm.stepCalls != 0 || sm.appends != 0 {
+		t.Fatalf("empty input caused %d step calls and %d appends, want none",
+			sm.stepCalls, sm.appends)
+	}
+
+	appendMessages(nil, toolStep()) // must not panic
+}
+
+// TestSessionManagerInterfaceIsFrozen guards the stability promise in the
+// SessionManager godoc. If a method is added, every external implementer
+// breaks at compile time — so this stub breaking is the intended early
+// warning, and the promise must be revisited before the change lands.
+func TestSessionManagerInterfaceIsFrozen(t *testing.T) {
+	t.Parallel()
+
+	var sm SessionManager = &stubSessionManager{}
+	if sm.GetSessionID() != "stub" {
+		t.Fatalf("GetSessionID = %q", sm.GetSessionID())
+	}
+}

--- a/pkg/kit/tools.go
+++ b/pkg/kit/tools.go
@@ -120,6 +120,30 @@ type ToolOutput struct {
 	// populated so embedders building structured-result extraction patterns
 	// (model calls a finish(...) tool, the loop ends, the typed value is
 	// returned) no longer need a side-channel.
+	//
+	// # Supported suspension mechanism
+	//
+	// Halt together with FinalValue is a supported way to suspend an agent
+	// turn and hand control back to the embedder, not merely a convenience
+	// for stopping early. Frameworks built on the SDK use it for
+	// human-in-the-loop: a tool returns Halt with a host-defined request
+	// value, the embedder parks the run, and a later turn resumes with the
+	// answer.
+	//
+	// Two properties are part of the contract and will not change without a
+	// major version bump:
+	//
+	//  1. A halted tool call still produces a well-formed tool result. The
+	//     halt is recorded before the response is built, so the assistant
+	//     message carrying the tool call and the tool message carrying its
+	//     result are both emitted and both persisted. The conversation left
+	//     behind is valid input for the next provider request, which is what
+	//     makes resumption possible.
+	//
+	//  2. FinalValue is propagated by dynamic type, unmodified. Kit neither
+	//     inspects nor copies it, so an embedder can round-trip any value,
+	//     including an unexported type, and recover it with a type assertion
+	//     on [TurnResult.FinalValue].
 	Halt bool
 }
 


### PR DESCRIPTION
## Description

Four additive changes to the public SDK, all driven by building a durable-execution
framework on top of `pkg/kit` as an external consumer. Every change is backward
compatible: no existing `SessionManager` implementation or hook consumer needs to
change.

**1. `StepAppender` — atomic step persistence.** A tool-calling step produces two
messages: an assistant message carrying the tool call, and a tool-role message
carrying its result. Kit persisted these with one `AppendMessage` call each, so a
`SessionManager` backed by durable storage performed two independent writes. A
process that died between them left an orphaned tool call on disk — a conversation
providers reject, which makes the session permanently unresumable.

`SessionManager`'s own godoc already promised these are *"appended together as a
pair"* so the session *"never contains an orphaned tool call without its result"*.
Kit honoured that in-process but could not honour it across a crash, because the
interface offers no way to hand a whole step over at once.

The new optional interface closes that gap:

```go
type StepAppender interface {
    AppendStep(msgs []LLMMessage) (entryIDs []string, err error)
}
```

Kit type-asserts for it and falls back to the existing per-message loop when it is
absent. Adding `AppendStep` directly to `SessionManager` would have been a breaking
change — Go interfaces have no default implementations, so every external
implementer would fail to compile with no deprecation window.

All **three** unbatched persistence loops now route through a shared
`appendMessages` helper: `OnStepMessages`, `persistGenerationRemainder` (which runs
at end-of-turn *and* on the context-overflow retry path, and can carry a complete
assistant + tool pair), and the pre-generation messages in `runTurn`. Fixing only
the first would have left the hazard in place.

**2. `PrepareStepResult.Tools` — per-step tool filtering.** `PrepareStepHook`'s
godoc has always advertised *"Dynamic tool filtering per step"*, but the result
struct had no field for it. `fantasy.PrepareStepResult` already supports per-step
tools and `internal/agent` already populates it every step (so runtime `AddTools` /
`RemoveTools` reach the model mid-turn) — the hook result simply was not wired
through. This is plumbing, not new machinery.

```go
host.OnPrepareStep(kit.HookPriorityNormal,
    func(h kit.PrepareStepHook) *kit.PrepareStepResult {
        if h.StepNumber < 2 {
            return nil // nil keeps the live tool set
        }
        return &kit.PrepareStepResult{Tools: []kit.Tool{}} // force a text answer
    })
```

`Tools` is nil-versus-empty sensitive, and that distinction is preserved through
both layers: fantasy only replaces `stepTools` when `Tools != nil`, so an empty
non-nil slice genuinely disables tools rather than restoring all of them.

**3 & 4. Documentation-only: stability promises.** No behaviour change.
`ToolOutput.Halt` + `FinalValue` is documented as a *supported* suspension
mechanism rather than an early-exit convenience, stating the two properties that
make resumption safe (a halted call still emits a well-formed tool result;
`FinalValue` is propagated by dynamic type, unmodified). `SessionManager` is
documented as frozen for the v0.x line, with new capability arriving through
optional interfaces — `StepAppender` is the first instance and sets the precedent.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project (`gofmt`, `go vet`, `golangci-lint run` — 0 issues)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`pkg/kit/README.md`)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`go test -race ./...`)

## Additional Information

**Added**

- `pkg/kit/session.go` — `StepAppender` interface and the unexported `appendMessages` dispatch helper
- `pkg/kit/step_appender_test.go` — 6 cases: `StepAppender` dispatch, per-message fallback, error path, nil/empty input, frozen-interface guard
- `internal/agent/prepare_step_tools_test.go` — 4 cases covering nil / replace / empty-disables / field-independence semantics for per-step tools

**Modified**

- `pkg/kit/kit.go` — three persistence loops routed through `appendMessages`; `Tools` threaded through the `OnPrepareStep` bridge
- `pkg/kit/hooks.go` — `PrepareStepResult.Tools` field
- `pkg/kit/tools.go` — godoc only, `ToolOutput.Halt` suspension contract
- `internal/agent/agent.go` — `PrepareStepUpdate.Tools` field and its application in the `PrepareStep` closure
- `pkg/kit/README.md` — new sections: Custom Session Storage, atomic step persistence, suspending a turn, per-step tool filtering

**Backward compatibility**

Verified empirically against an external consumer whose `SessionManager` implements
all 21 methods but **not** `StepAppender`: it compiles unchanged and its full test
suite passes against this branch, exercising the fallback path. A second run with a
wrapper that *does* implement `AppendStep` confirmed a tool-calling step arrives as
a single two-message call.

**Reviewer note**

`internal/agent/prepare_step_tools_test.go` duplicates the Phase-2 application
logic from the `PrepareStep` closure rather than calling it, because that closure is
a local variable inside `generateStreaming` and is not reachable from a test without
standing up a provider. The coupling is called out in a comment, but the test guards
a copy rather than the real code path. Extracting that block into a named method
would fix it properly — happy to do that here if preferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-step tool filtering, allowing tools to be replaced or disabled for individual steps.
  * Added optional atomic persistence for complete conversation steps, including assistant messages and tool results.
  * Added support for suspending tool-driven turns and resuming them with preserved results.
* **Documentation**
  * Expanded guidance for custom session storage, per-step tool filtering, and suspended turns.
  * Clarified tool suspension behavior and session persistence guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->